### PR TITLE
Adds Micro-Epsilon ILD1900 sensor to fcat

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Device publishers are only created if at least one device is found on the user-s
 | fcat_msgs/El2124States          | `/fcat/state/el2124s`           | Variable-sized Array of El2124State Telemetry          |
 | fcat_msgs/El3208States          | `/fcat/state/el3208s`           | Variable-sized Array of El3208State Telemetry          |
 | fcat_msgs/El3602States          | `/fcat/state/el3602s`           | Variable-sized Array of El3602State Telemetry          |
+| fcat_msgs/Ild1900States         | `/fcat/state/ild1900s`          | Variable-sized Array of Ild1900State Telemetry         |
 | fcat_msgs/JedStates             | `/fcat/state/jeds`              | Variable-sized Array of JedState Telemetry             |
 | fcat_msgs/CommanderStates       | `/fcat/state/commanders`        | Variable-sized Array of CommanderState Telemetry       |
 | fcat_msgs/ConditionalStates     | `/fcat/state/conditionals`      | Variable-sized Array of ConditionalState Telemetry     |

--- a/src/fcat.cpp
+++ b/src/fcat.cpp
@@ -152,6 +152,17 @@ void Fcat::InitializePublishersAndMessages(){
     el3602_states_msg_.states.resize(vec_state_ptrs.size());
   }
 
+  // Ild1900
+  vec_state_ptrs = device_type_vec_map_[fastcat::ILD1900_STATE];
+  if (vec_state_ptrs.size() > 0)
+  {
+    MSG("Creating Ild1900 pub");
+    ild1900_pub_ = this->create_publisher<fcat_msgs::msg::Ild1900States>("state/ild1900s", FCAT_PUB_QUEUE_SIZE);
+
+    ild1900_states_msg_.names.resize(vec_state_ptrs.size());
+    ild1900_states_msg_.states.resize(vec_state_ptrs.size());
+  }
+
   // Jed
   vec_state_ptrs = device_type_vec_map_[fastcat::JED_STATE];
   if(vec_state_ptrs.size() > 0){
@@ -430,6 +441,7 @@ void Fcat::Process(){
   PublishEl2124States();
   PublishEl3208States();
   PublishEl3602States();
+  PublishIld1900States();
   PublishJedStates();
 
   PublishCommanderStates();
@@ -586,6 +598,23 @@ void Fcat::PublishEl3602States(){
       index++;
     }
     el3602_pub_->publish(el3602_states_msg_);
+  }
+}
+
+void Fcat::PublishIld1900States()
+{
+  auto state_vec = device_type_vec_map_[fastcat::ILD1900_STATE];
+  if (state_vec.size() > 0)
+  {
+    size_t index = 0;
+
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++)
+    {
+      ild1900_states_msg_.names[index] = (*state_ptr)->name;
+      ild1900_states_msg_.states[index] = Ild1900StateToMsg(*state_ptr);
+      index++;
+    }
+    ild1900_pub_->publish(ild1900_states_msg_);
   }
 }
 

--- a/src/fcat.hpp
+++ b/src/fcat.hpp
@@ -47,6 +47,7 @@
 #include "fcat_msgs/msg/el2124_states.hpp"
 #include "fcat_msgs/msg/el3208_states.hpp"
 #include "fcat_msgs/msg/el3602_states.hpp"
+#include "fcat_msgs/msg/ild1900_states.hpp"
 #include "fcat_msgs/msg/jed_states.hpp"
 
 #include "fcat_msgs/msg/commander_states.hpp"
@@ -85,6 +86,8 @@ fcat_msgs::msg::El3208State El3208StateToMsg(
 
 fcat_msgs::msg::El3602State El3602StateToMsg(
     std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::Ild1900State Ild1900StateToMsg(std::shared_ptr<const fastcat::DeviceState> state);
 
 fcat_msgs::msg::JedState JedStateToMsg(
     std::shared_ptr<const fastcat::DeviceState> state);
@@ -142,6 +145,7 @@ private:
   void PublishEl2124States();
   void PublishEl3208States();
   void PublishEl3602States();
+  void PublishIld1900States();
   void PublishJedStates();
 
   void PublishCommanderStates();
@@ -267,6 +271,7 @@ private:
   rclcpp::Publisher<fcat_msgs::msg::El3602States>::SharedPtr   el3602_pub_;
   rclcpp::Publisher<fcat_msgs::msg::El2124States>::SharedPtr   el2124_pub_;
   rclcpp::Publisher<fcat_msgs::msg::El3208States>::SharedPtr   el3208_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::Ild1900States>::SharedPtr ild1900_pub_;
   rclcpp::Publisher<fcat_msgs::msg::JedStates>::SharedPtr      jed_pub_;
 
   rclcpp::Publisher<fcat_msgs::msg::SaturationStates>::SharedPtr saturation_pub_;
@@ -307,6 +312,7 @@ private:
   fcat_msgs::msg::El2124States   el2124_states_msg_;
   fcat_msgs::msg::El3208States   el3208_states_msg_;
   fcat_msgs::msg::El3602States   el3602_states_msg_;
+  fcat_msgs::msg::Ild1900States ild1900_states_msg_;
   fcat_msgs::msg::JedStates      jed_states_msg_;
 
   fcat_msgs::msg::CommanderStates       commander_states_msg_;

--- a/src/fcat_callbacks.cpp
+++ b/src/fcat_callbacks.cpp
@@ -130,6 +130,19 @@ fcat_msgs::msg::El3602State El3602StateToMsg(
   return msg;
 }
 
+fcat_msgs::msg::Ild1900State Ild1900StateToMsg(std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::Ild1900State();
+
+  msg.distance = state->ild1900_state.distance;
+  msg.linearized_distance_raw = state->ild1900_state.linearized_distance_raw;
+  msg.timestamp = state->ild1900_state.timestamp;
+  msg.counter = state->ild1900_state.counter;
+  msg.error = state->ild1900_state.error;
+
+  return msg;
+}
+
 fcat_msgs::msg::JedState JedStateToMsg(
     std::shared_ptr<const fastcat::DeviceState> state)
 {


### PR DESCRIPTION
Summary:
Adds support in fcat for Micro-Epsilon ILD1900 laser sensors which
measure distance with high precision.

Test Plan:
Will test with one ILD1900-100 sensor connected to a local EtherCAT
network.

Reviewers: alex-brinkman, kwehage