### PR TITLE
Update latest fcat

### DIFF
--- a/.github/workflows/ros2_build_and_tag.yml
+++ b/.github/workflows/ros2_build_and_tag.yml
@@ -46,7 +46,7 @@ env:
     apt-get install -y python3-ipython
     dpkg -i fcat/.github/python3-cogapp_3.3.0-3_all.deb
     cp fcat/.github/cog /usr/local/bin/
-    git clone --depth 1 --branch v0.2.0 https://github.com/nasa-jpl/fcat_msgs.git
+    git clone --depth 1 --branch update-msgs https://github.com/nasa-jpl/fcat_msgs.git
 
 jobs:
   # ============================================================================

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+build
+.clang-format
+*.swp
+*.swb
+*.swo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 include(FetchContent)
 FetchContent_Declare(fastcat
     GIT_REPOSITORY https://github.com/nasa-jpl/fastcat.git
-    GIT_TAG v0.4.8
+    GIT_TAG v0.13.13
     )
 FetchContent_MakeAvailable(fastcat)
 
@@ -54,7 +54,8 @@ add_executable(fcat
     src/fcat_main.cpp
     src/fcat.cpp
     src/fcat_callbacks.cpp
-    )
+    src/fcat_utils.cpp
+)
 
 ament_target_dependencies(fcat 
     rclcpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,42 +50,42 @@ foreach(include ${includes})
 endforeach()
 
 # Create fcat node
-add_executable(fcat
+add_executable(fcat_node
     src/fcat_main.cpp
     src/fcat.cpp
     src/fcat_callbacks.cpp
     src/fcat_utils.cpp
 )
 
-ament_target_dependencies(fcat 
+ament_target_dependencies(fcat_node 
     rclcpp
     sensor_msgs
     geometry_msgs
     std_srvs
     fcat_msgs
     )
-target_link_libraries(fcat
+target_link_libraries(fcat_node
     fastcat
     )
 
-# Create fcat_srvs node
-add_executable(fcat_srvs
+# Create fcat_services node
+add_executable(fcat_services
   src/fcat_srvs_main.cpp 
   src/fcat_srvs.cpp
   src/fcat_utils.cpp
   )
-ament_target_dependencies(fcat_srvs 
+ament_target_dependencies(fcat_services 
   rclcpp 
   fcat_msgs
   )
 
-target_link_libraries(fcat_srvs
+target_link_libraries(fcat_services
   fastcat
   )
 
 install(TARGETS
-    fcat
-    fcat_srvs
+    fcat_node
+    fcat_services
     DESTINATION lib/${PROJECT_NAME}
     )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,30 +1,30 @@
 cmake_minimum_required(VERSION 3.11)
 project(fcat
-    VERSION 0.6.1
-    LANGUAGES C CXX
-    DESCRIPTION "ROS2 Fastcat Node"
-    )
+  VERSION 0.6.1
+  LANGUAGES C CXX
+  DESCRIPTION "ROS2 Fastcat Node"
+)
 
 # Default to C99
 if(NOT CMAKE_C_STANDARD)
-    set(CMAKE_C_STANDARD 99)
+  set(CMAKE_C_STANDARD 99)
 endif()
 
 # Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-Wall -Wextra)
+  add_compile_options(-Wall -Wextra)
 endif()
 
 # Dependencies
 include(FetchContent)
 FetchContent_Declare(fastcat
-    GIT_REPOSITORY https://github.com/nasa-jpl/fastcat.git
-    GIT_TAG v0.13.13
-    )
+  GIT_REPOSITORY https://github.com/nasa-jpl/fastcat.git
+  GIT_TAG v0.13.13
+)
 FetchContent_MakeAvailable(fastcat)
 
 find_package(ament_cmake REQUIRED)
@@ -52,62 +52,61 @@ if(CLANG_FORMAT_BIN)
     COMMENT "Running clang-format on source files"
   )
 else()
-  message(STATUS "clang-format not found; 'format' target is unavailable f or fcat")
+  message(STATUS "clang-format not found; 'format' target is unavailable for fcat")
 endif()
 
-
-# Copies headers to install space 
+# Copies headers to install space
 file(GLOB_RECURSE includes RELATIVE
-    "${CMAKE_CURRENT_SOURCE_DIR}/src"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/*.hpp"
-    )
+  "${CMAKE_CURRENT_SOURCE_DIR}/src"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/*.hpp"
+)
 foreach(include ${includes})
-    configure_file(
-        "${CMAKE_CURRENT_SOURCE_DIR}/src/${include}"
-        "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/${include}"
-        COPYONLY
-        )
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/${include}"
+    "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/${include}"
+    COPYONLY
+  )
 endforeach()
 
 # Create fcat node
 add_executable(fcat_node
-    src/fcat_main.cpp
-    src/fcat.cpp
-    src/fcat_callbacks.cpp
-    src/fcat_utils.cpp
+  src/fcat_main.cpp
+  src/fcat.cpp
+  src/fcat_callbacks.cpp
+  src/fcat_utils.cpp
 )
 
-ament_target_dependencies(fcat_node 
-    rclcpp
-    sensor_msgs
-    geometry_msgs
-    std_srvs
-    fcat_msgs
-    )
+ament_target_dependencies(fcat_node
+  rclcpp
+  sensor_msgs
+  geometry_msgs
+  std_srvs
+  fcat_msgs
+)
 target_link_libraries(fcat_node
-    fastcat
-    )
+  fastcat
+)
 
 # Create fcat_services node
 add_executable(fcat_services
-  src/fcat_srvs_main.cpp 
+  src/fcat_srvs_main.cpp
   src/fcat_srvs.cpp
   src/fcat_utils.cpp
-  )
-ament_target_dependencies(fcat_services 
-  rclcpp 
+)
+ament_target_dependencies(fcat_services
+  rclcpp
   fcat_msgs
-  )
+)
 
 target_link_libraries(fcat_services
   fastcat
-  )
+)
 
 install(TARGETS
-    fcat_node
-    fcat_services
-    DESTINATION lib/${PROJECT_NAME}
-    )
+  fcat_node
+  fcat_services
+  DESTINATION lib/${PROJECT_NAME}
+)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_clang_format QUIET)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,26 @@ find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(fcat_msgs REQUIRED)
 
+find_program(CLANG_FORMAT_BIN NAMES clang-format)
+if(CLANG_FORMAT_BIN)
+  file(GLOB_RECURSE FCAT_FORMAT_FILES CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/*.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/*.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/*.hh"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/*.hpp"
+  )
+
+  add_custom_target(format
+    COMMAND ${CLANG_FORMAT_BIN} -i -style=file ${FCAT_FORMAT_FILES}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMENT "Running clang-format on source files"
+  )
+else()
+  message(STATUS "clang-format not found; 'format' target is unavailable f or fcat")
+endif()
+
 
 # Copies headers to install space 
 file(GLOB_RECURSE includes RELATIVE
@@ -88,5 +108,14 @@ install(TARGETS
     fcat_services
     DESTINATION lib/${PROJECT_NAME}
     )
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_clang_format QUIET)
+  if(ament_cmake_clang_format_FOUND)
+    ament_clang_format(
+      CONFIG_FILE ${CMAKE_CURRENT_SOURCE_DIR}/.clang-format
+    )
+  endif()
+endif()
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,9 @@ if(NOT CMAKE_C_STANDARD)
     set(CMAKE_C_STANDARD 99)
 endif()
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 14)
+    set(CMAKE_CXX_STANDARD 17)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -72,6 +72,7 @@ target_link_libraries(fcat
 add_executable(fcat_srvs
   src/fcat_srvs_main.cpp 
   src/fcat_srvs.cpp
+  src/fcat_utils.cpp
   )
 ament_target_dependencies(fcat_srvs 
   rclcpp 

--- a/package.xml
+++ b/package.xml
@@ -9,6 +9,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>python3-cogapp</build_depend>
+
   <depend>rclcpp</depend>
   <depend>fcat_msgs</depend>
   <depend>sensor_msgs</depend>

--- a/rosdep.yaml
+++ b/rosdep.yaml
@@ -1,0 +1,2 @@
+python3-cogapp:
+  ubuntu: [python3-cogapp]

--- a/scripts/fcat
+++ b/scripts/fcat
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+import argparse
+from pathlib import Path
+import sys
+import subprocess
+import re
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "workspace",
+        help="Path to ROS2 workspace",
+    )
+    parser.add_argument(
+        "-p",
+        "--package",
+        help="bringup package name",
+        required=True,
+    )
+    parser.add_argument(
+        "-n",
+        "--node",
+        help="ROS2 node name (when used in 'run' mode), or launch script "
+        + "name (when used in 'launch' mode)",
+        required=True,
+    )
+    parser.add_argument(
+        "-r",
+        "--niceness",
+        help="Niceness setting: an integer value in range [-20:19] where "
+        + "-20 is the best performance (default=-20)",
+        default=-20,
+    )
+    parser.add_argument(
+        "-a",
+        "--fcat-launch-arguments",
+        help="Additional arguments to pass to fcat launch file"
+        + "mode",
+        default=None,
+    )
+    return parser.parse_args()
+
+
+def sanitize(string):
+    """prevent command injection by stripping off anything following a
+    semicolon or comma"""
+    if string is None:
+        return ""
+    else:
+        return re.split(";|,", string)[0]
+
+
+def run_command(command, cwd=Path.cwd()):
+    cmd = ["/bin/bash", "-c"] + [command]
+    try:
+        p = subprocess.run(
+            cmd, stdout=sys.stdout, stderr=sys.stderr, cwd=cwd, check=True
+        )
+        return p.returncode
+    except KeyboardInterrupt:
+        return 1
+    except subprocess.CalledProcessError as e:
+        print(f"Error: command '{command}' returned non-zero exit status")
+        return e.returncode
+
+
+def main():
+    args = parse_args()
+
+    # verify workspace exists
+    if not Path(args.workspace).is_dir():
+        print(f"Error: {args.workspace} is an invalid directory")
+        sys.exit(-1)
+
+    sys.exit(
+        run_command(
+            "source install/setup.bash && "
+            + f"nice -n {args.niceness} "
+            + f"ros2 launch {sanitize(args.package)} {sanitize(args.node)} "
+            + f"{sanitize(args.fcat_launch_arguments)}",
+            Path(args.workspace),
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup_permisions.sh
+++ b/scripts/setup_permisions.sh
@@ -1,0 +1,5 @@
+
+
+sudo cp scripts/fcat /opt/ros/$ROS_DISTRO/bin/fcat
+sudo chmod 750 /opt/ros/$ROS_DISTRO/bin/fcat
+echo "%$USER ALL=(ALL:ALL) NOPASSWD:/opt/ros/$ROS_DISTRO/bin/fcat" | sudo tee /etc/sudoers.d/fcat

--- a/src/fcat.cpp
+++ b/src/fcat.cpp
@@ -1396,567 +1396,173 @@ void Fcat::InitializeSubscribers()
 void Fcat::InitializeServices()
 {
   // bus reset/fault
-  DeclareServiceCommand<std_srvs::srv::Trigger>(
-    this, "cmd/reset", &Fcat::ResetSrvCb,
-    CommandDescriptor("Issues a reset to all devices on the bus"));
+  services_.push_back(this->create_service<std_srvs::srv::Trigger>(
+    "cmd/reset", std::bind(&Fcat::ResetSrvCb, this, _1, _2), service_qos_));
 
-  DeclareServiceCommand<std_srvs::srv::Trigger>(
-    this, "cmd/fault", &Fcat::FaultSrvCb,
-    CommandDescriptor("Raises a fault to all devices on the bus"));
+  services_.push_back(this->create_service<std_srvs::srv::Trigger>(
+    "cmd/fault", std::bind(&Fcat::FaultSrvCb, this, _1, _2), service_qos_));
 
   // Actuator
   if (TypeExistsOnBus(fastcat::GOLD_ACTUATOR_STATE) ||
       TypeExistsOnBus(fastcat::PLATINUM_ACTUATOR_STATE)) {
-    DeclareServiceCommand<fcat_msgs::srv::ActuatorHaltService>(
-      this, "cmd/actuator_halt", &Fcat::ActuatorHaltSrvCb,
-      CommandDescriptor(
-        "Command to halt a single actuator without raising a fault",
-        {CommandArgumentDescriptor(
-          /*arg name*/ "name",
-          /*description*/ "The Fastcat Device Name")}));
+    services_.push_back(this->create_service<fcat_msgs::srv::ActuatorHaltService>(
+      "cmd/actuator_halt",
+      std::bind(&Fcat::ActuatorHaltSrvCb, this, _1, _2), service_qos_));
 
-    DeclareServiceCommand<
-      fcat_msgs::srv::ActuatorSetGainSchedulingIndexService>(
-      this, "cmd/actuator_set_gain_scheduling_index",
-      &Fcat::ActuatorSetGainSchedulingIndexSrvCb,
-      CommandDescriptor("Updates the Gain Scheduling Index exchanged through "
-                        "PDO. The Gain Scheduling MODE "
-                        "must be set by SDO through the service interface. "
-                        "If the Gain scheduling MODE is set to "
-                        "anything other than manual, this command has no "
-                        "effect on motor control performance.",
-                        {CommandArgumentDescriptor(
-                           /*arg name*/ "name",
-                           /*description*/ "The Fastcat Device Name"),
-                         CommandArgumentDescriptor(
-                           /*arg name*/ "gain_scheduling_index",
-                           /*description*/ "Desired gain table index")}));
+    services_.push_back(
+      this->create_service<fcat_msgs::srv::ActuatorSetGainSchedulingIndexService>(
+        "cmd/actuator_set_gain_scheduling_index",
+        std::bind(&Fcat::ActuatorSetGainSchedulingIndexSrvCb, this, _1, _2),
+        service_qos_));
 
-    DeclareServiceCommand<fcat_msgs::srv::ActuatorSetMaxCurrentService>(
-      this, "cmd/actuator_set_max_current", &Fcat::ActuatorSetMaxCurrentSrvCb,
-      CommandDescriptor(
-        "Updates the actuator peak current exchanged through PDO. "
-        "Typically, the Peak current "
-        "exceeds the Continous current (CL[1]) to allow for short power "
-        "boosts to improve "
-        "performance and help motor overcome transient loads. "
-        "When Peak current is less than the continous current (CL[1]), The "
-        "continous current limit "
-        "has no effect and boosting is disabled.",
-        {CommandArgumentDescriptor(
-           /*arg name*/ "name",
-           /*description*/ "The Fastcat Device Name"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "max_current",
-           /*description*/ "The desired peak current limit (PL[1])",
-           /*units*/ "Amperes")}));
+    services_.push_back(
+      this->create_service<fcat_msgs::srv::ActuatorSetMaxCurrentService>(
+        "cmd/actuator_set_max_current",
+        std::bind(&Fcat::ActuatorSetMaxCurrentSrvCb, this, _1, _2),
+        service_qos_));
 
-    DeclareServiceCommand<fcat_msgs::srv::ActuatorSetOutputPositionService>(
-      this, "cmd/actuator_set_output_position",
-      &Fcat::ActuatorSetOutputPositionSrvCb,
-      CommandDescriptor(
-        "Override to set the actuator to the specified value. When "
-        "possible, use "
-        "ActuatorCalibrate to calibrate position using the hardstops",
-        {CommandArgumentDescriptor(
-           /*arg name*/ "name",
-           /*description*/ "The Fastcat Device Name"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "position",
-           /*description*/
-           "Sets the current drive position to this value",
-           /*units*/ "EU")}));
+    services_.push_back(
+      this->create_service<fcat_msgs::srv::ActuatorSetOutputPositionService>(
+        "cmd/actuator_set_output_position",
+        std::bind(&Fcat::ActuatorSetOutputPositionSrvCb, this, _1, _2),
+        service_qos_));
 
-    DeclareServiceCommand<fcat_msgs::srv::ActuatorSetDigitalOutputService>(
-      this, "cmd/actuator_set_digital_output",
-      &Fcat::ActuatorSetDigitalOutputSrvCb,
-      CommandDescriptor(
-        "Set the Output Level for the actuator (Elmo command OB[N]).",
-        {CommandArgumentDescriptor(
-           /*arg name*/ "name",
-           /*description*/ "The Fastcat Device Name"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "digital_output_index",
-           /*description*/ "The user-chosen output index"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "output_level",
-           /*description*/ "The desired output level 1 or 0")}));
+    services_.push_back(
+      this->create_service<fcat_msgs::srv::ActuatorSetDigitalOutputService>(
+        "cmd/actuator_set_digital_output",
+        std::bind(&Fcat::ActuatorSetDigitalOutputSrvCb, this, _1, _2),
+        service_qos_));
 
-    DeclareServiceCommand<
-      fcat_msgs::srv::ActuatorSetProfDisengagingTimeoutService>(
-      this, "cmd/actuator_set_prof_disengaging_timeout",
-      &Fcat::ActuatorSetProfDisengagingTimeoutSrvCb,
-      CommandDescriptor("Updates the maximum time the actuator driver will "
-                        "wait for a profile command to begin "
-                        "execution before faulting.",
-                        {CommandArgumentDescriptor(
-                           /*arg name*/ "name",
-                           /*description*/ "The Fastcat Device Name"),
-                         CommandArgumentDescriptor(
-                           /*arg name*/ "timeout",
-                           /*description*/ "The desired timeout",
-                           /*units*/ "seconds")}));
+    services_.push_back(
+      this->create_service<
+        fcat_msgs::srv::ActuatorSetProfDisengagingTimeoutService>(
+        "cmd/actuator_set_prof_disengaging_timeout",
+        std::bind(&Fcat::ActuatorSetProfDisengagingTimeoutSrvCb, this, _1, _2),
+        service_qos_));
 
-    DeclareServiceCommand<fcat_msgs::srv::ActuatorProfPosService>(
-      this, "cmd/actuator_prof_pos", &Fcat::ActuatorProfPosSrvCb,
-      CommandDescriptor(
-        "Command a non-blocking Profiled Position motion profile to the "
-        "Actuator",
-        {CommandArgumentDescriptor(
-           /*arg name*/ "name",
-           /*description*/ "The Fastcat Device Name"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "target_position",
-           /*description*/ "Goal Position target of the motion profile",
-           /*Units*/ "EU"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "profile_velocity",
-           /*description*/
-           "The desired cruise rate of the motion profile",
-           /*Units*/ "EU / sec"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "profile_accel",
-           /*description*/
-           "The desired acceleration of the motion profile",
-           /*Units*/ "EU/sec^2"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "relative",
-           /*description*/ "If true, the target_position will computed "
-                           "relative "
-                           "to actual position")}));
+    services_.push_back(this->create_service<fcat_msgs::srv::ActuatorProfPosService>(
+      "cmd/actuator_prof_pos",
+      std::bind(&Fcat::ActuatorProfPosSrvCb, this, _1, _2), service_qos_));
 
-    DeclareServiceCommand<fcat_msgs::srv::ActuatorProfVelService>(
-      this, "cmd/actuator_prof_vel", &Fcat::ActuatorProfVelSrvCb,
-      CommandDescriptor(
-        "Command a non-blocking Profiled Velocity motion profile to the "
-        "Actuator",
-        {CommandArgumentDescriptor(
-           /*arg name*/ "name",
-           /*description*/ "The Fastcat Device Name"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "target_velocity",
-           /*description*/
-           "The desired cruise rate of the motion profile",
-           /*Units*/ "EU/sec"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "profile_accel",
-           /*description*/
-           "The desired acceleration of the motion profile",
-           /*Units*/ "EU/sec^2"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "max_duration",
-           /*description*/
-           "The duration of the command, negative values result "
-           "in indefinite profiles",
-           /*Units*/ "sec")}));
+    services_.push_back(this->create_service<fcat_msgs::srv::ActuatorProfVelService>(
+      "cmd/actuator_prof_vel",
+      std::bind(&Fcat::ActuatorProfVelSrvCb, this, _1, _2), service_qos_));
 
-    DeclareServiceCommand<fcat_msgs::srv::ActuatorProfTorqueService>(
-      this, "cmd/actuator_prof_torque", &Fcat::ActuatorProfTorqueSrvCb,
-      CommandDescriptor(
-        "Command a Profiled Torque motion profile to the Actuator. Here, "
-        "Torque"
-        "is equivalent to Current (frome the DS-402 specification)",
-        {CommandArgumentDescriptor(
-           /*arg name*/ "name",
-           /*description*/ "The Fastcat Device Name"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "target_torque_amps",
-           /*description*/ "The desired effort in current",
-           /*Units*/ "Amps"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "max_duration",
-           /*description*/
-           "The duration of the command, "
-           "negative values result in indefinite profiles",
-           /*Units*/ "sec")}));
+    services_.push_back(
+      this->create_service<fcat_msgs::srv::ActuatorProfTorqueService>(
+        "cmd/actuator_prof_torque",
+        std::bind(&Fcat::ActuatorProfTorqueSrvCb, this, _1, _2),
+        service_qos_));
 
-    DeclareServiceCommand<fcat_msgs::srv::ActuatorCalibrateService>(
-      this, "cmd/actuator_calibrate", &Fcat::ActuatorCalibrateSrvCb,
-      CommandDescriptor(
-        "Command a non-blocking hardstop calibration to the Actuator. "
-        "The actuator will move in "
-        "the signed velocity direction with the specified lowered current "
-        "limit "
-        "to detect the hardstop. From there, the position is set to the "
-        "calibration "
-        "limit defined in the configuration file. Finally, the original "
-        "current is "
-        "restored and the actuator is commanded to the command limit "
-        "defined in the "
-        "configuration file.",
-        {CommandArgumentDescriptor(
-           /*arg name*/ "name",
-           /*description*/ "The Fastcat Device Name"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "velocity",
-           /*description*/
-           "The desired approach velocity for all motions during "
-           "hardstop calibration",
-           /*Units*/ "EU/sec"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "accel",
-           /*description*/
-           "The desired acceleration of the motion profile",
-           /*Units*/ "EU/sec^2"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "max_current",
-           /*description*/
-           "Overrides the Peak current setting but only during "
-           "hardstop contact motion",
-           /*Units*/ "Amps")}));
+    services_.push_back(this->create_service<fcat_msgs::srv::ActuatorCalibrateService>(
+      "cmd/actuator_calibrate",
+      std::bind(&Fcat::ActuatorCalibrateSrvCb, this, _1, _2), service_qos_));
 
   }  // end Actuator Service Declarations
 
   // Commander
   if (TypeExistsOnBus(fastcat::COMMANDER_STATE)) {
-    DeclareServiceCommand<fcat_msgs::srv::CommanderEnableService>(
-      this, "cmd/commander_enable", &Fcat::CommanderEnableSrvCb,
-      CommandDescriptor("Enables the Commander to start issuing internal "
-                        "Fastcat device commands.",
-                        {CommandArgumentDescriptor(
-                          /*arg name*/ "name",
-                          /*description*/ "The Fastcat Device Name")}));
+    services_.push_back(this->create_service<fcat_msgs::srv::CommanderEnableService>(
+      "cmd/commander_enable",
+      std::bind(&Fcat::CommanderEnableSrvCb, this, _1, _2), service_qos_));
 
-    DeclareServiceCommand<fcat_msgs::srv::CommanderDisableService>(
-      this, "cmd/commander_disable", &Fcat::CommanderDisableSrvCb,
-      CommandDescriptor("Disables the Commander device to stop issuing "
-                        "internal Fastcat device commands.",
-                        {CommandArgumentDescriptor(
-                          /*arg name*/ "name",
-                          /*description*/ "The Fastcat Device Name")}));
+    services_.push_back(this->create_service<fcat_msgs::srv::CommanderDisableService>(
+      "cmd/commander_disable",
+      std::bind(&Fcat::CommanderDisableSrvCb, this, _1, _2), service_qos_));
   }  // end Commander Service Declarations
 
   // El2124
   if (TypeExistsOnBus(fastcat::EL2124_STATE)) {
-    DeclareServiceCommand<fcat_msgs::srv::El2124WriteAllChannelsService>(
-      this, "cmd/el2124_write_all_channels", &Fcat::El2124WriteAllChannelsSrvCb,
-      CommandDescriptor(
-        "Command the state of all digital outputs of a EL2124 device.",
-        {CommandArgumentDescriptor(
-           /*arg name*/ "name",
-           /*description*/ "The Fastcat Device Name"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "channel_ch1",
-           /*description*/ "Desired level for channel index 1"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "channel_ch2",
-           /*description*/ "Desired level for channel index 2"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "channel_ch3",
-           /*description*/ "Desired level for channel index 3"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "channel_ch4",
-           /*description*/ "Desired level for channel index 4")}));
+    services_.push_back(
+      this->create_service<fcat_msgs::srv::El2124WriteAllChannelsService>(
+        "cmd/el2124_write_all_channels",
+        std::bind(&Fcat::El2124WriteAllChannelsSrvCb, this, _1, _2),
+        service_qos_));
 
-    DeclareServiceCommand<fcat_msgs::srv::El2124WriteChannelService>(
-      this, "cmd/el2124_write_channel", &Fcat::El2124WriteChannelSrvCb,
-      CommandDescriptor(
-        "Command the state of one digital output of a EL2124 device, "
-        "leaving all other digital outputs unchanged.",
-        {
-          CommandArgumentDescriptor(
-            /*arg name*/ "name",
-            /*description*/ "The Fastcat Device Name"),
-          CommandArgumentDescriptor(
-            /*arg name*/ "channel",
-            /*description*/ "Desired channel index "),
-          CommandArgumentDescriptor(
-            /*arg name*/ "level",
-            /*description*/ "Desired digital output level"),
-        }));
+    services_.push_back(this->create_service<fcat_msgs::srv::El2124WriteChannelService>(
+      "cmd/el2124_write_channel",
+      std::bind(&Fcat::El2124WriteChannelSrvCb, this, _1, _2), service_qos_));
 
   }  // end El2124 Service Declarations
 
   // El2809
   if (TypeExistsOnBus(fastcat::EL2809_STATE)) {
-    DeclareServiceCommand<fcat_msgs::srv::El2809WriteAllChannelsService>(
-      this, "cmd/el2809_write_all_channels", &Fcat::El2809WriteAllChannelsSrvCb,
-      CommandDescriptor(
-        "Command the state of all digital outputs of a EL2809 device.",
-        {CommandArgumentDescriptor(
-           /*arg name*/ "name",
-           /*description*/ "The Fastcat Device Name"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "channel_ch1",
-           /*description*/ "Desired level for channel index 1"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "channel_ch2",
-           /*description*/ "Desired level for channel index 2"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "channel_ch3",
-           /*description*/ "Desired level for channel index 3"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "channel_ch4",
-           /*description*/ "Desired level for channel index 4"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "channel_ch5",
-           /*description*/ "Desired level for channel index 5"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "channel_ch6",
-           /*description*/ "Desired level for channel index 6"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "channel_ch7",
-           /*description*/ "Desired level for channel index 7"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "channel_ch8",
-           /*description*/ "Desired level for channel index 8"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "channel_ch9",
-           /*description*/ "Desired level for channel index 9"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "channel_ch10",
-           /*description*/ "Desired level for channel index 10"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "channel_ch11",
-           /*description*/ "Desired level for channel index 11"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "channel_ch12",
-           /*description*/ "Desired level for channel index 12"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "channel_ch13",
-           /*description*/ "Desired level for channel index 13"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "channel_ch14",
-           /*description*/ "Desired level for channel index 14"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "channel_ch15",
-           /*description*/ "Desired level for channel index 15"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "channel_ch16",
-           /*description*/ "Desired level for channel index 16")}));
+    services_.push_back(
+      this->create_service<fcat_msgs::srv::El2809WriteAllChannelsService>(
+        "cmd/el2809_write_all_channels",
+        std::bind(&Fcat::El2809WriteAllChannelsSrvCb, this, _1, _2),
+        service_qos_));
 
-    DeclareServiceCommand<fcat_msgs::srv::El2809WriteChannelService>(
-      this, "cmd/el2809_write_channel", &Fcat::El2809WriteChannelSrvCb,
-      CommandDescriptor(
-        "Command the state of one digital output of a EL2809 device, "
-        "leaving all other digital outputs unchanged.",
-        {
-          CommandArgumentDescriptor(
-            /*arg name*/ "name",
-            /*description*/ "The Fastcat Device Name"),
-          CommandArgumentDescriptor(
-            /*arg name*/ "channel",
-            /*description*/ "Desired channel index "),
-          CommandArgumentDescriptor(
-            /*arg name*/ "level",
-            /*description*/ "Desired digital output level"),
-        }));
+    services_.push_back(this->create_service<fcat_msgs::srv::El2809WriteChannelService>(
+      "cmd/el2809_write_channel",
+      std::bind(&Fcat::El2809WriteChannelSrvCb, this, _1, _2), service_qos_));
 
   }  // end El2809 Service Declarations
 
   // El2798
   if (TypeExistsOnBus(fastcat::EL2798_STATE)) {
-    DeclareServiceCommand<fcat_msgs::srv::El2798WriteAllChannelsService>(
-        this, "cmd/el2798_write_all_channels",
-        &Fcat::El2798WriteAllChannelsSrvCb,
-        CommandDescriptor(
-            "Command the state of all digital outputs of a EL2798 device.",
-            {CommandArgumentDescriptor(
-                 /*arg name*/ "name",
-                 /*description*/ "The Fastcat Device Name"),
-             CommandArgumentDescriptor(
-                 /*arg name*/ "channel_ch1",
-                 /*description*/ "Desired level for channel index 1"),
-             CommandArgumentDescriptor(
-                 /*arg name*/ "channel_ch2",
-                 /*description*/ "Desired level for channel index 2"),
-             CommandArgumentDescriptor(
-                 /*arg name*/ "channel_ch3",
-                 /*description*/ "Desired level for channel index 3"),
-             CommandArgumentDescriptor(
-                 /*arg name*/ "channel_ch4",
-                 /*description*/ "Desired level for channel index 4"),
-             CommandArgumentDescriptor(
-                 /*arg name*/ "channel_ch5",
-                 /*description*/ "Desired level for channel index 5"),
-             CommandArgumentDescriptor(
-                 /*arg name*/ "channel_ch6",
-                 /*description*/ "Desired level for channel index 6"),
-             CommandArgumentDescriptor(
-                 /*arg name*/ "channel_ch7",
-                 /*description*/ "Desired level for channel index 7"),
-             CommandArgumentDescriptor(
-                 /*arg name*/ "channel_ch8",
-                 /*description*/ "Desired level for channel index 8")}));
+    services_.push_back(
+      this->create_service<fcat_msgs::srv::El2798WriteAllChannelsService>(
+        "cmd/el2798_write_all_channels",
+        std::bind(&Fcat::El2798WriteAllChannelsSrvCb, this, _1, _2),
+        service_qos_));
 
-    DeclareServiceCommand<fcat_msgs::srv::El2798WriteChannelService>(
-        this, "cmd/el2798_write_channel", &Fcat::El2798WriteChannelSrvCb,
-        CommandDescriptor(
-            "Command the state of one digital output of a EL2798 device, "
-            "leaving all other digital outputs unchanged.",
-            {
-                CommandArgumentDescriptor(
-                    /*arg name*/ "name",
-                    /*description*/ "The Fastcat Device Name"),
-                CommandArgumentDescriptor(
-                    /*arg name*/ "channel",
-                    /*description*/ "Desired channel index "),
-                CommandArgumentDescriptor(
-                    /*arg name*/ "level",
-                    /*description*/ "Desired digital output level"),
-            }));
+    services_.push_back(this->create_service<fcat_msgs::srv::El2798WriteChannelService>(
+      "cmd/el2798_write_channel",
+      std::bind(&Fcat::El2798WriteChannelSrvCb, this, _1, _2), service_qos_));
 
   }  // end El2798 Service Declarations
 
   // El2828
   if (TypeExistsOnBus(fastcat::EL2828_STATE)) {
-    DeclareServiceCommand<fcat_msgs::srv::El2828WriteAllChannelsService>(
-        this, "cmd/el2828_write_all_channels",
-        &Fcat::El2828WriteAllChannelsSrvCb,
-        CommandDescriptor(
-            "Command the state of all digital outputs of a EL2828 device.",
-            {CommandArgumentDescriptor(
-                 /*arg name*/ "name",
-                 /*description*/ "The Fastcat Device Name"),
-             CommandArgumentDescriptor(
-                 /*arg name*/ "channel_ch1",
-                 /*description*/ "Desired level for channel index 1"),
-             CommandArgumentDescriptor(
-                 /*arg name*/ "channel_ch2",
-                 /*description*/ "Desired level for channel index 2"),
-             CommandArgumentDescriptor(
-                 /*arg name*/ "channel_ch3",
-                 /*description*/ "Desired level for channel index 3"),
-             CommandArgumentDescriptor(
-                 /*arg name*/ "channel_ch4",
-                 /*description*/ "Desired level for channel index 4"),
-             CommandArgumentDescriptor(
-                 /*arg name*/ "channel_ch5",
-                 /*description*/ "Desired level for channel index 5"),
-             CommandArgumentDescriptor(
-                 /*arg name*/ "channel_ch6",
-                 /*description*/ "Desired level for channel index 6"),
-             CommandArgumentDescriptor(
-                 /*arg name*/ "channel_ch7",
-                 /*description*/ "Desired level for channel index 7"),
-             CommandArgumentDescriptor(
-                 /*arg name*/ "channel_ch8",
-                 /*description*/ "Desired level for channel index 8")}));
+    services_.push_back(
+      this->create_service<fcat_msgs::srv::El2828WriteAllChannelsService>(
+        "cmd/el2828_write_all_channels",
+        std::bind(&Fcat::El2828WriteAllChannelsSrvCb, this, _1, _2),
+        service_qos_));
 
-    DeclareServiceCommand<fcat_msgs::srv::El2828WriteChannelService>(
-        this, "cmd/el2828_write_channel", &Fcat::El2828WriteChannelSrvCb,
-        CommandDescriptor(
-            "Command the state of one digital output of a EL2828 device, "
-            "leaving all other digital outputs unchanged.",
-            {
-                CommandArgumentDescriptor(
-                    /*arg name*/ "name",
-                    /*description*/ "The Fastcat Device Name"),
-                CommandArgumentDescriptor(
-                    /*arg name*/ "channel",
-                    /*description*/ "Desired channel index "),
-                CommandArgumentDescriptor(
-                    /*arg name*/ "level",
-                    /*description*/ "Desired digital output level"),
-            }));
+    services_.push_back(this->create_service<fcat_msgs::srv::El2828WriteChannelService>(
+      "cmd/el2828_write_channel",
+      std::bind(&Fcat::El2828WriteChannelSrvCb, this, _1, _2), service_qos_));
 
   }  // end El2828 Service Declarations
 
 
   // El4102
   if (TypeExistsOnBus(fastcat::EL4102_STATE)) {
-    DeclareServiceCommand<fcat_msgs::srv::El4102WriteAllChannelsService>(
-      this, "cmd/el4102_write_all_channels", &Fcat::El4102WriteAllChannelsSrvCb,
-      CommandDescriptor(
-        "Command all the analog voltage outputs of a EL4102 device.",
-        {
-          CommandArgumentDescriptor(
-            /*arg name*/ "name",
-            /*description*/ "The Fastcat Device Name"),
-          CommandArgumentDescriptor(
-            /*arg name*/ "voltage_output_ch1",
-            /*description*/
-            "Desired voltage output value for channel index 1",
-            /*units*/ "volts"),
-          CommandArgumentDescriptor(
-            /*arg name*/ "voltage_output_ch2",
-            /*description*/
-            "Desired voltage output value for channel index 2",
-            /*units*/ "volts"),
-        }));
+    services_.push_back(
+      this->create_service<fcat_msgs::srv::El4102WriteAllChannelsService>(
+        "cmd/el4102_write_all_channels",
+        std::bind(&Fcat::El4102WriteAllChannelsSrvCb, this, _1, _2),
+        service_qos_));
 
-    DeclareServiceCommand<fcat_msgs::srv::El4102WriteChannelService>(
-      this, "cmd/el4102_write_channel", &Fcat::El4102WriteChannelSrvCb,
-      CommandDescriptor(
-        "Command the state of one analog output of a EL4102 device, "
-        "leaving all other analog outputs unchanged.",
-        {CommandArgumentDescriptor(
-           /*arg name*/ "name",
-           /*description*/ "The Fastcat Device Name"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "channel",
-           /*description*/ "Desired channel index "),
-         CommandArgumentDescriptor(
-           /*arg name*/ "voltage_output",
-           /*description*/ "Desired voltage output value",
-           /*units*/ "volts")}));
+    services_.push_back(this->create_service<fcat_msgs::srv::El4102WriteChannelService>(
+      "cmd/el4102_write_channel",
+      std::bind(&Fcat::El4102WriteChannelSrvCb, this, _1, _2), service_qos_));
 
   }  // end El4102 Service Declarations
 
   // Faulter
   if (TypeExistsOnBus(fastcat::FAULTER_STATE)) {
-    DeclareServiceCommand<fcat_msgs::srv::FaulterEnableService>(
-      this, "cmd/faulter_enable", &Fcat::FaulterEnableSrvCb,
-      CommandDescriptor(
-        "Enables or Disables a Faulter device. When enabled, The Faulter "
-        "will "
-        "raise a fault if the input signal is != 0. When disabled, the "
-        "Faulter "
-        "cannot raise faults regardless of input signal.",
-        {CommandArgumentDescriptor(
-           /*arg name*/ "name",
-           /*description*/ "The Fastcat Device Name"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "enable",
-           /*description*/ "Boolean value to enable or disable the "
-                           "Faulter Device.")}));
+    services_.push_back(this->create_service<fcat_msgs::srv::FaulterEnableService>(
+      "cmd/faulter_enable",
+      std::bind(&Fcat::FaulterEnableSrvCb, this, _1, _2), service_qos_));
 
   }  // end Faulter Service Declarations
 
   // FTS
   if (TypeExistsOnBus(fastcat::FTS_STATE)) {
-    DeclareServiceCommand<fcat_msgs::srv::DeviceTriggerService>(
-      this, "cmd/fts_tare", &Fcat::FtsTareSrvCb,
-      CommandDescriptor("Tare a fts by offsetting the current sample by a "
-                        "bias term such that "
-                        "the tared_wrench reads zero.",
-                        {CommandArgumentDescriptor(
-                          /*arg name*/ "name",
-                          /*description*/ "The Fastcat Device Name")}));
+    services_.push_back(this->create_service<fcat_msgs::srv::DeviceTriggerService>(
+      "cmd/fts_tare",
+      std::bind(&Fcat::FtsTareSrvCb, this, _1, _2), service_qos_));
 
   }  // end FTS Service Declarations
 
   // PID
   if (TypeExistsOnBus(fastcat::PID_STATE)) {
-    DeclareServiceCommand<fcat_msgs::srv::PidActivateService>(
-      this, "cmd/pid_activate", &Fcat::PidActivateSrvCb,
-      CommandDescriptor(
-        "Start the PID Controller with specified parameters without "
-        "blocking.",
-        {CommandArgumentDescriptor(
-           /*arg name*/ "name",
-           /*description*/ "The Fastcat Device Name"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "setpoint",
-           /*description*/ "The controller setpoint",
-           /*Units*/ "EU"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "deadband",
-           /*description*/
-           "The controller deadband tolerange around the setpoint",
-           /*Units*/ "EU"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "persistence_duration",
-           /*description*/
-           "The amount of time the signal must remain with the "
-           "deadband to end control",
-           /*Units*/ "sec"),
-         CommandArgumentDescriptor(
-           /*arg name*/ "max_duration",
-           /*description*/
-           "The maximum duration of the command. Beware: "
-           "negative values can result in indefinite runtime",
-           /*Units*/ "sec")}));
+    services_.push_back(this->create_service<fcat_msgs::srv::PidActivateService>(
+      "cmd/pid_activate",
+      std::bind(&Fcat::PidActivateSrvCb, this, _1, _2), service_qos_));
 
   }  // end PID Service Declarations
 }

--- a/src/fcat.cpp
+++ b/src/fcat.cpp
@@ -22,7 +22,7 @@ using std::placeholders::_2;
 Fcat::~Fcat() { fcat_manager_.Shutdown(); }
 
 Fcat::Fcat(const rclcpp::NodeOptions& options)
-    : FcatNode("fcat", "fcat"),
+    : FcatNode("fcat", "fcat", options),
       service_qos_(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_services_default), rmw_qos_profile_services_default)
 {
   process_loop_callback_group_ =
@@ -30,6 +30,8 @@ Fcat::Fcat(const rclcpp::NodeOptions& options)
 
   topic_callback_group_ =
     this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+
+  SetTimerCallbackGroup(process_loop_callback_group_);
 
   std::string fastcat_config_path;
   {
@@ -248,7 +250,7 @@ Fcat::Fcat(const rclcpp::NodeOptions& options)
   last_time_ = this->now().seconds();
   module_state_msg_.faulted = false;
 
-  InitializeTimer();
+  StartProcessTimer();
   // SetActive();
 }
 
@@ -1155,7 +1157,7 @@ void Fcat::InitializeSubscribers()
 {
   rclcpp::SubscriptionOptions options;
 
-  options.callback_group = state_interface_cb_group_;
+  options.callback_group = topic_callback_group_;
 
   // bus reset/fault
   subscriptions_.push_back(this->create_subscription<std_msgs::msg::Empty>(
@@ -1163,8 +1165,6 @@ void Fcat::InitializeSubscribers()
 
   subscriptions_.push_back(this->create_subscription<std_msgs::msg::Empty>(
     "impl/fault", 1, std::bind(&Fcat::FaultCmdCb, this, _1), options));
-
-  options.callback_group = topic_callback_group_;
 
   // Async SDO
   subscriptions_.push_back(
@@ -1715,7 +1715,7 @@ void Fcat::PublishFcatModuleState()
   // Check for fault status and emit logs
   bool is_faulted = fcat_manager_.IsFaulted();
   if (!module_state_msg_.faulted && is_faulted) {
-    Fault();
+    // Fault(); // TODO: use lifecycle nodes
     RCLCPP_WARN(this->get_logger(), "Fastcat bus fault detected");
   } else if (module_state_msg_.faulted && !is_faulted) {
     RCLCPP_INFO(this->get_logger(), "Fastcat bus fault cleared");
@@ -2338,6 +2338,3 @@ void Fcat::PublishLinearInterpolationStates()
     linear_interpolation_pub_->publish(linear_interpolation_states_msg_);
   }
 }
-
-#include "rclcpp_components/register_node_macro.hpp"
-RCLCPP_COMPONENTS_REGISTER_NODE(Fcat)

--- a/src/fcat.cpp
+++ b/src/fcat.cpp
@@ -1,177 +1,686 @@
 #include "fcat/fcat.hpp"
 #include "rclcpp/rclcpp.hpp"
 
+#include <sched.h>
+#include <sys/sysinfo.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/mman.h>
+
 #include <chrono>
 
 using namespace std::chrono_literals;
 using std::placeholders::_1;
 using std::placeholders::_2;
 
-Fcat::~Fcat(){
-  fcat_manager_.Shutdown();
-}
 
-Fcat::Fcat() : FcatNode("fcat", "fcat") {
+Fcat::~Fcat() { fcat_manager_.Shutdown(); }
 
-  std::string fastcat_config_path;
-  this->declare_parameter<std::string>("fastcat_config_path", "");
-  this->get_parameter("fastcat_config_path", fastcat_config_path);
+Fcat::Fcat(const rclcpp::NodeOptions& options)
+    : casah_node::BaseInterface("fcat", "fcat", options),
+      casah_node::FaultInterface("fcat", "fcat", options),
+      casah_node::EvrInterface("fcat", "fcat", options),
+      service_qos_(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_services_default), rmw_qos_profile_services_default)
+{
+  process_loop_callback_group_ =
+    this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 
-  MSG("loading Yaml from %s", fastcat_config_path.c_str());
+  topic_callback_group_ =
+    this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+
+  std::string fastcat_config_path = DeclareInitParameterString(
+    "fastcat_config_path",
+    "",  // must be passed, cannot generally reason about this file path
+    "Location of the the fastcat topology YAML file");
+
+  EVR_ACTIVITY_LO("loading Yaml from %s", fastcat_config_path.c_str());
   YAML::Node node = YAML::LoadFile(fastcat_config_path);
 
   if (!fcat_manager_.ConfigFromYaml(node)) {
     throw std::invalid_argument(
-        "Fastcat Manager failed to process bus configuration YAML file.");
+      "Fastcat Manager failed to process bus configuration YAML file.");
   }
-  MSG("Created Fcat Manager!");
 
-  this->declare_parameter<bool>("create_joint_state_pub", true);
-  this->get_parameter("create_joint_state_pub", enable_js_pub_);
+  std::vector<std::string> gold_actuator_names;
+  fcat_manager_.GetDeviceNamesByType(gold_actuator_names,
+                                     fastcat::GOLD_ACTUATOR_STATE);
+
+  std::vector<std::string> platinum_actuator_names;
+  fcat_manager_.GetDeviceNamesByType(platinum_actuator_names,
+                                     fastcat::PLATINUM_ACTUATOR_STATE);
+
+  DeclareInitParameterInt("fastcat_actuator_count",
+                          static_cast<int>(gold_actuator_names.size() +
+                                           platinum_actuator_names.size()),
+                          "Total number of fastcat actuators", 0, -1, true);
+
+  int i = 0;
+  InitializeActuatorParams(gold_actuator_names, i);
+  InitializeActuatorParams(platinum_actuator_names, i);
+
+  use_sim_time_ = this->get_parameter("use_sim_time").as_bool();
+  enable_js_pub_ = DeclareInitParameterBool(
+    "create_joint_state_pub", true,
+    "If true, FCAT creates and publishes the \"/joint_states\" topic");
+
+  enable_ros_wrench_pub_ = DeclareInitParameterBool(
+    "create_ros_wrench_pub", true,
+    "If true, FCAT creates and publishes individual topics for FTS devices");
+
+  process_loop_cpu_id_ = DeclareInitParameterInt(
+    "process_loop_cpu_id", 0,
+    "Set the CPU ID for the main Process() thread; this settings should be "
+    "used in conjunction with setting the kernel parameter 'isolcpus=0', so "
+    "that the Process() thread is the only process running on CPU0; set to -1 "
+    "to disable CPU pinning; it is expected that most applications will use "
+    "either 0 or -1, but there may be exceptional cases where it is necessary "
+    "to pin to a different CPU core; fcat will throw a fatal error if you "
+    "attempt "
+    "to pin to a CPU core value greater than the number of cores available "
+    "(default: 0)",
+    -1, 128);
+
+  enable_realtime_preempt_ = DeclareInitParameterBool(
+    "enable_realtime_preempt", enable_realtime_preempt_,
+    "If true, FCAT's ethercat thread will use the FIFO scheduler, allowing it to "
+    "preempt the kernel. This setting requires the realtime kernel");
+
+  scheduler_priority_ = DeclareInitParameterInt(
+    "scheduler_priority", scheduler_priority_,
+    "Set real-time scheduler priority level, only used if 'enable_realtime_preempt' "
+    "parameter is set to 'true', which requires the realtime kernel. Note that this "
+    "value is used to set the 'rt_priority' real-time priority setting which is "
+    "different from a processes 'niceness' setting. 'rt_priority' ranges from 1 to 99 "
+    "with 99 being the highest priority (default: 49), ", 1, 99);
+
+  fault_on_cycle_slip_ = DeclareInitParameterBool(
+    "fault_on_cycle_slip", fault_on_cycle_slip_,
+    "Fault the ethercat bus if large cycle slips detected (default: true)");
+
+  cycle_slip_fault_magnitude_ = DeclareInitParameterDouble(
+    "cycle_slip_fault_magnitude", cycle_slip_fault_magnitude_,
+    "Fault if cycle slip is greater than a multiple of the the nominal process loop "
+    "period (default: 3.0)");
+
+  DeclareRuntimeParameterInt("csp_explicit_interpolation_cycles_delay", 3,
+                             "Delays the onset of a motion profile in explicit "
+                             "interpolation mode by a "
+                             "number of cycles of the calling module; if set "
+                             "to 3, then fcat will wait until "
+                             "4 messages csp messages accumulate in the buffer "
+                             "before initiating motion "
+                             "profile.",
+                             0, 10);
+
+  DeclareRuntimeParameterInt(
+    "csp_interpolation_cycles_stale", 10,
+    "When fastcat is in CSP interpolation mode, module will "
+    "transition to HOLDING state when it has not received a "
+    "new CSP setpoint within the number of internal loop "
+    "cycles configured by this parameter",
+    4, 40);
+
+  DeclareRuntimeParameterString(
+    "csp_explicit_interpolation_algorithm", "cubic",
+    "Specify the algorithm used for explicit interpolation; "
+    "one of ['cubic', 'linear']: cubic interpolation is a third order "
+    "interpolation "
+    "of position and velocity with c2 continuity between csp set points; "
+    "linear interpolation linearly interpolates both position and "
+    "velocity between csp setpoints");
+
+  DeclareRuntimeParameterString("csp_explicit_interpolation_timestamp_source",
+                                "csp_message",
+                                "Specify the source for the timestamp used for "
+                                "csp interpolation in explicit mode; "
+                                "If set to 'csp_message', fastcat uses the "
+                                "request_time from the csp message, "
+                                "if set to 'clock', fastcat uses the current "
+                                "clock on receipt of the message; "
+                                "['csp_message', 'clock']");
+
+  DeclareRuntimeParameterBool(
+    "report_cycle_slips", true,
+    "If true, fcat emits EVR messages to report timer "
+    "slips");
 
   PopulateDeviceStateFields();
 
   // Must populate certain device state fields before initializing pub/sub
   InitializePublishersAndMessages();
   InitializeSubscribers();
+  InitializeServices();
 
-  SetTimerRate(fcat_manager_.GetTargetLoopRate());
-  last_time_ = fcat_get_time_sec();
-  MSG("Starting Wall Timer at %lf hz", fcat_manager_.GetTargetLoopRate());
-  InitializeTimer();
+  param_cb_handles_.push_back(this->add_on_set_parameters_callback(
+    std::bind(&Fcat::SetParametersCb, this, _1)));
+
+  // pull the Timer Rate from the Fastcat YAML
+  InitializeTimerRate(fcat_manager_.GetTargetLoopRate());
+  EVR_ACTIVITY_LO("Starting Wall Timer at %lf hz",
+                  fcat_manager_.GetTargetLoopRate());
+
+  loop_period_sec_ = 1.0 / fcat_manager_.GetTargetLoopRate();
+  last_time_ = this->now().seconds();
+  module_state_msg_.faulted = false;
+
+  Fcat::StartProcessTimer();
+  SetActive();
 }
 
-void Fcat::PopulateDeviceStateFields(){
+void Fcat::SetRealtimePreempt(int scheduler_priority) {
+  // this method must be called from within a thread
+  struct sched_param param;
+  param.sched_priority = scheduler_priority;
+  if(sched_setscheduler(0, SCHED_FIFO, &param) == -1) {
+    EVR_WARNING_HI(
+      "Unable to set realtime FIFO scheduler with priority of "
+      "%d; the realtime kernel must be installed to use this feature",
+      scheduler_priority
+    );
+    return;
+  }
+  
+  // Lock memory
+  if(mlockall(MCL_CURRENT | MCL_FUTURE) == -1) {
+    EVR_WARNING_HI("Unable to lock memory; 'mlockall' failed");
+  }
+  
+  // Pre-fault our stack
+  const size_t max_safe_stack = 8 * 1024;
+  unsigned char dummy[max_safe_stack];
+  memset(dummy, 0, max_safe_stack);
+}
 
+void Fcat::StartProcessTimer()
+{
+  rclcpp::Parameter rate_param;
+  if (!this->get_parameter("target_loop_rate_hz", rate_param)) {
+    EVR_FATAL(
+      "Developer Warning: must call InitializeTimerRate(...) before "
+      "starting timer");
+    rclcpp::shutdown();
+  }
+
+  double period_usec = 1.0e6 / fcat_manager_.GetTargetLoopRate();
+  std::chrono::duration<double, std::micro> chrono_dur(period_usec);
+  process_timer_ =
+    rclcpp::create_timer(this, this->get_clock(), chrono_dur,
+                         std::bind(&casah_node::FaultInterface::Process, this),
+                         process_loop_callback_group_);
+}
+
+rcl_interfaces::msg::SetParametersResult Fcat::SetParametersCb(
+  const std::vector<rclcpp::Parameter>& parameters)
+{
+  rcl_interfaces::msg::SetParametersResult result;
+  result.successful = true;
+
+  for (const auto& parameter : parameters) {
+    if (parameter.get_name() == "csp_explicit_interpolation_cycles_delay") {
+      size_t delay = static_cast<size_t>(parameter.as_int());
+      fcat_manager_.SetExplicitInterpolationCyclesDelay(delay);
+      result.successful = true;
+    } else if (parameter.get_name() == "csp_interpolation_cycles_stale") {
+      size_t cycles = static_cast<size_t>(parameter.as_int());
+      fcat_manager_.SetInterpolationCyclesStale(cycles);
+      result.successful = true;
+    } else if (parameter.get_name() == "csp_explicit_interpolation_algorithm") {
+      auto value = parameter.as_string();
+      if (value == "cubic") {
+        fcat_manager_.SetExplicitInterpolationAlgorithmCubic();
+        result.successful = true;
+      } else if (value == "linear") {
+        fcat_manager_.SetExplicitInterpolationAlgorithmLinear();
+        result.successful = true;
+      } else {
+        result.reason =
+          "Invalid algorithm requested, must be one of ['cubic', 'linear']";
+        result.successful = false;
+      }
+    } else if (parameter.get_name() ==
+               "csp_explicit_interpolation_timestamp_source") {
+      auto value = parameter.as_string();
+      if (value == "csp_message") {
+        fcat_manager_.SetExplicitInterpolationTimestampSourceCspMessage();
+        result.successful = true;
+      } else if (value == "clock") {
+        fcat_manager_.SetExplicitInterpolationTimestampSourceClock();
+        result.successful = true;
+      } else {
+        result.reason =
+          "Invalid algorithm requested, must be one of ['csp_message', "
+          "'clock']";
+        result.successful = false;
+      }
+    }
+  }
+  return result;
+}
+
+void Fcat::InitializeActuatorParams(
+  const std::vector<std::string>& actuator_names, int& i)
+{
+  fastcat::Actuator::ActuatorParams actuator_params;
+  for (auto& actuator_name : actuator_names) {
+    if (fcat_manager_.GetActuatorParams(actuator_name, actuator_params)) {
+      std::string parameter_prefix =
+        "fastcat_actuator_" + std::to_string(++i) + "_";
+      std::string description_prefix = "Actuator " + std::to_string(i) + " ";
+      DeclareInitParameterString(parameter_prefix + "name", actuator_name,
+                                 description_prefix + "name", true);
+      DeclareInitParameterString(parameter_prefix + "actuator_type",
+                                 actuator_params.actuator_type_str,
+                                 description_prefix + "actuator type", true);
+      DeclareInitParameterDouble(
+        parameter_prefix + "gear_ratio", actuator_params.gear_ratio,
+        description_prefix + "gear ratio", 0.0, -1.0, true);
+      DeclareInitParameterDouble(
+        parameter_prefix + "counts_per_rev", actuator_params.counts_per_rev,
+        description_prefix + "counts per revolution", 0.0, -1.0, true);
+      DeclareInitParameterDouble(parameter_prefix + "max_speed_eu_per_sec",
+                                 actuator_params.max_speed_eu_per_sec,
+                                 description_prefix + "max speed [eu/sec]", 0.0,
+                                 -1.0, true);
+      DeclareInitParameterDouble(
+        parameter_prefix + "max_accel_eu_per_sec2",
+        actuator_params.max_accel_eu_per_sec2,
+        description_prefix + "max acceleration [eu/sec^2]", 0.0, -1.0, true);
+      DeclareInitParameterDouble(parameter_prefix + "over_speed_multiplier",
+                                 actuator_params.over_speed_multiplier,
+                                 description_prefix + "over speed multiplier",
+                                 0.0, -1.0, true);
+      DeclareInitParameterDouble(
+        parameter_prefix + "vel_tracking_error_eu_per_sec",
+        actuator_params.vel_tracking_error_eu_per_sec,
+        description_prefix + "velocity tracking error [eu/sec]", 0.0, -1.0,
+        true);
+      DeclareInitParameterDouble(
+        parameter_prefix + "pos_tracking_error_eu",
+        actuator_params.pos_tracking_error_eu,
+        description_prefix + "position tracking error [eu]", 0.0, -1.0, true);
+      DeclareInitParameterDouble(
+        parameter_prefix + "peak_current_limit_amps",
+        actuator_params.peak_current_limit_amps,
+        description_prefix + "peak current limit [amps]", 0.0, -1.0, true);
+      DeclareInitParameterDouble(parameter_prefix + "peak_current_time_sec",
+                                 actuator_params.peak_current_time_sec,
+                                 description_prefix + "peak current time [sec]",
+                                 0.0, -1.0, true);
+      DeclareInitParameterDouble(
+        parameter_prefix + "continuous_current_limit_amps",
+        actuator_params.continuous_current_limit_amps,
+        description_prefix + "continuous current limit [amps]", 0.0, -1.0,
+        true);
+      DeclareInitParameterDouble(parameter_prefix + "torque_slope_amps_per_sec",
+                                 actuator_params.torque_slope_amps_per_sec,
+                                 description_prefix + "torque slope [amps/sec]",
+                                 0.0, -1.0, true);
+      DeclareInitParameterDouble(
+        parameter_prefix + "low_pos_cal_limit_eu",
+        actuator_params.low_pos_cal_limit_eu,
+        description_prefix + "low position calibration limit [eu]", 0.0, -1.0,
+        true);
+      DeclareInitParameterDouble(
+        parameter_prefix + "low_pos_cmd_limit_eu",
+        actuator_params.low_pos_cmd_limit_eu,
+        description_prefix + "low position command limit [eu]", 0.0, -1.0,
+        true);
+      DeclareInitParameterDouble(
+        parameter_prefix + "high_pos_cal_limit_eu",
+        actuator_params.high_pos_cal_limit_eu,
+        description_prefix + "high position calibration limit [eu]", 0.0, -1.0,
+        true);
+      DeclareInitParameterDouble(
+        parameter_prefix + "high_pos_cmd_limit_eu",
+        actuator_params.high_pos_cmd_limit_eu,
+        description_prefix + "high position command limit [eu]", 0.0, -1.0,
+        true);
+      DeclareInitParameterDouble(parameter_prefix + "holding_duration_sec",
+                                 actuator_params.holding_duration_sec,
+                                 description_prefix + "holding duration [sec]",
+                                 0.0, -1.0, true);
+      DeclareInitParameterDouble(
+        parameter_prefix + "elmo_brake_engage_msec",
+        actuator_params.elmo_brake_engage_msec,
+        description_prefix + "brake engage time [msec]", 0.0, -1.0, true);
+      DeclareInitParameterDouble(
+        parameter_prefix + "elmo_brake_disengage_msec",
+        actuator_params.elmo_brake_disengage_msec,
+        description_prefix + "brake disengage time [msec]", 0.0, -1.0, true);
+      DeclareInitParameterDouble(
+        parameter_prefix + "elmo_crc", actuator_params.elmo_crc,
+        description_prefix + "crc value", 0.0, -1.0, true);
+      DeclareInitParameterDouble(
+        parameter_prefix + "elmo_drive_max_cur_limit_amps",
+        actuator_params.elmo_drive_max_cur_limit_amps,
+        description_prefix + "drive max current limit [amps]", 0.0, -1.0, true);
+      DeclareInitParameterDouble(
+        parameter_prefix + "smooth_factor", actuator_params.smooth_factor,
+        description_prefix + "smoothing factor", 0.0, -1.0, true);
+      DeclareInitParameterDouble(
+        parameter_prefix + "torque_constant", actuator_params.torque_constant,
+        description_prefix + "torque constant", 0.0, -1.0, true);
+      DeclareInitParameterDouble(parameter_prefix + "winding_resistance",
+                                 actuator_params.winding_resistance,
+                                 description_prefix + "winding resistance", 0.0,
+                                 -1.0, true);
+      DeclareInitParameterDouble(
+        parameter_prefix + "brake_power", actuator_params.brake_power,
+        description_prefix + "brake power", 0.0, -1.0, true);
+      DeclareInitParameterDouble(
+        parameter_prefix + "motor_encoder_gear_ratio",
+        actuator_params.motor_encoder_gear_ratio,
+        description_prefix + "motor encoder gear ratio", 0.0, -1.0, true);
+      DeclareInitParameterBool(parameter_prefix + "has_absolute_encoder",
+                               actuator_params.actuator_absolute_encoder,
+                               description_prefix + "has absolute encoder",
+                               true);
+    }
+  }
+}
+
+void Fcat::PopulateDeviceStateFields()
+{
   device_state_ptrs_ = fcat_manager_.GetDeviceStatePointers();
 
-  for(auto it = device_state_ptrs_.begin(); it != device_state_ptrs_.end(); ++it){
-    MSG("Populating device_name_state_map_[%s]", (*it)->name.c_str());
+  for (auto it = device_state_ptrs_.begin(); it != device_state_ptrs_.end();
+       ++it) {
+    EVR_ACTIVITY_LO("Populating device_name_state_map_[%s]",
+                    (*it)->name.c_str());
 
     device_name_state_map_[(*it)->name] = *it;
 
     device_type_vec_map_[(*it)->type].push_back(*it);
 
-    MSG("counts[%d] = %ld", (*it)->type, device_type_vec_map_[(*it)->type].size());
+    EVR_ACTIVITY_LO("counts[%d] = %ld", (*it)->type,
+                    device_type_vec_map_[(*it)->type].size());
   }
 }
 
-bool Fcat::DeviceExistsOnBus(std::string name, fastcat::DeviceStateType type)
+bool Fcat::ActuatorExistsOnBus(const std::string& name)
 {
-  if(!(device_name_state_map_.end() != device_name_state_map_.find(name))){
-    ERROR("Device %s does not exist on bus", name.c_str());
+  std::string error_message;
+  if (DeviceExistsOnBus(name, fastcat::GOLD_ACTUATOR_STATE, error_message)) {
+    return true;
+  } else if (DeviceExistsOnBus(name, fastcat::PLATINUM_ACTUATOR_STATE, error_message)) {
+    return true;
+  }
+  // handle other future Actuator device types here
+  EVR_WARNING_HI("%s", error_message.c_str());
+  return false;
+}
+
+bool Fcat::ActuatorExistsOnBus(const std::string& name,
+                               std::string& error_message)
+{
+  if (DeviceExistsOnBus(name, fastcat::GOLD_ACTUATOR_STATE, error_message)) {
+    return true;
+  } else if (DeviceExistsOnBus(name, fastcat::PLATINUM_ACTUATOR_STATE,
+                               error_message)) {
+    return true;
+  }
+  // handle other future Actuator device types here
+  return false;
+}
+
+bool Fcat::DeviceExistsOnBus(const std::string& name,
+                             fastcat::DeviceStateType type,
+                             std::string& error_message)
+{
+  char str[512];
+  if (!(device_name_state_map_.end() != device_name_state_map_.find(name))) {
+    snprintf(str, 512, "Device %s does not exist on bus", name.c_str());
+    error_message = str;
     return false;
   }
-  if(device_name_state_map_[name]->type != type){
-    ERROR("Device type does not match for %s", name.c_str());
+  if (device_name_state_map_[name]->type != type) {
+    snprintf(str, 512, "Device type does not match for %s", name.c_str());
+    error_message = str;
     return false;
   }
   return true;
 }
 
-bool Fcat::TypeExistsOnBus(fastcat::DeviceStateType type){
-  if(device_type_vec_map_[type].size() > 0){
+bool Fcat::DeviceExistsOnBus(const std::string& name,
+                             fastcat::DeviceStateType type)
+{
+  std::string error_message;
+  bool success = DeviceExistsOnBus(name, type, error_message);
+  if (not success) {
+    EVR_WARNING_HI("%s", error_message.c_str());
+  }
+  return success;
+}
+
+bool Fcat::TypeExistsOnBus(fastcat::DeviceStateType type)
+{
+  if (device_type_vec_map_[type].size() > 0) {
     return true;
   }
   return false;
 }
 
-void Fcat::InitializePublishersAndMessages(){
-  MSG("Fcat::InitializePublishers()");
+void Fcat::InitializePublishersAndMessages()
+{
+  EVR_ACTIVITY_LO("Fcat::InitializePublishers()");
 
-  // Actuator
-  auto vec_state_ptrs = device_type_vec_map_[fastcat::ACTUATOR_STATE];
-  if(vec_state_ptrs.size() > 0){
+  rclcpp::QoS qos_profile(publisher_queue_size_);
+  qos_profile.best_effort();
 
-    MSG("Creating actuator pub");
+  // Async SDO Response
+  async_sdo_response_pub_ =
+    this->create_publisher<fcat_msgs::msg::AsyncSdoResponse>(
+      "state/async_sdo_response", qos_profile);
+
+  // Actuators
+  auto gold_vec_state_ptrs = device_type_vec_map_[fastcat::GOLD_ACTUATOR_STATE];
+  auto platinum_vec_state_ptrs =
+    device_type_vec_map_[fastcat::PLATINUM_ACTUATOR_STATE];
+  size_t num_actuators =
+    gold_vec_state_ptrs.size() + platinum_vec_state_ptrs.size();
+
+  if (num_actuators > 0) {
+    EVR_ACTIVITY_LO("Creating actuator pub");
     actuator_pub_ = this->create_publisher<fcat_msgs::msg::ActuatorStates>(
-        "state/actuators", FCAT_PUB_QUEUE_SIZE);
+      "state/actuators", qos_profile);
 
-    actuator_states_msg_.names.resize(vec_state_ptrs.size());
-    actuator_states_msg_.states.resize(vec_state_ptrs.size());
+    actuator_states_msg_.names.resize(num_actuators);
+    actuator_states_msg_.states.resize(num_actuators);
 
-    if(enable_js_pub_){
-      MSG("Creating joint_states pub");
+    if (enable_js_pub_) {
+      EVR_ACTIVITY_LO("Creating joint_states pub");
 
-      // This is the only topic that broadcasts in the global 
-      // namespace. This prevents needing to remap `fcat/state/joint_states` 
+      // This is the only topic that broadcasts in the global
+      // namespace. This prevents needing to remap `fcat/state/joint_states`
       // to `/joint_states` in launch files or through command line args.
       // It can always be reverted if this causes any issues down the road.
-      joint_state_pub_ = 
-        this->create_publisher<sensor_msgs::msg::JointState>(
-            "/joint_states", FCAT_PUB_QUEUE_SIZE);
+      joint_state_pub_ = this->create_publisher<sensor_msgs::msg::JointState>(
+        "/joint_states", qos_profile);
     }
   }
 
   // Egd
-  vec_state_ptrs = device_type_vec_map_[fastcat::EGD_STATE];
-  if(vec_state_ptrs.size() > 0){
-
-    MSG("Creating Egd pub");
+  auto vec_state_ptrs = device_type_vec_map_[fastcat::EGD_STATE];
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating Egd pub");
     egd_pub_ = this->create_publisher<fcat_msgs::msg::EgdStates>(
-        "state/egds", FCAT_PUB_QUEUE_SIZE);
+      "state/egds", qos_profile);
 
     egd_states_msg_.names.resize(vec_state_ptrs.size());
     egd_states_msg_.states.resize(vec_state_ptrs.size());
   }
 
+  // El1008
+  vec_state_ptrs = device_type_vec_map_[fastcat::EL1008_STATE];
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating El1008 pub");
+    el1008_pub_ = this->create_publisher<fcat_msgs::msg::El1008States>(
+      "state/el1008s", qos_profile);
+
+    el1008_states_msg_.names.resize(vec_state_ptrs.size());
+    el1008_states_msg_.states.resize(vec_state_ptrs.size());
+  }
 
   // El2124
   vec_state_ptrs = device_type_vec_map_[fastcat::EL2124_STATE];
-  if(vec_state_ptrs.size() > 0){
-
-    MSG("Creating El2124 pub");
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating El2124 pub");
     el2124_pub_ = this->create_publisher<fcat_msgs::msg::El2124States>(
-        "state/el2124s", FCAT_PUB_QUEUE_SIZE);
+      "state/el2124s", qos_profile);
 
     el2124_states_msg_.names.resize(vec_state_ptrs.size());
     el2124_states_msg_.states.resize(vec_state_ptrs.size());
   }
 
+  // El2809
+  vec_state_ptrs = device_type_vec_map_[fastcat::EL2809_STATE];
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating El2809 pub");
+    el2809_pub_ = this->create_publisher<fcat_msgs::msg::El2809States>(
+      "state/el2809s", qos_profile);
+
+    el2809_states_msg_.names.resize(vec_state_ptrs.size());
+    el2809_states_msg_.states.resize(vec_state_ptrs.size());
+  }
+
+  // El2798
+  vec_state_ptrs = device_type_vec_map_[fastcat::EL2798_STATE];
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating El2798 pub");
+    el2798_pub_ = this->create_publisher<fcat_msgs::msg::El2798States>(
+        "state/el2798s", qos_profile);
+
+    el2798_states_msg_.names.resize(vec_state_ptrs.size());
+    el2798_states_msg_.states.resize(vec_state_ptrs.size());
+  }
+
+  // El2828
+  vec_state_ptrs = device_type_vec_map_[fastcat::EL2828_STATE];
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating El2828 pub");
+    el2828_pub_ = this->create_publisher<fcat_msgs::msg::El2828States>(
+        "state/el2828s", qos_profile);
+
+    el2828_states_msg_.names.resize(vec_state_ptrs.size());
+    el2828_states_msg_.states.resize(vec_state_ptrs.size());
+  }
+
+  // El3104
+  vec_state_ptrs = device_type_vec_map_[fastcat::EL3104_STATE];
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating El3104 pub");
+    el3104_pub_ = this->create_publisher<fcat_msgs::msg::El3104States>(
+      "state/el3104s", qos_profile);
+
+    el3104_states_msg_.names.resize(vec_state_ptrs.size());
+    el3104_states_msg_.states.resize(vec_state_ptrs.size());
+  }
+
+  // El3162
+  vec_state_ptrs = device_type_vec_map_[fastcat::EL3162_STATE];
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating El3162 pub");
+    el3162_pub_ = this->create_publisher<fcat_msgs::msg::El3162States>(
+      "state/el3162s", qos_profile);
+
+    el3162_states_msg_.names.resize(vec_state_ptrs.size());
+    el3162_states_msg_.states.resize(vec_state_ptrs.size());
+  }
+
+  // El3202
+  vec_state_ptrs = device_type_vec_map_[fastcat::EL3202_STATE];
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating El3202 pub");
+    el3202_pub_ = this->create_publisher<fcat_msgs::msg::El3202States>(
+      "state/el3202s", qos_profile);
+
+    el3202_states_msg_.names.resize(vec_state_ptrs.size());
+    el3202_states_msg_.states.resize(vec_state_ptrs.size());
+  }
+
   // El3208
   vec_state_ptrs = device_type_vec_map_[fastcat::EL3208_STATE];
-  if(vec_state_ptrs.size() > 0){
-
-    MSG("Creating El3208 pub");
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating El3208 pub");
     el3208_pub_ = this->create_publisher<fcat_msgs::msg::El3208States>(
-        "state/el3208s", FCAT_PUB_QUEUE_SIZE);
+      "state/el3208s", qos_profile);
 
     el3208_states_msg_.names.resize(vec_state_ptrs.size());
     el3208_states_msg_.states.resize(vec_state_ptrs.size());
   }
 
+  // El3314
+  vec_state_ptrs = device_type_vec_map_[fastcat::EL3314_STATE];
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating El3314 pub");
+    el3314_pub_ = this->create_publisher<fcat_msgs::msg::El3314States>(
+      "state/el3314s", qos_profile);
+
+    el3314_states_msg_.names.resize(vec_state_ptrs.size());
+    el3314_states_msg_.states.resize(vec_state_ptrs.size());
+  }
+
+  // El3318
+  vec_state_ptrs = device_type_vec_map_[fastcat::EL3318_STATE];
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating El3318 pub");
+    el3318_pub_ = this->create_publisher<fcat_msgs::msg::El3318States>(
+      "state/el3318s", qos_profile);
+
+    el3318_states_msg_.names.resize(vec_state_ptrs.size());
+    el3318_states_msg_.states.resize(vec_state_ptrs.size());
+  }
+
   // El3602
   vec_state_ptrs = device_type_vec_map_[fastcat::EL3602_STATE];
-  if(vec_state_ptrs.size() > 0){
-
-    MSG("Creating El3602 pub");
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating El3602 pub");
     el3602_pub_ = this->create_publisher<fcat_msgs::msg::El3602States>(
-        "state/el3602s", FCAT_PUB_QUEUE_SIZE);
+      "state/el3602s", qos_profile);
 
     el3602_states_msg_.names.resize(vec_state_ptrs.size());
     el3602_states_msg_.states.resize(vec_state_ptrs.size());
   }
 
-  // Jed
-  vec_state_ptrs = device_type_vec_map_[fastcat::JED_STATE];
-  if(vec_state_ptrs.size() > 0){
+  // El4102
+  vec_state_ptrs = device_type_vec_map_[fastcat::EL4102_STATE];
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating El4102 pub");
+    el4102_pub_ = this->create_publisher<fcat_msgs::msg::El4102States>(
+      "state/el4102s", qos_profile);
 
-    MSG("Creating Jed pub");
-    jed_pub_ = this->create_publisher<fcat_msgs::msg::JedStates>(
-        "state/jeds", FCAT_PUB_QUEUE_SIZE);
-
-    jed_states_msg_.names.resize(vec_state_ptrs.size());
-    jed_states_msg_.states.resize(vec_state_ptrs.size());
+    el4102_states_msg_.names.resize(vec_state_ptrs.size());
+    el4102_states_msg_.states.resize(vec_state_ptrs.size());
   }
 
+  // El5042
+  vec_state_ptrs = device_type_vec_map_[fastcat::EL5042_STATE];
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating El5042 pub");
+    el5042_pub_ = this->create_publisher<fcat_msgs::msg::El5042States>(
+        "state/el5042s", qos_profile);
+
+    el5042_states_msg_.names.resize(vec_state_ptrs.size());
+    el5042_states_msg_.states.resize(vec_state_ptrs.size());
+  }
+
+  // ILD1900
+  vec_state_ptrs = device_type_vec_map_[fastcat::ILD1900_STATE];
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating Ild1900 pub");
+    ild1900_pub_ = this->create_publisher<fcat_msgs::msg::Ild1900States>(
+      "state/ild1900s", qos_profile);
+
+    ild1900_states_msg_.names.resize(vec_state_ptrs.size());
+    ild1900_states_msg_.states.resize(vec_state_ptrs.size());
+  }
 
   // Commander
   vec_state_ptrs = device_type_vec_map_[fastcat::COMMANDER_STATE];
-  if(vec_state_ptrs.size() > 0){
-
-    MSG("Creating Commander pub");
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating Commander pub");
     commander_pub_ = this->create_publisher<fcat_msgs::msg::CommanderStates>(
-        "state/commanders", FCAT_PUB_QUEUE_SIZE);
+      "state/commanders", qos_profile);
 
     commander_states_msg_.names.resize(vec_state_ptrs.size());
     commander_states_msg_.states.resize(vec_state_ptrs.size());
@@ -179,11 +688,11 @@ void Fcat::InitializePublishersAndMessages(){
 
   // Conditional
   vec_state_ptrs = device_type_vec_map_[fastcat::CONDITIONAL_STATE];
-  if(vec_state_ptrs.size() > 0){
-
-    MSG("Creating Conditional pub");
-    conditional_pub_ = this->create_publisher<fcat_msgs::msg::ConditionalStates>(
-        "state/conditionals", FCAT_PUB_QUEUE_SIZE);
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating Conditional pub");
+    conditional_pub_ =
+      this->create_publisher<fcat_msgs::msg::ConditionalStates>(
+        "state/conditionals", qos_profile);
 
     conditional_states_msg_.names.resize(vec_state_ptrs.size());
     conditional_states_msg_.states.resize(vec_state_ptrs.size());
@@ -191,11 +700,10 @@ void Fcat::InitializePublishersAndMessages(){
 
   // Faulter
   vec_state_ptrs = device_type_vec_map_[fastcat::FAULTER_STATE];
-  if(vec_state_ptrs.size() > 0){
-
-    MSG("Creating Faulter pub");
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating Faulter pub");
     faulter_pub_ = this->create_publisher<fcat_msgs::msg::FaulterStates>(
-        "state/faulters", FCAT_PUB_QUEUE_SIZE);
+      "state/faulters", qos_profile);
 
     faulter_states_msg_.names.resize(vec_state_ptrs.size());
     faulter_states_msg_.states.resize(vec_state_ptrs.size());
@@ -203,11 +711,10 @@ void Fcat::InitializePublishersAndMessages(){
 
   // Filter
   vec_state_ptrs = device_type_vec_map_[fastcat::FILTER_STATE];
-  if(vec_state_ptrs.size() > 0){
-
-    MSG("Creating Filter pub");
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating Filter pub");
     filter_pub_ = this->create_publisher<fcat_msgs::msg::FilterStates>(
-        "state/filter", FCAT_PUB_QUEUE_SIZE);
+      "state/filter", qos_profile);
 
     filter_states_msg_.names.resize(vec_state_ptrs.size());
     filter_states_msg_.states.resize(vec_state_ptrs.size());
@@ -215,11 +722,10 @@ void Fcat::InitializePublishersAndMessages(){
 
   // Function
   vec_state_ptrs = device_type_vec_map_[fastcat::FUNCTION_STATE];
-  if(vec_state_ptrs.size() > 0){
-
-    MSG("Creating Function pub");
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating Function pub");
     function_pub_ = this->create_publisher<fcat_msgs::msg::FunctionStates>(
-        "state/functions", FCAT_PUB_QUEUE_SIZE);
+      "state/functions", qos_profile);
 
     function_states_msg_.names.resize(vec_state_ptrs.size());
     function_states_msg_.states.resize(vec_state_ptrs.size());
@@ -227,11 +733,10 @@ void Fcat::InitializePublishersAndMessages(){
 
   // Pid
   vec_state_ptrs = device_type_vec_map_[fastcat::PID_STATE];
-  if(vec_state_ptrs.size() > 0){
-
-    MSG("Creating Pid pub");
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating Pid pub");
     pid_pub_ = this->create_publisher<fcat_msgs::msg::PidStates>(
-        "state/pids", FCAT_PUB_QUEUE_SIZE);
+      "state/pids", qos_profile);
 
     pid_states_msg_.names.resize(vec_state_ptrs.size());
     pid_states_msg_.states.resize(vec_state_ptrs.size());
@@ -239,11 +744,10 @@ void Fcat::InitializePublishersAndMessages(){
 
   // Saturation
   vec_state_ptrs = device_type_vec_map_[fastcat::SATURATION_STATE];
-  if(vec_state_ptrs.size() > 0){
-
-    MSG("Creating Saturation pub");
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating Saturation pub");
     saturation_pub_ = this->create_publisher<fcat_msgs::msg::SaturationStates>(
-        "state/saturations", FCAT_PUB_QUEUE_SIZE);
+      "state/saturations", qos_profile);
 
     saturation_states_msg_.names.resize(vec_state_ptrs.size());
     saturation_states_msg_.states.resize(vec_state_ptrs.size());
@@ -251,11 +755,11 @@ void Fcat::InitializePublishersAndMessages(){
 
   // Schmitt Trigger
   vec_state_ptrs = device_type_vec_map_[fastcat::SCHMITT_TRIGGER_STATE];
-  if(vec_state_ptrs.size() > 0){
-
-    MSG("Creating Schmitt Trigger pub");
-    schmitt_trigger_pub_ = this->create_publisher<fcat_msgs::msg::SchmittTriggerStates>(
-        "state/schmitt_triggers", FCAT_PUB_QUEUE_SIZE);
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating Schmitt Trigger pub");
+    schmitt_trigger_pub_ =
+      this->create_publisher<fcat_msgs::msg::SchmittTriggerStates>(
+        "state/schmitt_triggers", qos_profile);
 
     schmitt_trigger_states_msg_.names.resize(vec_state_ptrs.size());
     schmitt_trigger_states_msg_.states.resize(vec_state_ptrs.size());
@@ -263,174 +767,1015 @@ void Fcat::InitializePublishersAndMessages(){
 
   // Signal Generator
   vec_state_ptrs = device_type_vec_map_[fastcat::SIGNAL_GENERATOR_STATE];
-  if(vec_state_ptrs.size() > 0){
-
-    MSG("Creating Signal Generator pub");
-    signal_generator_pub_ = this->create_publisher<fcat_msgs::msg::SignalGeneratorStates>(
-        "state/signal_generators", FCAT_PUB_QUEUE_SIZE);
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating Signal Generator pub");
+    signal_generator_pub_ =
+      this->create_publisher<fcat_msgs::msg::SignalGeneratorStates>(
+        "state/signal_generators", qos_profile);
 
     signal_generator_states_msg_.names.resize(vec_state_ptrs.size());
-
     signal_generator_states_msg_.states.resize(vec_state_ptrs.size());
   }
 
-  
+  // Linear Interpolation
+  vec_state_ptrs = device_type_vec_map_[fastcat::LINEAR_INTERPOLATION_STATE];
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating LinearInterpolation pub");
+    linear_interpolation_pub_ =
+      this->create_publisher<fcat_msgs::msg::LinearInterpolationStates>(
+        "state/linear_interpolators", qos_profile);
+
+    linear_interpolation_states_msg_.names.resize(vec_state_ptrs.size());
+    linear_interpolation_states_msg_.states.resize(vec_state_ptrs.size());
+  }
+
+  // Three Node Thermal Model
+  vec_state_ptrs =
+    device_type_vec_map_[fastcat::THREE_NODE_THERMAL_MODEL_STATE];
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating ThreeNodeThermalModel pub");
+    three_node_thermal_model_pub_ =
+      this->create_publisher<fcat_msgs::msg::ThreeNodeThermalModelStates>(
+        "state/three_node_thermal_models", qos_profile);
+
+    three_node_thermal_model_states_msg_.names.resize(vec_state_ptrs.size());
+    three_node_thermal_model_states_msg_.states.resize(vec_state_ptrs.size());
+  }
+
   // FTS, AtiFts, VirtualFts
   vec_state_ptrs = device_type_vec_map_[fastcat::FTS_STATE];
-  for(auto dev_state_ptr = vec_state_ptrs.begin(); dev_state_ptr != vec_state_ptrs.end(); dev_state_ptr++){
 
-     std::string device = (*dev_state_ptr)->name;
-     fts_raw_pub_map_[device] = 
-       this->create_publisher<geometry_msgs::msg::Wrench>(
-         "fts/" + device + "/raw_wrench", FCAT_PUB_QUEUE_SIZE);
+  if (vec_state_ptrs.size() > 0) {
+    EVR_ACTIVITY_LO("Creating FTS pub");
 
-     fts_tared_pub_map_[device] = 
-       this->create_publisher<geometry_msgs::msg::Wrench>(
-         "fts/" + device + "/tared_wrench", FCAT_PUB_QUEUE_SIZE);
-   }
+    fts_pub_ = this->create_publisher<fcat_msgs::msg::FtsStates>(
+      "state/fts", qos_profile);
 
+    fts_states_msg_.names.resize(vec_state_ptrs.size());
+    fts_states_msg_.states.resize(vec_state_ptrs.size());
+
+    if (enable_ros_wrench_pub_) {
+      for (auto dev_state_ptr = vec_state_ptrs.begin();
+           dev_state_ptr != vec_state_ptrs.end(); dev_state_ptr++) {
+        std::string device = (*dev_state_ptr)->name;
+        fts_raw_pub_map_[device] =
+          this->create_publisher<geometry_msgs::msg::WrenchStamped>(
+            "fts/" + device + "/raw_wrench", qos_profile);
+
+        fts_tared_pub_map_[device] =
+          this->create_publisher<geometry_msgs::msg::WrenchStamped>(
+            "fts/" + device + "/tared_wrench", qos_profile);
+
+        EVR_ACTIVITY_LO("Creating ROS WrenchStamped Topics for %s",
+                        device.c_str());
+      }
+    }
+  }
+
+  // Module State (always published)
   module_state_pub_ = this->create_publisher<fcat_msgs::msg::ModuleState>(
-      "state/module_state", FCAT_PUB_QUEUE_SIZE);
+    "state/module_state", qos_profile);
 }
 
+void Fcat::InitializeSubscribers()
+{
+  rclcpp::SubscriptionOptions options;
 
-void Fcat::InitializeSubscribers(){
+  options.callback_group = state_interface_cb_group_;
 
   // bus reset/fault
-  reset_sub_ = this->create_subscription<std_msgs::msg::Empty>(
-      "cmd/reset",
-      FCAT_SUB_QUEUE_SIZE,
-      std::bind(&Fcat::ResetCb, this, _1));
+  subscriptions_.push_back(this->create_subscription<std_msgs::msg::Empty>(
+    "impl/reset", 1, std::bind(&Fcat::ResetCmdCb, this, _1), options));
 
-  fault_sub_ = this->create_subscription<std_msgs::msg::Empty>(
-      "cmd/fault",
-      FCAT_SUB_QUEUE_SIZE,
-      std::bind(&Fcat::FaultCb, this, _1));
+  subscriptions_.push_back(this->create_subscription<std_msgs::msg::Empty>(
+    "impl/fault", 1, std::bind(&Fcat::FaultCmdCb, this, _1), options));
 
+  options.callback_group = topic_callback_group_;
+
+  // Async SDO
+  subscriptions_.push_back(
+    this->create_subscription<fcat_msgs::msg::AsyncSdoReadCmd>(
+      "impl/async_sdo_read", subscription_queue_size_,
+      std::bind(&Fcat::AsyncSdoReadCmdCb, this, _1), options));
+
+  subscriptions_.push_back(
+    this->create_subscription<fcat_msgs::msg::AsyncSdoWriteCmd>(
+      "impl/async_sdo_write", subscription_queue_size_,
+      std::bind(&Fcat::AsyncSdoWriteCmdCb, this, _1), options));
 
   // Actuator
-  if(TypeExistsOnBus(fastcat::ACTUATOR_STATE)){
+  if (TypeExistsOnBus(fastcat::GOLD_ACTUATOR_STATE) ||
+      TypeExistsOnBus(fastcat::PLATINUM_ACTUATOR_STATE)) {
+    subscriptions_.push_back(
+      this->create_subscription<fcat_msgs::msg::ActuatorCspCmd>(
+        "impl/actuator_csp", subscription_queue_size_,
+        std::bind(&Fcat::ActuatorCSPCmdCb, this, _1), options));
 
-    actuator_csp_sub_ = this->create_subscription<fcat_msgs::msg::ActuatorCspCmd>(
-        "cmd/actuator_csp", 
-        FCAT_SUB_QUEUE_SIZE, 
-        std::bind(&Fcat::ActuatorCSPCmdCb, this, _1));
+    subscriptions_.push_back(
+      this->create_subscription<fcat_msgs::msg::ActuatorCsvCmd>(
+        "impl/actuator_csv", subscription_queue_size_,
+        std::bind(&Fcat::ActuatorCSVCmdCb, this, _1), options));
 
-    actuator_csv_sub_ = this->create_subscription<fcat_msgs::msg::ActuatorCsvCmd>(
-        "cmd/actuator_csv", 
-        FCAT_SUB_QUEUE_SIZE, 
-        std::bind(&Fcat::ActuatorCSVCmdCb, this, _1));
+    subscriptions_.push_back(
+      this->create_subscription<fcat_msgs::msg::ActuatorCstCmd>(
+        "impl/actuator_cst", subscription_queue_size_,
+        std::bind(&Fcat::ActuatorCSTCmdCb, this, _1), options));
 
-    actuator_cst_sub_ = this->create_subscription<fcat_msgs::msg::ActuatorCstCmd>(
-        "cmd/actuator_cst", 
-        FCAT_SUB_QUEUE_SIZE, 
-        std::bind(&Fcat::ActuatorCSTCmdCb, this, _1));
+    subscriptions_.push_back(
+      this->create_subscription<fcat_msgs::msg::ActuatorCspCmds>(
+        "impl/actuator_csp_multi", subscription_queue_size_,
+        std::bind(&Fcat::ActuatorCSPCmdsCb, this, _1), options));
 
-    actuator_calibrate_sub_ = this->create_subscription<fcat_msgs::msg::ActuatorCalibrateCmd>(
-        "cmd/actuator_calibrate", 
-        FCAT_SUB_QUEUE_SIZE, 
-        std::bind(&Fcat::ActuatorCalibrateCmdCb, this, _1));
+    subscriptions_.push_back(
+      this->create_subscription<fcat_msgs::msg::ActuatorCsvCmds>(
+        "impl/actuator_csv_multi", subscription_queue_size_,
+        std::bind(&Fcat::ActuatorCSVCmdsCb, this, _1), options));
 
-    actuator_prof_pos_sub_ = this->create_subscription<fcat_msgs::msg::ActuatorProfPosCmd>(
-        "cmd/actuator_prof_pos", 
-        FCAT_SUB_QUEUE_SIZE, 
-        std::bind(&Fcat::ActuatorProfPosCmdCb, this, _1));
+    subscriptions_.push_back(
+      this->create_subscription<fcat_msgs::msg::ActuatorCstCmds>(
+        "impl/actuator_cst_multi", subscription_queue_size_,
+        std::bind(&Fcat::ActuatorCSTCmdsCb, this, _1), options));
 
-    actuator_prof_torque_sub_ = this->create_subscription<fcat_msgs::msg::ActuatorProfTorqueCmd>(
-        "cmd/actuator_prof_torque", 
-        FCAT_SUB_QUEUE_SIZE, 
-        std::bind(&Fcat::ActuatorProfTorqueCmdCb, this, _1));
+    subscriptions_.push_back(
+      this->create_subscription<fcat_msgs::msg::ActuatorCalibrateCmd>(
+        "impl/actuator_calibrate", subscription_queue_size_,
+        std::bind(&Fcat::ActuatorCalibrateCmdCb, this, _1), options));
 
-    actuator_prof_vel_sub_ = this->create_subscription<fcat_msgs::msg::ActuatorProfVelCmd>(
-        "cmd/actuator_prof_vel", 
-        FCAT_SUB_QUEUE_SIZE, 
-        std::bind(&Fcat::ActuatorProfVelCmdCb, this, _1));
+    subscriptions_.push_back(
+      this->create_subscription<fcat_msgs::msg::ActuatorProfPosCmd>(
+        "impl/actuator_prof_pos", subscription_queue_size_,
+        std::bind(&Fcat::ActuatorProfPosCmdCb, this, _1), options));
 
-    actuator_set_output_position_sub_ = 
+    subscriptions_.push_back(
+      this->create_subscription<fcat_msgs::msg::ActuatorProfTorqueCmd>(
+        "impl/actuator_prof_torque", subscription_queue_size_,
+        std::bind(&Fcat::ActuatorProfTorqueCmdCb, this, _1), options));
+
+    subscriptions_.push_back(
+      this->create_subscription<fcat_msgs::msg::ActuatorProfVelCmd>(
+        "impl/actuator_prof_vel", subscription_queue_size_,
+        std::bind(&Fcat::ActuatorProfVelCmdCb, this, _1), options));
+
+    subscriptions_.push_back(
+      this->create_subscription<fcat_msgs::msg::ActuatorProfPosCmds>(
+        "impl/actuator_prof_pos_multi", subscription_queue_size_,
+        std::bind(&Fcat::ActuatorProfPosCmdsCb, this, _1), options));
+
+    subscriptions_.push_back(
       this->create_subscription<fcat_msgs::msg::ActuatorSetOutputPositionCmd>(
-          "cmd/actuator_set_output_position", 
-          FCAT_SUB_QUEUE_SIZE, 
-          std::bind(&Fcat::ActuatorSetOutputPositionCmdCb, this, _1));
+        "impl/actuator_set_output_position", subscription_queue_size_,
+        std::bind(&Fcat::ActuatorSetOutputPositionCmdCb, this, _1), options));
+
+    subscriptions_.push_back(
+      this->create_subscription<fcat_msgs::msg::ActuatorSetDigitalOutputCmd>(
+        "impl/actuator_set_digital_output", subscription_queue_size_,
+        std::bind(&Fcat::ActuatorSetDigitalOutputCmdCb, this, _1), options));
+
+    subscriptions_.push_back(
+      this->create_subscription<fcat_msgs::msg::ActuatorSetMaxCurrentCmd>(
+        "impl/actuator_set_max_current", subscription_queue_size_,
+        std::bind(&Fcat::ActuatorSetMaxCurrentCmdCb, this, _1), options));
+
+    subscriptions_.push_back(
+      this->create_subscription<fcat_msgs::msg::ActuatorSetUnitModeCmd>(
+        "impl/actuator_set_unit_mode", subscription_queue_size_,
+        std::bind(&Fcat::ActuatorSetUnitModeCmdCb, this, _1), options));
+
+    subscriptions_.push_back(
+      this->create_subscription<
+        fcat_msgs::msg::ActuatorSetProfDisengagingTimeoutCmd>(
+        "impl/actuator_set_prof_disengaging_timeout", subscription_queue_size_,
+        std::bind(&Fcat::ActuatorSetProfDisengagingTimeoutCmdCb, this, _1),
+        options));
+
+    subscriptions_.push_back(
+      this->create_subscription<fcat_msgs::msg::ActuatorHaltCmd>(
+        "impl/actuator_halt", subscription_queue_size_,
+        std::bind(&Fcat::ActuatorHaltCmdCb, this, _1), options));
+
+    subscriptions_.push_back(
+      this->create_subscription<fcat_msgs::msg::ActuatorHaltCmds>(
+        "impl/actuator_halt_multi", subscription_queue_size_,
+        std::bind(&Fcat::ActuatorHaltCmdsCb, this, _1), options));
   }
 
   // Commander
-  if(TypeExistsOnBus(fastcat::COMMANDER_STATE)){
-    commander_enable_sub_ = 
+  if (TypeExistsOnBus(fastcat::COMMANDER_STATE)) {
+    subscriptions_.push_back(
       this->create_subscription<fcat_msgs::msg::CommanderEnableCmd>(
-          "cmd/commander_enable", 
-          FCAT_SUB_QUEUE_SIZE, 
-          std::bind(&Fcat::CommanderEnableCmdCb, this, _1));
+        "impl/commander_enable", subscription_queue_size_,
+        std::bind(&Fcat::CommanderEnableCmdCb, this, _1), options));
 
-    commander_disable_sub_ = 
+    subscriptions_.push_back(
       this->create_subscription<fcat_msgs::msg::CommanderDisableCmd>(
-          "cmd/commander_disable", 
-          FCAT_SUB_QUEUE_SIZE, 
-          std::bind(&Fcat::CommanderDisableCmdCb, this, _1));
+        "impl/commander_disable", subscription_queue_size_,
+        std::bind(&Fcat::CommanderDisableCmdCb, this, _1), options));
   }
 
   // El2124
-  if(TypeExistsOnBus(fastcat::EL2124_STATE)){
-    el2124_write_all_channels_sub_ = 
+  if (TypeExistsOnBus(fastcat::EL2124_STATE)) {
+    subscriptions_.push_back(
       this->create_subscription<fcat_msgs::msg::El2124WriteAllChannelsCmd>(
-          "cmd/el2124_write_all_channels", 
-          FCAT_SUB_QUEUE_SIZE, 
-          std::bind(&Fcat::El2124WriteAllChannelsCmdCb, this, _1));
+        "impl/el2124_write_all_channels", subscription_queue_size_,
+        std::bind(&Fcat::El2124WriteAllChannelsCmdCb, this, _1), options));
 
-    el2124_write_channel_sub_ = 
+    subscriptions_.push_back(
       this->create_subscription<fcat_msgs::msg::El2124WriteChannelCmd>(
-          "cmd/el2124_write_channel", 
-          FCAT_SUB_QUEUE_SIZE, 
-          std::bind(&Fcat::El2124WriteChannelCmdCb, this, _1));
+        "impl/el2124_write_channel", subscription_queue_size_,
+        std::bind(&Fcat::El2124WriteChannelCmdCb, this, _1), options));
+  }
+
+  // El2809
+  if (TypeExistsOnBus(fastcat::EL2809_STATE)) {
+    subscriptions_.push_back(
+      this->create_subscription<fcat_msgs::msg::El2809WriteAllChannelsCmd>(
+        "impl/el2809_write_all_channels", subscription_queue_size_,
+        std::bind(&Fcat::El2809WriteAllChannelsCmdCb, this, _1), options));
+
+    subscriptions_.push_back(
+      this->create_subscription<fcat_msgs::msg::El2809WriteChannelCmd>(
+        "impl/el2809_write_channel", subscription_queue_size_,
+        std::bind(&Fcat::El2809WriteChannelCmdCb, this, _1), options));
+  }
+
+  // El2798
+  if (TypeExistsOnBus(fastcat::EL2798_STATE)) {
+    subscriptions_.push_back(
+        this->create_subscription<fcat_msgs::msg::El2798WriteAllChannelsCmd>(
+            "impl/el2798_write_all_channels", subscription_queue_size_,
+            std::bind(&Fcat::El2798WriteAllChannelsCmdCb, this, _1), options));
+
+    subscriptions_.push_back(
+        this->create_subscription<fcat_msgs::msg::El2798WriteChannelCmd>(
+            "impl/el2798_write_channel", subscription_queue_size_,
+            std::bind(&Fcat::El2798WriteChannelCmdCb, this, _1), options));
+  }
+
+  // El2828
+  if (TypeExistsOnBus(fastcat::EL2828_STATE)) {
+    subscriptions_.push_back(
+        this->create_subscription<fcat_msgs::msg::El2828WriteAllChannelsCmd>(
+            "impl/el2828_write_all_channels", subscription_queue_size_,
+            std::bind(&Fcat::El2828WriteAllChannelsCmdCb, this, _1), options));
+
+    subscriptions_.push_back(
+        this->create_subscription<fcat_msgs::msg::El2828WriteChannelCmd>(
+            "impl/el2828_write_channel", subscription_queue_size_,
+            std::bind(&Fcat::El2828WriteChannelCmdCb, this, _1), options));
+  }
+
+  // EL4102
+  if (TypeExistsOnBus(fastcat::EL4102_STATE)) {
+    subscriptions_.push_back(
+      this->create_subscription<fcat_msgs::msg::El4102WriteAllChannelsCmd>(
+        "impl/el4102_write_all_channels", subscription_queue_size_,
+        std::bind(&Fcat::El4102WriteAllChannelsCmdCb, this, _1), options));
+
+    subscriptions_.push_back(
+      this->create_subscription<fcat_msgs::msg::El4102WriteChannelCmd>(
+        "impl/el4102_write_channel", subscription_queue_size_,
+        std::bind(&Fcat::El4102WriteChannelCmdCb, this, _1), options));
   }
 
   // Faulter
-  if(TypeExistsOnBus(fastcat::FAULTER_STATE)){
-    faulter_enable_sub_ = this->create_subscription<fcat_msgs::msg::FaulterEnableCmd>(
-        "cmd/faulter_enable", 
-        FCAT_SUB_QUEUE_SIZE, 
-        std::bind(&Fcat::FaulterEnableCmdCb, this, _1));
+  if (TypeExistsOnBus(fastcat::FAULTER_STATE)) {
+    subscriptions_.push_back(
+      this->create_subscription<fcat_msgs::msg::FaulterEnableCmd>(
+        "impl/faulter_enable", subscription_queue_size_,
+        std::bind(&Fcat::FaulterEnableCmdCb, this, _1), options));
   }
 
   // Fts
-  if(TypeExistsOnBus(fastcat::FTS_STATE)){
-    fts_tare_sub_= this->create_subscription<fcat_msgs::msg::FtsTareCmd>(
-        "cmd/fts_tare", 
-        FCAT_SUB_QUEUE_SIZE, 
-        std::bind(&Fcat::FtsTareCmdCb, this, _1));
-  }
-
-  // Jed
-  if(TypeExistsOnBus(fastcat::JED_STATE)){
-    jed_set_cmd_value_sub_= this->create_subscription<fcat_msgs::msg::JedSetCmdValueCmd>(
-        "cmd/jed_set_cmd_value", 
-        FCAT_SUB_QUEUE_SIZE, 
-        std::bind(&Fcat::JedSetCmdValueCmdCb, this, _1));
+  if (TypeExistsOnBus(fastcat::FTS_STATE)) {
+    subscriptions_.push_back(
+      this->create_subscription<fcat_msgs::msg::FtsTareCmd>(
+        "impl/fts_tare", subscription_queue_size_,
+        std::bind(&Fcat::FtsTareCmdCb, this, _1), options));
   }
 
   // Pid
-  if(TypeExistsOnBus(fastcat::PID_STATE)){
-    pid_activate_sub_= this->create_subscription<fcat_msgs::msg::PidActivateCmd>(
-        "cmd/pid_activate", 
-        FCAT_SUB_QUEUE_SIZE, 
-        std::bind(&Fcat::PidActivateCmdCb, this, _1));
+  if (TypeExistsOnBus(fastcat::PID_STATE)) {
+    subscriptions_.push_back(
+      this->create_subscription<fcat_msgs::msg::PidActivateCmd>(
+        "impl/pid_activate", subscription_queue_size_,
+        std::bind(&Fcat::PidActivateCmdCb, this, _1), options));
   }
 }
 
+void Fcat::InitializeServices()
+{
+  // bus reset/fault
+  DeclareServiceCommand<std_srvs::srv::Trigger>(
+    this, "cmd/reset", &Fcat::ResetSrvCb,
+    CommandDescriptor("Issues a reset to all devices on the bus"));
 
-void Fcat::Process(){
+  DeclareServiceCommand<std_srvs::srv::Trigger>(
+    this, "cmd/fault", &Fcat::FaultSrvCb,
+    CommandDescriptor("Raises a fault to all devices on the bus"));
 
-  fcat_manager_.Process();
+  // Actuator
+  if (TypeExistsOnBus(fastcat::GOLD_ACTUATOR_STATE) ||
+      TypeExistsOnBus(fastcat::PLATINUM_ACTUATOR_STATE)) {
+    DeclareServiceCommand<fcat_msgs::srv::ActuatorHaltService>(
+      this, "cmd/actuator_halt", &Fcat::ActuatorHaltSrvCb,
+      CommandDescriptor(
+        "Command to halt a single actuator without raising a fault",
+        {CommandArgumentDescriptor(
+          /*arg name*/ "name",
+          /*description*/ "The Fastcat Device Name")}));
 
-  PublishModuleState();
+    DeclareServiceCommand<
+      fcat_msgs::srv::ActuatorSetGainSchedulingIndexService>(
+      this, "cmd/actuator_set_gain_scheduling_index",
+      &Fcat::ActuatorSetGainSchedulingIndexSrvCb,
+      CommandDescriptor("Updates the Gain Scheduling Index exchanged through "
+                        "PDO. The Gain Scheduling MODE "
+                        "must be set by SDO through the service interface. "
+                        "If the Gain scheduling MODE is set to "
+                        "anything other than manual, this command has no "
+                        "effect on motor control performance.",
+                        {CommandArgumentDescriptor(
+                           /*arg name*/ "name",
+                           /*description*/ "The Fastcat Device Name"),
+                         CommandArgumentDescriptor(
+                           /*arg name*/ "gain_scheduling_index",
+                           /*description*/ "Desired gain table index")}));
 
+    DeclareServiceCommand<fcat_msgs::srv::ActuatorSetMaxCurrentService>(
+      this, "cmd/actuator_set_max_current", &Fcat::ActuatorSetMaxCurrentSrvCb,
+      CommandDescriptor(
+        "Updates the actuator peak current exchanged through PDO. "
+        "Typically, the Peak current "
+        "exceeds the Continous current (CL[1]) to allow for short power "
+        "boosts to improve "
+        "performance and help motor overcome transient loads. "
+        "When Peak current is less than the continous current (CL[1]), The "
+        "continous current limit "
+        "has no effect and boosting is disabled.",
+        {CommandArgumentDescriptor(
+           /*arg name*/ "name",
+           /*description*/ "The Fastcat Device Name"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "max_current",
+           /*description*/ "The desired peak current limit (PL[1])",
+           /*units*/ "Amperes")}));
+
+    DeclareServiceCommand<fcat_msgs::srv::ActuatorSetOutputPositionService>(
+      this, "cmd/actuator_set_output_position",
+      &Fcat::ActuatorSetOutputPositionSrvCb,
+      CommandDescriptor(
+        "Override to set the actuator to the specified value. When "
+        "possible, use "
+        "ActuatorCalibrate to calibrate position using the hardstops",
+        {CommandArgumentDescriptor(
+           /*arg name*/ "name",
+           /*description*/ "The Fastcat Device Name"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "position",
+           /*description*/
+           "Sets the current drive position to this value",
+           /*units*/ "EU")}));
+
+    DeclareServiceCommand<fcat_msgs::srv::ActuatorSetDigitalOutputService>(
+      this, "cmd/actuator_set_digital_output",
+      &Fcat::ActuatorSetDigitalOutputSrvCb,
+      CommandDescriptor(
+        "Set the Output Level for the actuator (Elmo command OB[N]).",
+        {CommandArgumentDescriptor(
+           /*arg name*/ "name",
+           /*description*/ "The Fastcat Device Name"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "digital_output_index",
+           /*description*/ "The user-chosen output index"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "output_level",
+           /*description*/ "The desired output level 1 or 0")}));
+
+    DeclareServiceCommand<
+      fcat_msgs::srv::ActuatorSetProfDisengagingTimeoutService>(
+      this, "cmd/actuator_set_prof_disengaging_timeout",
+      &Fcat::ActuatorSetProfDisengagingTimeoutSrvCb,
+      CommandDescriptor("Updates the maximum time the actuator driver will "
+                        "wait for a profile command to begin "
+                        "execution before faulting.",
+                        {CommandArgumentDescriptor(
+                           /*arg name*/ "name",
+                           /*description*/ "The Fastcat Device Name"),
+                         CommandArgumentDescriptor(
+                           /*arg name*/ "timeout",
+                           /*description*/ "The desired timeout",
+                           /*units*/ "seconds")}));
+
+    DeclareServiceCommand<fcat_msgs::srv::ActuatorProfPosService>(
+      this, "cmd/actuator_prof_pos", &Fcat::ActuatorProfPosSrvCb,
+      CommandDescriptor(
+        "Command a non-blocking Profiled Position motion profile to the "
+        "Actuator",
+        {CommandArgumentDescriptor(
+           /*arg name*/ "name",
+           /*description*/ "The Fastcat Device Name"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "target_position",
+           /*description*/ "Goal Position target of the motion profile",
+           /*Units*/ "EU"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "profile_velocity",
+           /*description*/
+           "The desired cruise rate of the motion profile",
+           /*Units*/ "EU / sec"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "profile_accel",
+           /*description*/
+           "The desired acceleration of the motion profile",
+           /*Units*/ "EU/sec^2"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "relative",
+           /*description*/ "If true, the target_position will computed "
+                           "relative "
+                           "to actual position")}));
+
+    DeclareServiceCommand<fcat_msgs::srv::ActuatorProfVelService>(
+      this, "cmd/actuator_prof_vel", &Fcat::ActuatorProfVelSrvCb,
+      CommandDescriptor(
+        "Command a non-blocking Profiled Velocity motion profile to the "
+        "Actuator",
+        {CommandArgumentDescriptor(
+           /*arg name*/ "name",
+           /*description*/ "The Fastcat Device Name"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "target_velocity",
+           /*description*/
+           "The desired cruise rate of the motion profile",
+           /*Units*/ "EU/sec"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "profile_accel",
+           /*description*/
+           "The desired acceleration of the motion profile",
+           /*Units*/ "EU/sec^2"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "max_duration",
+           /*description*/
+           "The duration of the command, negative values result "
+           "in indefinite profiles",
+           /*Units*/ "sec")}));
+
+    DeclareServiceCommand<fcat_msgs::srv::ActuatorProfTorqueService>(
+      this, "cmd/actuator_prof_torque", &Fcat::ActuatorProfTorqueSrvCb,
+      CommandDescriptor(
+        "Command a Profiled Torque motion profile to the Actuator. Here, "
+        "Torque"
+        "is equivalent to Current (frome the DS-402 specification)",
+        {CommandArgumentDescriptor(
+           /*arg name*/ "name",
+           /*description*/ "The Fastcat Device Name"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "target_torque_amps",
+           /*description*/ "The desired effort in current",
+           /*Units*/ "Amps"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "max_duration",
+           /*description*/
+           "The duration of the command, "
+           "negative values result in indefinite profiles",
+           /*Units*/ "sec")}));
+
+    DeclareServiceCommand<fcat_msgs::srv::ActuatorCalibrateService>(
+      this, "cmd/actuator_calibrate", &Fcat::ActuatorCalibrateSrvCb,
+      CommandDescriptor(
+        "Command a non-blocking hardstop calibration to the Actuator. "
+        "The actuator will move in "
+        "the signed velocity direction with the specified lowered current "
+        "limit "
+        "to detect the hardstop. From there, the position is set to the "
+        "calibration "
+        "limit defined in the configuration file. Finally, the original "
+        "current is "
+        "restored and the actuator is commanded to the command limit "
+        "defined in the "
+        "configuration file.",
+        {CommandArgumentDescriptor(
+           /*arg name*/ "name",
+           /*description*/ "The Fastcat Device Name"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "velocity",
+           /*description*/
+           "The desired approach velocity for all motions during "
+           "hardstop calibration",
+           /*Units*/ "EU/sec"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "accel",
+           /*description*/
+           "The desired acceleration of the motion profile",
+           /*Units*/ "EU/sec^2"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "max_current",
+           /*description*/
+           "Overrides the Peak current setting but only during "
+           "hardstop contact motion",
+           /*Units*/ "Amps")}));
+
+  }  // end Actuator Service Declarations
+
+  // Commander
+  if (TypeExistsOnBus(fastcat::COMMANDER_STATE)) {
+    DeclareServiceCommand<fcat_msgs::srv::CommanderEnableService>(
+      this, "cmd/commander_enable", &Fcat::CommanderEnableSrvCb,
+      CommandDescriptor("Enables the Commander to start issuing internal "
+                        "Fastcat device commands.",
+                        {CommandArgumentDescriptor(
+                          /*arg name*/ "name",
+                          /*description*/ "The Fastcat Device Name")}));
+
+    DeclareServiceCommand<fcat_msgs::srv::CommanderDisableService>(
+      this, "cmd/commander_disable", &Fcat::CommanderDisableSrvCb,
+      CommandDescriptor("Disables the Commander device to stop issuing "
+                        "internal Fastcat device commands.",
+                        {CommandArgumentDescriptor(
+                          /*arg name*/ "name",
+                          /*description*/ "The Fastcat Device Name")}));
+  }  // end Commander Service Declarations
+
+  // El2124
+  if (TypeExistsOnBus(fastcat::EL2124_STATE)) {
+    DeclareServiceCommand<fcat_msgs::srv::El2124WriteAllChannelsService>(
+      this, "cmd/el2124_write_all_channels", &Fcat::El2124WriteAllChannelsSrvCb,
+      CommandDescriptor(
+        "Command the state of all digital outputs of a EL2124 device.",
+        {CommandArgumentDescriptor(
+           /*arg name*/ "name",
+           /*description*/ "The Fastcat Device Name"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "channel_ch1",
+           /*description*/ "Desired level for channel index 1"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "channel_ch2",
+           /*description*/ "Desired level for channel index 2"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "channel_ch3",
+           /*description*/ "Desired level for channel index 3"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "channel_ch4",
+           /*description*/ "Desired level for channel index 4")}));
+
+    DeclareServiceCommand<fcat_msgs::srv::El2124WriteChannelService>(
+      this, "cmd/el2124_write_channel", &Fcat::El2124WriteChannelSrvCb,
+      CommandDescriptor(
+        "Command the state of one digital output of a EL2124 device, "
+        "leaving all other digital outputs unchanged.",
+        {
+          CommandArgumentDescriptor(
+            /*arg name*/ "name",
+            /*description*/ "The Fastcat Device Name"),
+          CommandArgumentDescriptor(
+            /*arg name*/ "channel",
+            /*description*/ "Desired channel index "),
+          CommandArgumentDescriptor(
+            /*arg name*/ "level",
+            /*description*/ "Desired digital output level"),
+        }));
+
+  }  // end El2124 Service Declarations
+
+  // El2809
+  if (TypeExistsOnBus(fastcat::EL2809_STATE)) {
+    DeclareServiceCommand<fcat_msgs::srv::El2809WriteAllChannelsService>(
+      this, "cmd/el2809_write_all_channels", &Fcat::El2809WriteAllChannelsSrvCb,
+      CommandDescriptor(
+        "Command the state of all digital outputs of a EL2809 device.",
+        {CommandArgumentDescriptor(
+           /*arg name*/ "name",
+           /*description*/ "The Fastcat Device Name"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "channel_ch1",
+           /*description*/ "Desired level for channel index 1"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "channel_ch2",
+           /*description*/ "Desired level for channel index 2"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "channel_ch3",
+           /*description*/ "Desired level for channel index 3"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "channel_ch4",
+           /*description*/ "Desired level for channel index 4"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "channel_ch5",
+           /*description*/ "Desired level for channel index 5"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "channel_ch6",
+           /*description*/ "Desired level for channel index 6"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "channel_ch7",
+           /*description*/ "Desired level for channel index 7"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "channel_ch8",
+           /*description*/ "Desired level for channel index 8"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "channel_ch9",
+           /*description*/ "Desired level for channel index 9"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "channel_ch10",
+           /*description*/ "Desired level for channel index 10"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "channel_ch11",
+           /*description*/ "Desired level for channel index 11"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "channel_ch12",
+           /*description*/ "Desired level for channel index 12"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "channel_ch13",
+           /*description*/ "Desired level for channel index 13"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "channel_ch14",
+           /*description*/ "Desired level for channel index 14"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "channel_ch15",
+           /*description*/ "Desired level for channel index 15"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "channel_ch16",
+           /*description*/ "Desired level for channel index 16")}));
+
+    DeclareServiceCommand<fcat_msgs::srv::El2809WriteChannelService>(
+      this, "cmd/el2809_write_channel", &Fcat::El2809WriteChannelSrvCb,
+      CommandDescriptor(
+        "Command the state of one digital output of a EL2809 device, "
+        "leaving all other digital outputs unchanged.",
+        {
+          CommandArgumentDescriptor(
+            /*arg name*/ "name",
+            /*description*/ "The Fastcat Device Name"),
+          CommandArgumentDescriptor(
+            /*arg name*/ "channel",
+            /*description*/ "Desired channel index "),
+          CommandArgumentDescriptor(
+            /*arg name*/ "level",
+            /*description*/ "Desired digital output level"),
+        }));
+
+  }  // end El2809 Service Declarations
+
+  // El2798
+  if (TypeExistsOnBus(fastcat::EL2798_STATE)) {
+    DeclareServiceCommand<fcat_msgs::srv::El2798WriteAllChannelsService>(
+        this, "cmd/el2798_write_all_channels",
+        &Fcat::El2798WriteAllChannelsSrvCb,
+        CommandDescriptor(
+            "Command the state of all digital outputs of a EL2798 device.",
+            {CommandArgumentDescriptor(
+                 /*arg name*/ "name",
+                 /*description*/ "The Fastcat Device Name"),
+             CommandArgumentDescriptor(
+                 /*arg name*/ "channel_ch1",
+                 /*description*/ "Desired level for channel index 1"),
+             CommandArgumentDescriptor(
+                 /*arg name*/ "channel_ch2",
+                 /*description*/ "Desired level for channel index 2"),
+             CommandArgumentDescriptor(
+                 /*arg name*/ "channel_ch3",
+                 /*description*/ "Desired level for channel index 3"),
+             CommandArgumentDescriptor(
+                 /*arg name*/ "channel_ch4",
+                 /*description*/ "Desired level for channel index 4"),
+             CommandArgumentDescriptor(
+                 /*arg name*/ "channel_ch5",
+                 /*description*/ "Desired level for channel index 5"),
+             CommandArgumentDescriptor(
+                 /*arg name*/ "channel_ch6",
+                 /*description*/ "Desired level for channel index 6"),
+             CommandArgumentDescriptor(
+                 /*arg name*/ "channel_ch7",
+                 /*description*/ "Desired level for channel index 7"),
+             CommandArgumentDescriptor(
+                 /*arg name*/ "channel_ch8",
+                 /*description*/ "Desired level for channel index 8")}));
+
+    DeclareServiceCommand<fcat_msgs::srv::El2798WriteChannelService>(
+        this, "cmd/el2798_write_channel", &Fcat::El2798WriteChannelSrvCb,
+        CommandDescriptor(
+            "Command the state of one digital output of a EL2798 device, "
+            "leaving all other digital outputs unchanged.",
+            {
+                CommandArgumentDescriptor(
+                    /*arg name*/ "name",
+                    /*description*/ "The Fastcat Device Name"),
+                CommandArgumentDescriptor(
+                    /*arg name*/ "channel",
+                    /*description*/ "Desired channel index "),
+                CommandArgumentDescriptor(
+                    /*arg name*/ "level",
+                    /*description*/ "Desired digital output level"),
+            }));
+
+  }  // end El2798 Service Declarations
+
+  // El2828
+  if (TypeExistsOnBus(fastcat::EL2828_STATE)) {
+    DeclareServiceCommand<fcat_msgs::srv::El2828WriteAllChannelsService>(
+        this, "cmd/el2828_write_all_channels",
+        &Fcat::El2828WriteAllChannelsSrvCb,
+        CommandDescriptor(
+            "Command the state of all digital outputs of a EL2828 device.",
+            {CommandArgumentDescriptor(
+                 /*arg name*/ "name",
+                 /*description*/ "The Fastcat Device Name"),
+             CommandArgumentDescriptor(
+                 /*arg name*/ "channel_ch1",
+                 /*description*/ "Desired level for channel index 1"),
+             CommandArgumentDescriptor(
+                 /*arg name*/ "channel_ch2",
+                 /*description*/ "Desired level for channel index 2"),
+             CommandArgumentDescriptor(
+                 /*arg name*/ "channel_ch3",
+                 /*description*/ "Desired level for channel index 3"),
+             CommandArgumentDescriptor(
+                 /*arg name*/ "channel_ch4",
+                 /*description*/ "Desired level for channel index 4"),
+             CommandArgumentDescriptor(
+                 /*arg name*/ "channel_ch5",
+                 /*description*/ "Desired level for channel index 5"),
+             CommandArgumentDescriptor(
+                 /*arg name*/ "channel_ch6",
+                 /*description*/ "Desired level for channel index 6"),
+             CommandArgumentDescriptor(
+                 /*arg name*/ "channel_ch7",
+                 /*description*/ "Desired level for channel index 7"),
+             CommandArgumentDescriptor(
+                 /*arg name*/ "channel_ch8",
+                 /*description*/ "Desired level for channel index 8")}));
+
+    DeclareServiceCommand<fcat_msgs::srv::El2828WriteChannelService>(
+        this, "cmd/el2828_write_channel", &Fcat::El2828WriteChannelSrvCb,
+        CommandDescriptor(
+            "Command the state of one digital output of a EL2828 device, "
+            "leaving all other digital outputs unchanged.",
+            {
+                CommandArgumentDescriptor(
+                    /*arg name*/ "name",
+                    /*description*/ "The Fastcat Device Name"),
+                CommandArgumentDescriptor(
+                    /*arg name*/ "channel",
+                    /*description*/ "Desired channel index "),
+                CommandArgumentDescriptor(
+                    /*arg name*/ "level",
+                    /*description*/ "Desired digital output level"),
+            }));
+
+  }  // end El2828 Service Declarations
+
+
+  // El4102
+  if (TypeExistsOnBus(fastcat::EL4102_STATE)) {
+    DeclareServiceCommand<fcat_msgs::srv::El4102WriteAllChannelsService>(
+      this, "cmd/el4102_write_all_channels", &Fcat::El4102WriteAllChannelsSrvCb,
+      CommandDescriptor(
+        "Command all the analog voltage outputs of a EL4102 device.",
+        {
+          CommandArgumentDescriptor(
+            /*arg name*/ "name",
+            /*description*/ "The Fastcat Device Name"),
+          CommandArgumentDescriptor(
+            /*arg name*/ "voltage_output_ch1",
+            /*description*/
+            "Desired voltage output value for channel index 1",
+            /*units*/ "volts"),
+          CommandArgumentDescriptor(
+            /*arg name*/ "voltage_output_ch2",
+            /*description*/
+            "Desired voltage output value for channel index 2",
+            /*units*/ "volts"),
+        }));
+
+    DeclareServiceCommand<fcat_msgs::srv::El4102WriteChannelService>(
+      this, "cmd/el4102_write_channel", &Fcat::El4102WriteChannelSrvCb,
+      CommandDescriptor(
+        "Command the state of one analog output of a EL4102 device, "
+        "leaving all other analog outputs unchanged.",
+        {CommandArgumentDescriptor(
+           /*arg name*/ "name",
+           /*description*/ "The Fastcat Device Name"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "channel",
+           /*description*/ "Desired channel index "),
+         CommandArgumentDescriptor(
+           /*arg name*/ "voltage_output",
+           /*description*/ "Desired voltage output value",
+           /*units*/ "volts")}));
+
+  }  // end El4102 Service Declarations
+
+  // Faulter
+  if (TypeExistsOnBus(fastcat::FAULTER_STATE)) {
+    DeclareServiceCommand<fcat_msgs::srv::FaulterEnableService>(
+      this, "cmd/faulter_enable", &Fcat::FaulterEnableSrvCb,
+      CommandDescriptor(
+        "Enables or Disables a Faulter device. When enabled, The Faulter "
+        "will "
+        "raise a fault if the input signal is != 0. When disabled, the "
+        "Faulter "
+        "cannot raise faults regardless of input signal.",
+        {CommandArgumentDescriptor(
+           /*arg name*/ "name",
+           /*description*/ "The Fastcat Device Name"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "enable",
+           /*description*/ "Boolean value to enable or disable the "
+                           "Faulter Device.")}));
+
+  }  // end Faulter Service Declarations
+
+  // FTS
+  if (TypeExistsOnBus(fastcat::FTS_STATE)) {
+    DeclareServiceCommand<fcat_msgs::srv::DeviceTriggerService>(
+      this, "cmd/fts_tare", &Fcat::FtsTareSrvCb,
+      CommandDescriptor("Tare a fts by offsetting the current sample by a "
+                        "bias term such that "
+                        "the tared_wrench reads zero.",
+                        {CommandArgumentDescriptor(
+                          /*arg name*/ "name",
+                          /*description*/ "The Fastcat Device Name")}));
+
+  }  // end FTS Service Declarations
+
+  // PID
+  if (TypeExistsOnBus(fastcat::PID_STATE)) {
+    DeclareServiceCommand<fcat_msgs::srv::PidActivateService>(
+      this, "cmd/pid_activate", &Fcat::PidActivateSrvCb,
+      CommandDescriptor(
+        "Start the PID Controller with specified parameters without "
+        "blocking.",
+        {CommandArgumentDescriptor(
+           /*arg name*/ "name",
+           /*description*/ "The Fastcat Device Name"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "setpoint",
+           /*description*/ "The controller setpoint",
+           /*Units*/ "EU"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "deadband",
+           /*description*/
+           "The controller deadband tolerange around the setpoint",
+           /*Units*/ "EU"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "persistence_duration",
+           /*description*/
+           "The amount of time the signal must remain with the "
+           "deadband to end control",
+           /*Units*/ "sec"),
+         CommandArgumentDescriptor(
+           /*arg name*/ "max_duration",
+           /*description*/
+           "The maximum duration of the command. Beware: "
+           "negative values can result in indefinite runtime",
+           /*Units*/ "sec")}));
+
+  }  // end PID Service Declarations
+}
+
+void Fcat::SetCpuAffinity() {
+#ifdef _GNU_SOURCE
+    if (gettid() != getpid()) {
+      int cpus_available = get_nprocs_conf();
+      EVR_ACTIVITY_LO("This system has %d CPUs configured", cpus_available);
+      if (process_loop_cpu_id_ >= cpus_available) {
+        EVR_FATAL(
+          "User requested to pin Process() function to CPU ID %d, but "
+          "only %d CPUs are available on this machine",
+          process_loop_cpu_id_, cpus_available);
+        rclcpp::shutdown();
+      } else {
+        cpu_set_t affinity;
+        CPU_ZERO(&affinity);
+        CPU_SET(process_loop_cpu_id_, &affinity);
+
+        EVR_ACTIVITY_LO("Setting CPU affinity for thread ID: %d", gettid());
+        int result = sched_setaffinity(gettid(), sizeof(cpu_set_t), &affinity);
+        if (result != 0) {
+          EVR_WARNING_HI(
+            "Could not set process affinity to CPU %d for thread ID: %d, "
+            "sched_setaffinity returned result: %d",
+            process_loop_cpu_id_, gettid(), result);
+        } else {
+          EVR_ACTIVITY_LO("Set CPU affinity to CPU %d for thread ID: %d",
+                         process_loop_cpu_id_, gettid());
+        }
+        process_loop_thread_id_ = gettid();
+      }
+    }
+#else
+  EVR_WARNING_HI(
+    "GNU extensions are not available on this machine/compiler; the Process() "
+    "loop "
+    "cannot be moved to CPU %d",
+    process_loop_thread_id_);
+#endif
+}
+
+
+void Fcat::Process()
+{
+  CFW_TRACE("Handling Process() loop");
+  auto now = this->get_clock()->now();
+
+  bool report_cycle_slips = this->get_parameter("report_cycle_slips").as_bool();
+  if (report_cycle_slips && time_stamp_initialized_ &&
+      cpu_affinity_initialized_) {
+    double dt = now.seconds() - publish_time_stamp_.seconds();
+    if (dt > 2.0 * loop_period_sec_) {
+      EVR_WARNING_LO(
+        "Cycle slip detected; seconds since last Process() call: "
+        "%f",
+        dt);
+    }
+    if(fault_on_cycle_slip_ && dt > cycle_slip_fault_magnitude_ * loop_period_sec_) {      
+      fcat_manager_.ExecuteAllDeviceFaults();
+      const std::shared_ptr<std_msgs::msg::Empty> msg;
+      FaultInterface::FaultCmdCb(msg);
+      publish_time_stamp_ = now;
+      return;
+    }
+  }
+
+  publish_time_stamp_ = now;
+  time_stamp_initialized_ = true;
+
+#ifdef _GNU_SOURCE
+  // sched_affinity is a GNU extension, and may not be available in some
+  // compilers
+  if (!cpu_affinity_initialized_) {
+    if (process_loop_cpu_id_ < 0) {
+      // no thread pinning requested
+      cpu_affinity_initialized_ = true;
+    } else if (gettid() != getpid()) {
+      int cpus_available = get_nprocs_conf();
+      EVR_ACTIVITY_LO("This system has %d CPUs configured", cpus_available);
+      if (process_loop_cpu_id_ >= cpus_available) {
+        EVR_FATAL(
+          "User requested to pin Process() function to CPU ID %d, but "
+          "only %d CPUs are available on this machine",
+          process_loop_cpu_id_, cpus_available);
+        rclcpp::shutdown();
+      } else {
+        cpu_set_t affinity;
+        CPU_ZERO(&affinity);
+        CPU_SET(process_loop_cpu_id_, &affinity);
+
+        EVR_ACTIVITY_LO("Process loop started in thread ID: %d", gettid());
+        int result = sched_setaffinity(gettid(), sizeof(cpu_set_t), &affinity);
+        if (result != 0) {
+          EVR_WARNING_HI(
+            "Could not set process affinity to CPU %d for thread ID: %d, "
+            "sched_setaffinity returned result: %d",
+            process_loop_cpu_id_, gettid(), result);
+        } else {
+          EVR_ACTIVITY_LO("Set CPU affinity to CPU %d for thread ID: %d",
+                         process_loop_cpu_id_, gettid());
+        }
+        process_loop_thread_id_ = gettid();
+        cpu_affinity_initialized_ = true;
+      }
+    }
+  }
+#else
+  EVR_WARNING_HI(
+    "GNU extensions are not available on this machine/compiler; the Process() "
+    "loop cannot be moved to CPU %d",
+    process_loop_thread_id_);
+  cpu_affinity_initialized_ = true;
+#endif
+
+  if(!process_loop_realtime_preempt_initialized_) {
+    if(enable_realtime_preempt_) {
+      EVR_ACTIVITY_HI("Setting realtime priority for process loop to %d", scheduler_priority_);
+      SetRealtimePreempt(scheduler_priority_);
+    }
+    process_loop_realtime_preempt_initialized_ = true;
+  }
+
+  if (use_sim_time_) {
+    fcat_manager_.Process(publish_time_stamp_.seconds());
+  } else {
+    fcat_manager_.Process();
+  }
+
+  PublishAsyncSdoResponse();
+  PublishFcatModuleState();
   PublishFtsStates();
-
   PublishActuatorStates();
   PublishEgdStates();
+  PublishEl1008States();
   PublishEl2124States();
+  PublishEl2809States();
+  PublishEl2798States();
+  PublishEl2828States();
+  PublishEl3104States();
+  PublishEl3162States();
+  PublishEl3202States();
   PublishEl3208States();
+  PublishEl3314States();
+  PublishEl3318States();
   PublishEl3602States();
-  PublishJedStates();
+  PublishEl4102States();
+  PublishEl5042States();
+  PublishIld1900States();
 
   PublishCommanderStates();
   PublishConditionalStates();
@@ -441,95 +1786,181 @@ void Fcat::Process(){
   PublishSaturationStates();
   PublishSchmittTriggerStates();
   PublishSignalGeneratorStates();
+  PublishLinearInterpolationStates();
+  PublishThreeNodeThermalModelStates();
 }
 
-void Fcat::PublishModuleState(){
-  auto module_state_msg = fcat_msgs::msg::ModuleState();
+void Fcat::PublishFcatModuleState()
+{
+  // Check for fault status and emit EVRs
+  bool is_faulted = fcat_manager_.IsFaulted();
+  if (!module_state_msg_.faulted && is_faulted) {
+    Fault();
+    EVR_WARNING_LO("Fastcat bus fault detected");
+  } else if (module_state_msg_.faulted && !is_faulted) {
+    EVR_ACTIVITY_HI("Fastcat bus fault cleared");
+  }
 
-  module_state_msg.faulted = fcat_manager_.IsFaulted();
+  module_state_msg_.faulted = is_faulted;
+  module_state_msg_.command_queue_size = command_queue_size_;
+  command_queue_size_ = 0;
 
-  double now = fcat_get_time_sec();
-  module_state_msg.jitter = now - last_time_;
-  last_time_ = now;
+  // Populate the rest of the message
+  double t = this->now().seconds();
 
-  module_state_pub_->publish(module_state_msg);
+  // jitter is defined as the delta between the last time the module
+  // was serviced and the nominal loop period. e.g. if a module
+  // is serviced exactly at its nominal loop period, it will have zero jitter
+  module_state_msg_.jitter = t - last_time_ - loop_period_sec_;
+  last_time_ = t;
+
+  module_state_msg_.header.stamp = publish_time_stamp_;
+
+  module_state_pub_->publish(module_state_msg_);
 }
 
-void Fcat::PublishFtsStates(){
+void Fcat::PublishAsyncSdoResponse()
+{
+  fastcat::SdoResponse sdo_resp;
+  if (fcat_manager_.PopSdoResponseQueue(sdo_resp)) {
+    fcat_msgs::msg::AsyncSdoResponse msg;
 
+    msg.device_name = sdo_resp.device_name;
+    msg.request_type =
+      jsd_sdo_request_type_to_string(sdo_resp.response.request_type);
+    msg.sdo_index = sdo_resp.response.sdo_index;
+    msg.sdo_subindex = sdo_resp.response.sdo_subindex;
+    msg.data_type = jsd_sdo_data_type_to_string(sdo_resp.response.data_type);
+    msg.app_id = sdo_resp.response.app_id;
+    msg.success = sdo_resp.response.success;
+
+    msg.data = jsd_sdo_data_to_string(sdo_resp.response.data_type,
+                                      sdo_resp.response.data);
+
+    CFW_TRACE("Publishing new AsyncSdoResponse");
+
+    async_sdo_response_pub_->publish(msg);
+  }
+}
+
+void Fcat::PublishFtsStates()
+{
   // FTS, AtiFts, VirtualFts
   auto vec_state_ptrs = device_type_vec_map_[fastcat::FTS_STATE];
+  if (vec_state_ptrs.size() > 0) {
+    size_t index = 0;
 
-  for(auto dev_state_ptr = vec_state_ptrs.begin(); dev_state_ptr != vec_state_ptrs.end(); dev_state_ptr++){
-  auto wrench_msg = geometry_msgs::msg::Wrench();
+    fts_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto dev_state_ptr = vec_state_ptrs.begin();
+         dev_state_ptr != vec_state_ptrs.end(); dev_state_ptr++) {
+      // Aggregate FTS state message
+      fts_states_msg_.names[index] = (*dev_state_ptr)->name;
+      fts_states_msg_.states[index] = FtsStateToMsg(*dev_state_ptr);
+      index++;
 
-    std::string device = (*dev_state_ptr)->name;
-    fastcat::FtsState fts_state = (*dev_state_ptr)->fts_state;
+      if (enable_ros_wrench_pub_) {
+        auto wrench_msg = geometry_msgs::msg::WrenchStamped();
 
-    wrench_msg.force.x = fts_state.raw_fx;
-    wrench_msg.force.y = fts_state.raw_fy;
-    wrench_msg.force.z = fts_state.raw_fz;
+        wrench_msg.header.stamp = publish_time_stamp_;
 
-    wrench_msg.torque.x = fts_state.raw_tx;
-    wrench_msg.torque.y = fts_state.raw_ty;
-    wrench_msg.torque.z = fts_state.raw_tz;
+        std::string device = (*dev_state_ptr)->name;
+        fastcat::FtsState fts_state = (*dev_state_ptr)->fts_state;
 
-    fts_raw_pub_map_[device]->publish(wrench_msg);
+        // Publish Raw FTS
+        wrench_msg.header.stamp = publish_time_stamp_;
 
+        wrench_msg.wrench.force.x = fts_state.raw_fx;
+        wrench_msg.wrench.force.y = fts_state.raw_fy;
+        wrench_msg.wrench.force.z = fts_state.raw_fz;
 
-    wrench_msg.force.x = fts_state.tared_fx;
-    wrench_msg.force.y = fts_state.tared_fy;
-    wrench_msg.force.z = fts_state.tared_fz;
+        wrench_msg.wrench.torque.x = fts_state.raw_tx;
+        wrench_msg.wrench.torque.y = fts_state.raw_ty;
+        wrench_msg.wrench.torque.z = fts_state.raw_tz;
 
-    wrench_msg.torque.x = fts_state.tared_tx;
-    wrench_msg.torque.y = fts_state.tared_ty;
-    wrench_msg.torque.z = fts_state.tared_tz;
+        fts_raw_pub_map_[device]->publish(wrench_msg);
 
-    fts_tared_pub_map_[device]->publish(wrench_msg);
-   }
+        // Publish Tared FTS
+        wrench_msg.header.stamp = publish_time_stamp_;
 
+        wrench_msg.wrench.force.x = fts_state.tared_fx;
+        wrench_msg.wrench.force.y = fts_state.tared_fy;
+        wrench_msg.wrench.force.z = fts_state.tared_fz;
+
+        wrench_msg.wrench.torque.x = fts_state.tared_tx;
+        wrench_msg.wrench.torque.y = fts_state.tared_ty;
+        wrench_msg.wrench.torque.z = fts_state.tared_tz;
+
+        fts_tared_pub_map_[device]->publish(wrench_msg);
+      }
+    }
+
+    // dont forget to publish the aggregated fts states message
+    fts_pub_->publish(fts_states_msg_);
+  }
 }
 
-void Fcat::PublishActuatorStates(){
+void Fcat::PublishActuatorStates()
+{
+  auto& gold_act_state_vec = device_type_vec_map_[fastcat::GOLD_ACTUATOR_STATE];
+  auto& platinum_act_state_vec =
+    device_type_vec_map_[fastcat::PLATINUM_ACTUATOR_STATE];
+  size_t num_actuators =
+    gold_act_state_vec.size() + platinum_act_state_vec.size();
 
-  auto act_state_vec = device_type_vec_map_[fastcat::ACTUATOR_STATE];
-  if(act_state_vec.size() > 0){
+  if (num_actuators > 0) {
     size_t index = 0;
-    auto js_msg = sensor_msgs::msg::JointState(); // TODO preallocate
+    auto js_msg = sensor_msgs::msg::JointState();
+    js_msg.name.reserve(num_actuators);
+    js_msg.position.reserve(num_actuators);
+    js_msg.velocity.reserve(num_actuators);
 
-    for(auto state_ptr = act_state_vec.begin(); 
-        state_ptr != act_state_vec.end(); state_ptr++)
-    {
+    actuator_states_msg_.header.stamp = publish_time_stamp_;
+    js_msg.header.stamp = publish_time_stamp_;
+
+    for (auto state_ptr : gold_act_state_vec) {
       // Populate ActuatorStates message
-      actuator_states_msg_.names[index] = (*state_ptr)->name;
-      actuator_states_msg_.states[index] = ActuatorStateToMsg(*state_ptr);
+      actuator_states_msg_.names[index] = state_ptr->name;
+      actuator_states_msg_.states[index] = ActuatorStateToMsg(state_ptr);
       index++;
 
       // Populate JointState message
-      js_msg.name.push_back((*state_ptr)->name);
-      js_msg.position.push_back((*state_ptr)->actuator_state.actual_position);
-      js_msg.velocity.push_back((*state_ptr)->actuator_state.actual_velocity);
+      js_msg.name.push_back(state_ptr->name);
+      js_msg.position.push_back(state_ptr->gold_actuator_state.actual_position);
+      js_msg.velocity.push_back(state_ptr->gold_actuator_state.actual_velocity);
+    }
+
+    for (auto state_ptr : platinum_act_state_vec) {
+      // Populate ActuatorStates message
+      actuator_states_msg_.names[index] = state_ptr->name;
+      actuator_states_msg_.states[index] = ActuatorStateToMsg(state_ptr);
+      index++;
+
+      // Populate JointState message
+      js_msg.name.push_back(state_ptr->name);
+      js_msg.position.push_back(
+        state_ptr->platinum_actuator_state.actual_position);
+      js_msg.velocity.push_back(
+        state_ptr->platinum_actuator_state.actual_velocity);
     }
 
     actuator_pub_->publish(actuator_states_msg_);
 
-    js_msg.header.stamp = now();
-    if(enable_js_pub_){
+    js_msg.header.stamp = this->now();
+    if (enable_js_pub_) {
       joint_state_pub_->publish(js_msg);
     }
-
   }
 }
 
-void Fcat::PublishEgdStates(){
-
+void Fcat::PublishEgdStates()
+{
   auto state_vec = device_type_vec_map_[fastcat::EGD_STATE];
-  if(state_vec.size() > 0){
+  if (state_vec.size() > 0) {
     size_t index = 0;
 
-    for(auto state_ptr = state_vec.begin(); 
-        state_ptr != state_vec.end(); state_ptr++)
-    {
+    egd_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
+         state_ptr++) {
       egd_states_msg_.names[index] = (*state_ptr)->name;
       egd_states_msg_.states[index] = EgdStateToMsg(*state_ptr);
       index++;
@@ -538,15 +1969,54 @@ void Fcat::PublishEgdStates(){
   }
 }
 
-void Fcat::PublishEl2124States(){
-
-  auto state_vec = device_type_vec_map_[fastcat::EL2124_STATE];
-  if(state_vec.size() > 0){
+void Fcat::PublishThreeNodeThermalModelStates()
+{
+  // FTS, AtiFts, VirtualFts
+  auto vec_state_ptrs =
+    device_type_vec_map_[fastcat::THREE_NODE_THERMAL_MODEL_STATE];
+  if (vec_state_ptrs.size() > 0) {
     size_t index = 0;
 
-    for(auto state_ptr = state_vec.begin(); 
-        state_ptr != state_vec.end(); state_ptr++)
-    {
+    three_node_thermal_model_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto dev_state_ptr = vec_state_ptrs.begin();
+         dev_state_ptr != vec_state_ptrs.end(); dev_state_ptr++) {
+      three_node_thermal_model_states_msg_.names[index] =
+        (*dev_state_ptr)->name;
+      three_node_thermal_model_states_msg_.states[index] =
+        ThreeNodeThermalModelStateToMsg(*dev_state_ptr);
+      index++;
+    }
+    three_node_thermal_model_pub_->publish(
+      three_node_thermal_model_states_msg_);
+  }
+}
+
+void Fcat::PublishEl1008States()
+{
+  auto state_vec = device_type_vec_map_[fastcat::EL1008_STATE];
+  if (state_vec.size() > 0) {
+    size_t index = 0;
+
+    el1008_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
+         state_ptr++) {
+      el1008_states_msg_.names[index] = (*state_ptr)->name;
+      el1008_states_msg_.states[index] = El1008StateToMsg(*state_ptr);
+      index++;
+    }
+    el1008_pub_->publish(el1008_states_msg_);
+  }
+}
+
+void Fcat::PublishEl2124States()
+{
+  auto state_vec = device_type_vec_map_[fastcat::EL2124_STATE];
+  if (state_vec.size() > 0) {
+    size_t index = 0;
+
+    el2124_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
+         state_ptr++) {
       el2124_states_msg_.names[index] = (*state_ptr)->name;
       el2124_states_msg_.states[index] = El2124StateToMsg(*state_ptr);
       index++;
@@ -555,15 +2025,117 @@ void Fcat::PublishEl2124States(){
   }
 }
 
-void Fcat::PublishEl3208States(){
-
-  auto state_vec = device_type_vec_map_[fastcat::EL3208_STATE];
-  if(state_vec.size() > 0){
+void Fcat::PublishEl2809States()
+{
+  auto state_vec = device_type_vec_map_[fastcat::EL2809_STATE];
+  if (state_vec.size() > 0) {
     size_t index = 0;
 
-    for(auto state_ptr = state_vec.begin(); 
-        state_ptr != state_vec.end(); state_ptr++)
-    {
+    el2809_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
+         state_ptr++) {
+      el2809_states_msg_.names[index] = (*state_ptr)->name;
+      el2809_states_msg_.states[index] = El2809StateToMsg(*state_ptr);
+      index++;
+    }
+    el2809_pub_->publish(el2809_states_msg_);
+  }
+}
+
+void Fcat::PublishEl2798States()
+{
+  auto state_vec = device_type_vec_map_[fastcat::EL2798_STATE];
+  if (state_vec.size() > 0) {
+    size_t index = 0;
+
+    el2798_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
+         state_ptr++) {
+      el2798_states_msg_.names[index]  = (*state_ptr)->name;
+      el2798_states_msg_.states[index] = El2798StateToMsg(*state_ptr);
+      index++;
+    }
+    el2798_pub_->publish(el2798_states_msg_);
+  }
+}
+
+void Fcat::PublishEl2828States()
+{
+  auto state_vec = device_type_vec_map_[fastcat::EL2828_STATE];
+  if (state_vec.size() > 0) {
+    size_t index = 0;
+
+    el2828_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
+         state_ptr++) {
+      el2828_states_msg_.names[index]  = (*state_ptr)->name;
+      el2828_states_msg_.states[index] = El2828StateToMsg(*state_ptr);
+      index++;
+    }
+    el2828_pub_->publish(el2828_states_msg_);
+  }
+}
+
+void Fcat::PublishEl3104States()
+{
+  auto state_vec = device_type_vec_map_[fastcat::EL3104_STATE];
+  if (state_vec.size() > 0) {
+    size_t index = 0;
+
+    el3104_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
+         state_ptr++) {
+      el3104_states_msg_.names[index] = (*state_ptr)->name;
+      el3104_states_msg_.states[index] = El3104StateToMsg(*state_ptr);
+      index++;
+    }
+    el3104_pub_->publish(el3104_states_msg_);
+  }
+}
+
+void Fcat::PublishEl3162States()
+{
+  auto state_vec = device_type_vec_map_[fastcat::EL3162_STATE];
+  if (state_vec.size() > 0) {
+    size_t index = 0;
+
+    el3162_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
+         state_ptr++) {
+      el3162_states_msg_.names[index] = (*state_ptr)->name;
+      el3162_states_msg_.states[index] = El3162StateToMsg(*state_ptr);
+      index++;
+    }
+    el3162_pub_->publish(el3162_states_msg_);
+  }
+}
+
+void Fcat::PublishEl3202States()
+{
+  auto state_vec = device_type_vec_map_[fastcat::EL3202_STATE];
+  if (state_vec.size() > 0) {
+    size_t index = 0;
+
+    el3202_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
+         state_ptr++) {
+      el3202_states_msg_.names[index] = (*state_ptr)->name;
+      el3202_states_msg_.states[index] = El3202StateToMsg(*state_ptr);
+      index++;
+    }
+    el3202_pub_->publish(el3202_states_msg_);
+  }
+}
+
+void Fcat::PublishEl3208States()
+{
+  auto state_vec = device_type_vec_map_[fastcat::EL3208_STATE];
+  if (state_vec.size() > 0) {
+    size_t index = 0;
+
+    el3208_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
+         state_ptr++) {
       el3208_states_msg_.names[index] = (*state_ptr)->name;
       el3208_states_msg_.states[index] = El3208StateToMsg(*state_ptr);
       index++;
@@ -572,15 +2144,49 @@ void Fcat::PublishEl3208States(){
   }
 }
 
-void Fcat::PublishEl3602States(){
-
-  auto state_vec = device_type_vec_map_[fastcat::EL3602_STATE];
-  if(state_vec.size() > 0){
+void Fcat::PublishEl3314States()
+{
+  auto state_vec = device_type_vec_map_[fastcat::EL3314_STATE];
+  if (state_vec.size() > 0) {
     size_t index = 0;
 
-    for(auto state_ptr = state_vec.begin(); 
-        state_ptr != state_vec.end(); state_ptr++)
-    {
+    el3314_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
+         state_ptr++) {
+      el3314_states_msg_.names[index] = (*state_ptr)->name;
+      el3314_states_msg_.states[index] = El3314StateToMsg(*state_ptr);
+      index++;
+    }
+    el3314_pub_->publish(el3314_states_msg_);
+  }
+}
+
+void Fcat::PublishEl3318States()
+{
+  auto state_vec = device_type_vec_map_[fastcat::EL3318_STATE];
+  if (state_vec.size() > 0) {
+    size_t index = 0;
+
+    el3318_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
+         state_ptr++) {
+      el3318_states_msg_.names[index] = (*state_ptr)->name;
+      el3318_states_msg_.states[index] = El3318StateToMsg(*state_ptr);
+      index++;
+    }
+    el3318_pub_->publish(el3318_states_msg_);
+  }
+}
+
+void Fcat::PublishEl3602States()
+{
+  auto state_vec = device_type_vec_map_[fastcat::EL3602_STATE];
+  if (state_vec.size() > 0) {
+    size_t index = 0;
+
+    el3602_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
+         state_ptr++) {
       el3602_states_msg_.names[index] = (*state_ptr)->name;
       el3602_states_msg_.states[index] = El3602StateToMsg(*state_ptr);
       index++;
@@ -589,32 +2195,66 @@ void Fcat::PublishEl3602States(){
   }
 }
 
-void Fcat::PublishJedStates(){
-
-  auto state_vec = device_type_vec_map_[fastcat::JED_STATE];
-  if(state_vec.size() > 0){
+void Fcat::PublishEl4102States()
+{
+  auto state_vec = device_type_vec_map_[fastcat::EL4102_STATE];
+  if (state_vec.size() > 0) {
     size_t index = 0;
 
-    for(auto state_ptr = state_vec.begin(); 
-        state_ptr != state_vec.end(); state_ptr++)
-    {
-      jed_states_msg_.names[index] = (*state_ptr)->name;
-      jed_states_msg_.states[index] = JedStateToMsg(*state_ptr);
+    el4102_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
+         state_ptr++) {
+      el4102_states_msg_.names[index] = (*state_ptr)->name;
+      el4102_states_msg_.states[index] = El4102StateToMsg(*state_ptr);
       index++;
     }
-    jed_pub_->publish(jed_states_msg_);
+    el4102_pub_->publish(el4102_states_msg_);
   }
 }
 
-void Fcat::PublishCommanderStates(){
-
-  auto state_vec = device_type_vec_map_[fastcat::COMMANDER_STATE];
-  if(state_vec.size() > 0){
+void Fcat::PublishEl5042States()
+{
+  auto state_vec = device_type_vec_map_[fastcat::EL5042_STATE];
+  if (state_vec.size() > 0) {
     size_t index = 0;
 
-    for(auto state_ptr = state_vec.begin(); 
-        state_ptr != state_vec.end(); state_ptr++)
-    {
+    el5042_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
+         state_ptr++) {
+      el5042_states_msg_.names[index]  = (*state_ptr)->name;
+      el5042_states_msg_.states[index] = El5042StateToMsg(*state_ptr);
+      index++;
+    }
+    el5042_pub_->publish(el5042_states_msg_);
+  }
+}
+
+void Fcat::PublishIld1900States()
+{
+  auto state_vec = device_type_vec_map_[fastcat::ILD1900_STATE];
+  if (state_vec.size() > 0) {
+    size_t index = 0;
+
+    ild1900_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
+         state_ptr++) {
+      ild1900_states_msg_.names[index] = (*state_ptr)->name;
+      ild1900_states_msg_.states[index] = Ild1900StateToMsg(*state_ptr);
+      index++;
+    }
+    ild1900_pub_->publish(ild1900_states_msg_);
+  }
+}
+
+void Fcat::PublishCommanderStates()
+{
+  auto state_vec = device_type_vec_map_[fastcat::COMMANDER_STATE];
+  if (state_vec.size() > 0) {
+    size_t index = 0;
+
+    commander_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
+         state_ptr++) {
       commander_states_msg_.names[index] = (*state_ptr)->name;
       commander_states_msg_.states[index] = CommanderStateToMsg(*state_ptr);
       index++;
@@ -623,15 +2263,15 @@ void Fcat::PublishCommanderStates(){
   }
 }
 
-void Fcat::PublishConditionalStates(){
-
+void Fcat::PublishConditionalStates()
+{
   auto state_vec = device_type_vec_map_[fastcat::CONDITIONAL_STATE];
-  if(state_vec.size() > 0){
+  if (state_vec.size() > 0) {
     size_t index = 0;
 
-    for(auto state_ptr = state_vec.begin(); 
-        state_ptr != state_vec.end(); state_ptr++)
-    {
+    conditional_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
+         state_ptr++) {
       conditional_states_msg_.names[index] = (*state_ptr)->name;
       conditional_states_msg_.states[index] = ConditionalStateToMsg(*state_ptr);
       index++;
@@ -640,15 +2280,15 @@ void Fcat::PublishConditionalStates(){
   }
 }
 
-void Fcat::PublishFaulterStates(){
-
+void Fcat::PublishFaulterStates()
+{
   auto state_vec = device_type_vec_map_[fastcat::FAULTER_STATE];
-  if(state_vec.size() > 0){
+  if (state_vec.size() > 0) {
     size_t index = 0;
 
-    for(auto state_ptr = state_vec.begin(); 
-        state_ptr != state_vec.end(); state_ptr++)
-    {
+    faulter_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
+         state_ptr++) {
       faulter_states_msg_.names[index] = (*state_ptr)->name;
       faulter_states_msg_.states[index] = FaulterStateToMsg(*state_ptr);
       index++;
@@ -657,15 +2297,15 @@ void Fcat::PublishFaulterStates(){
   }
 }
 
-void Fcat::PublishFilterStates(){
-
+void Fcat::PublishFilterStates()
+{
   auto state_vec = device_type_vec_map_[fastcat::FILTER_STATE];
-  if(state_vec.size() > 0){
+  if (state_vec.size() > 0) {
     size_t index = 0;
 
-    for(auto state_ptr = state_vec.begin(); 
-        state_ptr != state_vec.end(); state_ptr++)
-    {
+    filter_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
+         state_ptr++) {
       filter_states_msg_.names[index] = (*state_ptr)->name;
       filter_states_msg_.states[index] = FilterStateToMsg(*state_ptr);
       index++;
@@ -674,15 +2314,15 @@ void Fcat::PublishFilterStates(){
   }
 }
 
-void Fcat::PublishFunctionStates(){
-
+void Fcat::PublishFunctionStates()
+{
   auto state_vec = device_type_vec_map_[fastcat::FUNCTION_STATE];
-  if(state_vec.size() > 0){
+  if (state_vec.size() > 0) {
     size_t index = 0;
 
-    for(auto state_ptr = state_vec.begin(); 
-        state_ptr != state_vec.end(); state_ptr++)
-    {
+    function_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
+         state_ptr++) {
       function_states_msg_.names[index] = (*state_ptr)->name;
       function_states_msg_.states[index] = FunctionStateToMsg(*state_ptr);
       index++;
@@ -691,15 +2331,15 @@ void Fcat::PublishFunctionStates(){
   }
 }
 
-void Fcat::PublishPidStates(){
-
+void Fcat::PublishPidStates()
+{
   auto state_vec = device_type_vec_map_[fastcat::PID_STATE];
-  if(state_vec.size() > 0){
+  if (state_vec.size() > 0) {
     size_t index = 0;
 
-    for(auto state_ptr = state_vec.begin(); 
-        state_ptr != state_vec.end(); state_ptr++)
-    {
+    pid_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
+         state_ptr++) {
       pid_states_msg_.names[index] = (*state_ptr)->name;
       pid_states_msg_.states[index] = PidStateToMsg(*state_ptr);
       index++;
@@ -708,15 +2348,15 @@ void Fcat::PublishPidStates(){
   }
 }
 
-void Fcat::PublishSaturationStates(){
-
+void Fcat::PublishSaturationStates()
+{
   auto state_vec = device_type_vec_map_[fastcat::SATURATION_STATE];
-  if(state_vec.size() > 0){
+  if (state_vec.size() > 0) {
     size_t index = 0;
 
-    for(auto state_ptr = state_vec.begin(); 
-        state_ptr != state_vec.end(); state_ptr++)
-    {
+    saturation_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
+         state_ptr++) {
       saturation_states_msg_.names[index] = (*state_ptr)->name;
       saturation_states_msg_.states[index] = SaturationStateToMsg(*state_ptr);
       index++;
@@ -725,36 +2365,59 @@ void Fcat::PublishSaturationStates(){
   }
 }
 
-void Fcat::PublishSchmittTriggerStates(){
-
+void Fcat::PublishSchmittTriggerStates()
+{
   auto state_vec = device_type_vec_map_[fastcat::SCHMITT_TRIGGER_STATE];
-  if(state_vec.size() > 0){
+  if (state_vec.size() > 0) {
     size_t index = 0;
 
-    for(auto state_ptr = state_vec.begin(); 
-        state_ptr != state_vec.end(); state_ptr++)
-    {
+    schmitt_trigger_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
+         state_ptr++) {
       schmitt_trigger_states_msg_.names[index] = (*state_ptr)->name;
-      schmitt_trigger_states_msg_.states[index] = SchmittTriggerStateToMsg(*state_ptr);
+      schmitt_trigger_states_msg_.states[index] =
+        SchmittTriggerStateToMsg(*state_ptr);
       index++;
     }
     schmitt_trigger_pub_->publish(schmitt_trigger_states_msg_);
   }
 }
 
-void Fcat::PublishSignalGeneratorStates(){
-
+void Fcat::PublishSignalGeneratorStates()
+{
   auto state_vec = device_type_vec_map_[fastcat::SIGNAL_GENERATOR_STATE];
-  if(state_vec.size() > 0){
+  if (state_vec.size() > 0) {
     size_t index = 0;
 
-    for(auto state_ptr = state_vec.begin(); 
-        state_ptr != state_vec.end(); state_ptr++)
-    {
+    signal_generator_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
+         state_ptr++) {
       signal_generator_states_msg_.names[index] = (*state_ptr)->name;
-      signal_generator_states_msg_.states[index] = SignalGeneratorStateToMsg(*state_ptr);
+      signal_generator_states_msg_.states[index] =
+        SignalGeneratorStateToMsg(*state_ptr);
       index++;
     }
     signal_generator_pub_->publish(signal_generator_states_msg_);
   }
 }
+
+void Fcat::PublishLinearInterpolationStates()
+{
+  auto state_vec = device_type_vec_map_[fastcat::LINEAR_INTERPOLATION_STATE];
+  if (state_vec.size() > 0) {
+    size_t index = 0;
+
+    linear_interpolation_states_msg_.header.stamp = publish_time_stamp_;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
+         state_ptr++) {
+      linear_interpolation_states_msg_.names[index] = (*state_ptr)->name;
+      linear_interpolation_states_msg_.states[index] =
+        LinearInterpolationStateToMsg(*state_ptr);
+      index++;
+    }
+    linear_interpolation_pub_->publish(linear_interpolation_states_msg_);
+  }
+}
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(Fcat)

--- a/src/fcat.cpp
+++ b/src/fcat.cpp
@@ -22,7 +22,7 @@ using std::placeholders::_2;
 Fcat::~Fcat() { fcat_manager_.Shutdown(); }
 
 Fcat::Fcat(const rclcpp::NodeOptions& options)
-    : casah_node::BaseInterface("fcat", "fcat", options),
+    : FcatNode("fcat", "fcat"),
       service_qos_(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_services_default), rmw_qos_profile_services_default)
 {
   process_loop_callback_group_ =
@@ -248,8 +248,8 @@ Fcat::Fcat(const rclcpp::NodeOptions& options)
   last_time_ = this->now().seconds();
   module_state_msg_.faulted = false;
 
-  Fcat::StartProcessTimer();
-  SetActive();
+  InitializeTimer();
+  // SetActive();
 }
 
 void Fcat::SetRealtimePreempt(int scheduler_priority) {
@@ -276,23 +276,6 @@ void Fcat::SetRealtimePreempt(int scheduler_priority) {
   memset(dummy, 0, max_safe_stack);
 }
 
-void Fcat::StartProcessTimer()
-{
-  rclcpp::Parameter rate_param;
-  if (!this->get_parameter("target_loop_rate_hz", rate_param)) {
-    RCLCPP_FATAL(this->get_logger(),
-      "Developer Warning: must call InitializeTimerRate(...) before "
-      "starting timer");
-    rclcpp::shutdown();
-  }
-
-  double period_usec = 1.0e6 / fcat_manager_.GetTargetLoopRate();
-  std::chrono::duration<double, std::micro> chrono_dur(period_usec);
-  process_timer_ =
-    rclcpp::create_timer(this, this->get_clock(), chrono_dur,
-                         std::bind(&casah_node::FaultInterface::Process, this),
-                         process_loop_callback_group_);
-}
 
 rcl_interfaces::msg::SetParametersResult Fcat::SetParametersCb(
   const std::vector<rclcpp::Parameter>& parameters)
@@ -1625,7 +1608,7 @@ void Fcat::Process()
     if(fault_on_cycle_slip_ && dt > cycle_slip_fault_magnitude_ * loop_period_sec_) {      
       fcat_manager_.ExecuteAllDeviceFaults();
       const std::shared_ptr<std_msgs::msg::Empty> msg;
-      FaultInterface::FaultCmdCb(msg);
+      // FaultInterface::FaultCmdCb(msg); // TODO: use lifecyle nodes
       publish_time_stamp_ = now;
       return;
     }

--- a/src/fcat.cpp
+++ b/src/fcat.cpp
@@ -223,26 +223,27 @@ Fcat::Fcat(const rclcpp::NodeOptions& options)
   }
 
   PopulateDeviceStateFields();
-
+  
   // Must populate certain device state fields before initializing pub/sub
   InitializePublishersAndMessages();
   InitializeSubscribers();
   InitializeServices();
-
+  
   param_cb_handles_.push_back(
-      this->add_on_set_parameters_callback(std::bind(&Fcat::SetParametersCb, this, _1)));
+    this->add_on_set_parameters_callback(std::bind(&Fcat::SetParametersCb, this, _1)));
 
   // pull the Timer Rate from the Fastcat YAML
   InitializeTimerRate(fcat_manager_.GetTargetLoopRate());
   RCLCPP_INFO(this->get_logger(), "Starting Wall Timer at %lf hz",
-              fcat_manager_.GetTargetLoopRate());
+  fcat_manager_.GetTargetLoopRate());
 
   loop_period_sec_ = 1.0 / fcat_manager_.GetTargetLoopRate();
   last_time_ = this->now().seconds();
   module_state_msg_.faulted = false;
-
+  
+  fcat_state_ = FcatState::INACTIVE;
   StartProcessTimer();
-  // SetActive();
+  fcat_state_ = FcatState::ACTIVE;
 }
 
 void Fcat::SetRealtimePreempt(int scheduler_priority) {
@@ -1458,7 +1459,7 @@ void Fcat::Process() {
     if (fault_on_cycle_slip_ && dt > cycle_slip_fault_magnitude_ * loop_period_sec_) {
       fcat_manager_.ExecuteAllDeviceFaults();
       const std::shared_ptr<std_msgs::msg::Empty> msg;
-      // FaultInterface::FaultCmdCb(msg); // TODO: use lifecyle nodes
+      Fault(); // TODO: use lifecyle nodes
       publish_time_stamp_ = now;
       return;
     }
@@ -1565,7 +1566,7 @@ void Fcat::PublishFcatModuleState() {
   // Check for fault status and emit logs
   bool is_faulted = fcat_manager_.IsFaulted();
   if (!module_state_msg_.faulted && is_faulted) {
-    // Fault(); // TODO: use lifecycle nodes
+    Fault(); // TODO: use lifecycle nodes
     RCLCPP_WARN(this->get_logger(), "Fastcat bus fault detected");
   } else if (module_state_msg_.faulted && !is_faulted) {
     RCLCPP_INFO(this->get_logger(), "Fastcat bus fault cleared");

--- a/src/fcat.cpp
+++ b/src/fcat.cpp
@@ -502,7 +502,7 @@ void Fcat::InitializeActuatorParams(
           description_prefix + "low position calibration limit [eu]";
         descriptor.read_only = true;
         rcl_interfaces::msg::FloatingPointRange range;
-        range.from_value = 0.0;
+        range.from_value = std::numeric_limits<double>::lowest();
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
@@ -516,7 +516,7 @@ void Fcat::InitializeActuatorParams(
           description_prefix + "low position command limit [eu]";
         descriptor.read_only = true;
         rcl_interfaces::msg::FloatingPointRange range;
-        range.from_value = 0.0;
+        range.from_value = std::numeric_limits<double>::lowest();
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
@@ -530,7 +530,7 @@ void Fcat::InitializeActuatorParams(
           description_prefix + "high position calibration limit [eu]";
         descriptor.read_only = true;
         rcl_interfaces::msg::FloatingPointRange range;
-        range.from_value = 0.0;
+        range.from_value = std::numeric_limits<double>::lowest();
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
@@ -544,7 +544,7 @@ void Fcat::InitializeActuatorParams(
           description_prefix + "high position command limit [eu]";
         descriptor.read_only = true;
         rcl_interfaces::msg::FloatingPointRange range;
-        range.from_value = 0.0;
+        range.from_value = std::numeric_limits<double>::lowest();
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
@@ -596,7 +596,7 @@ void Fcat::InitializeActuatorParams(
         descriptor.description = description_prefix + "crc value";
         descriptor.read_only = true;
         rcl_interfaces::msg::FloatingPointRange range;
-        range.from_value = 0.0;
+        range.from_value = std::numeric_limits<double>::lowest();
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);

--- a/src/fcat.cpp
+++ b/src/fcat.cpp
@@ -19,7 +19,6 @@ Fcat::~Fcat() { fcat_manager_.Shutdown(); }
 Fcat::Fcat(const rclcpp::NodeOptions& options)
     : casah_node::BaseInterface("fcat", "fcat", options),
       casah_node::FaultInterface("fcat", "fcat", options),
-      casah_node::EvrInterface("fcat", "fcat", options),
       service_qos_(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_services_default), rmw_qos_profile_services_default)
 {
   process_loop_callback_group_ =
@@ -33,7 +32,7 @@ Fcat::Fcat(const rclcpp::NodeOptions& options)
     "",  // must be passed, cannot generally reason about this file path
     "Location of the the fastcat topology YAML file");
 
-  EVR_ACTIVITY_LO("loading Yaml from %s", fastcat_config_path.c_str());
+  RCLCPP_INFO(this->get_logger(), "loading Yaml from %s", fastcat_config_path.c_str());
   YAML::Node node = YAML::LoadFile(fastcat_config_path);
 
   if (!fcat_manager_.ConfigFromYaml(node)) {
@@ -141,7 +140,7 @@ Fcat::Fcat(const rclcpp::NodeOptions& options)
 
   DeclareRuntimeParameterBool(
     "report_cycle_slips", true,
-    "If true, fcat emits EVR messages to report timer "
+    "If true, fcat emits logs to report timer "
     "slips");
 
   PopulateDeviceStateFields();
@@ -156,7 +155,7 @@ Fcat::Fcat(const rclcpp::NodeOptions& options)
 
   // pull the Timer Rate from the Fastcat YAML
   InitializeTimerRate(fcat_manager_.GetTargetLoopRate());
-  EVR_ACTIVITY_LO("Starting Wall Timer at %lf hz",
+  RCLCPP_INFO(this->get_logger(), "Starting Wall Timer at %lf hz",
                   fcat_manager_.GetTargetLoopRate());
 
   loop_period_sec_ = 1.0 / fcat_manager_.GetTargetLoopRate();
@@ -172,7 +171,7 @@ void Fcat::SetRealtimePreempt(int scheduler_priority) {
   struct sched_param param;
   param.sched_priority = scheduler_priority;
   if(sched_setscheduler(0, SCHED_FIFO, &param) == -1) {
-    EVR_WARNING_HI(
+    RCLCPP_WARN(this->get_logger(),
       "Unable to set realtime FIFO scheduler with priority of "
       "%d; the realtime kernel must be installed to use this feature",
       scheduler_priority
@@ -182,7 +181,7 @@ void Fcat::SetRealtimePreempt(int scheduler_priority) {
   
   // Lock memory
   if(mlockall(MCL_CURRENT | MCL_FUTURE) == -1) {
-    EVR_WARNING_HI("Unable to lock memory; 'mlockall' failed");
+    RCLCPP_WARN(this->get_logger(), "Unable to lock memory; 'mlockall' failed");
   }
   
   // Pre-fault our stack
@@ -195,7 +194,7 @@ void Fcat::StartProcessTimer()
 {
   rclcpp::Parameter rate_param;
   if (!this->get_parameter("target_loop_rate_hz", rate_param)) {
-    EVR_FATAL(
+    RCLCPP_FATAL(this->get_logger(),
       "Developer Warning: must call InitializeTimerRate(...) before "
       "starting timer");
     rclcpp::shutdown();
@@ -385,14 +384,14 @@ void Fcat::PopulateDeviceStateFields()
 
   for (auto it = device_state_ptrs_.begin(); it != device_state_ptrs_.end();
        ++it) {
-    EVR_ACTIVITY_LO("Populating device_name_state_map_[%s]",
+    RCLCPP_INFO(this->get_logger(), "Populating device_name_state_map_[%s]",
                     (*it)->name.c_str());
 
     device_name_state_map_[(*it)->name] = *it;
 
     device_type_vec_map_[(*it)->type].push_back(*it);
 
-    EVR_ACTIVITY_LO("counts[%d] = %ld", (*it)->type,
+    RCLCPP_INFO(this->get_logger(), "counts[%d] = %ld", (*it)->type,
                     device_type_vec_map_[(*it)->type].size());
   }
 }
@@ -406,7 +405,7 @@ bool Fcat::ActuatorExistsOnBus(const std::string& name)
     return true;
   }
   // handle other future Actuator device types here
-  EVR_WARNING_HI("%s", error_message.c_str());
+  RCLCPP_WARN(this->get_logger(), "%s", error_message.c_str());
   return false;
 }
 
@@ -447,7 +446,7 @@ bool Fcat::DeviceExistsOnBus(const std::string& name,
   std::string error_message;
   bool success = DeviceExistsOnBus(name, type, error_message);
   if (not success) {
-    EVR_WARNING_HI("%s", error_message.c_str());
+    RCLCPP_WARN(this->get_logger(), "%s", error_message.c_str());
   }
   return success;
 }
@@ -462,7 +461,7 @@ bool Fcat::TypeExistsOnBus(fastcat::DeviceStateType type)
 
 void Fcat::InitializePublishersAndMessages()
 {
-  EVR_ACTIVITY_LO("Fcat::InitializePublishers()");
+  RCLCPP_INFO(this->get_logger(), "Fcat::InitializePublishers()");
 
   rclcpp::QoS qos_profile(publisher_queue_size_);
   qos_profile.best_effort();
@@ -480,7 +479,7 @@ void Fcat::InitializePublishersAndMessages()
     gold_vec_state_ptrs.size() + platinum_vec_state_ptrs.size();
 
   if (num_actuators > 0) {
-    EVR_ACTIVITY_LO("Creating actuator pub");
+    RCLCPP_INFO(this->get_logger(), "Creating actuator pub");
     actuator_pub_ = this->create_publisher<fcat_msgs::msg::ActuatorStates>(
       "state/actuators", qos_profile);
 
@@ -488,7 +487,7 @@ void Fcat::InitializePublishersAndMessages()
     actuator_states_msg_.states.resize(num_actuators);
 
     if (enable_js_pub_) {
-      EVR_ACTIVITY_LO("Creating joint_states pub");
+      RCLCPP_INFO(this->get_logger(), "Creating joint_states pub");
 
       // This is the only topic that broadcasts in the global
       // namespace. This prevents needing to remap `fcat/state/joint_states`
@@ -502,7 +501,7 @@ void Fcat::InitializePublishersAndMessages()
   // Egd
   auto vec_state_ptrs = device_type_vec_map_[fastcat::EGD_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating Egd pub");
+    RCLCPP_INFO(this->get_logger(), "Creating Egd pub");
     egd_pub_ = this->create_publisher<fcat_msgs::msg::EgdStates>(
       "state/egds", qos_profile);
 
@@ -513,7 +512,7 @@ void Fcat::InitializePublishersAndMessages()
   // El1008
   vec_state_ptrs = device_type_vec_map_[fastcat::EL1008_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating El1008 pub");
+    RCLCPP_INFO(this->get_logger(), "Creating El1008 pub");
     el1008_pub_ = this->create_publisher<fcat_msgs::msg::El1008States>(
       "state/el1008s", qos_profile);
 
@@ -524,7 +523,7 @@ void Fcat::InitializePublishersAndMessages()
   // El2124
   vec_state_ptrs = device_type_vec_map_[fastcat::EL2124_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating El2124 pub");
+    RCLCPP_INFO(this->get_logger(), "Creating El2124 pub");
     el2124_pub_ = this->create_publisher<fcat_msgs::msg::El2124States>(
       "state/el2124s", qos_profile);
 
@@ -535,7 +534,7 @@ void Fcat::InitializePublishersAndMessages()
   // El2809
   vec_state_ptrs = device_type_vec_map_[fastcat::EL2809_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating El2809 pub");
+    RCLCPP_INFO(this->get_logger(), "Creating El2809 pub");
     el2809_pub_ = this->create_publisher<fcat_msgs::msg::El2809States>(
       "state/el2809s", qos_profile);
 
@@ -546,7 +545,7 @@ void Fcat::InitializePublishersAndMessages()
   // El2798
   vec_state_ptrs = device_type_vec_map_[fastcat::EL2798_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating El2798 pub");
+    RCLCPP_INFO(this->get_logger(), "Creating El2798 pub");
     el2798_pub_ = this->create_publisher<fcat_msgs::msg::El2798States>(
         "state/el2798s", qos_profile);
 
@@ -557,7 +556,7 @@ void Fcat::InitializePublishersAndMessages()
   // El2828
   vec_state_ptrs = device_type_vec_map_[fastcat::EL2828_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating El2828 pub");
+    RCLCPP_INFO(this->get_logger(), "Creating El2828 pub");
     el2828_pub_ = this->create_publisher<fcat_msgs::msg::El2828States>(
         "state/el2828s", qos_profile);
 
@@ -568,7 +567,7 @@ void Fcat::InitializePublishersAndMessages()
   // El3104
   vec_state_ptrs = device_type_vec_map_[fastcat::EL3104_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating El3104 pub");
+    RCLCPP_INFO(this->get_logger(), "Creating El3104 pub");
     el3104_pub_ = this->create_publisher<fcat_msgs::msg::El3104States>(
       "state/el3104s", qos_profile);
 
@@ -579,7 +578,7 @@ void Fcat::InitializePublishersAndMessages()
   // El3162
   vec_state_ptrs = device_type_vec_map_[fastcat::EL3162_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating El3162 pub");
+    RCLCPP_INFO(this->get_logger(), "Creating El3162 pub");
     el3162_pub_ = this->create_publisher<fcat_msgs::msg::El3162States>(
       "state/el3162s", qos_profile);
 
@@ -590,7 +589,7 @@ void Fcat::InitializePublishersAndMessages()
   // El3202
   vec_state_ptrs = device_type_vec_map_[fastcat::EL3202_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating El3202 pub");
+    RCLCPP_INFO(this->get_logger(), "Creating El3202 pub");
     el3202_pub_ = this->create_publisher<fcat_msgs::msg::El3202States>(
       "state/el3202s", qos_profile);
 
@@ -601,7 +600,7 @@ void Fcat::InitializePublishersAndMessages()
   // El3208
   vec_state_ptrs = device_type_vec_map_[fastcat::EL3208_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating El3208 pub");
+    RCLCPP_INFO(this->get_logger(), "Creating El3208 pub");
     el3208_pub_ = this->create_publisher<fcat_msgs::msg::El3208States>(
       "state/el3208s", qos_profile);
 
@@ -612,7 +611,7 @@ void Fcat::InitializePublishersAndMessages()
   // El3314
   vec_state_ptrs = device_type_vec_map_[fastcat::EL3314_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating El3314 pub");
+    RCLCPP_INFO(this->get_logger(), "Creating El3314 pub");
     el3314_pub_ = this->create_publisher<fcat_msgs::msg::El3314States>(
       "state/el3314s", qos_profile);
 
@@ -623,7 +622,7 @@ void Fcat::InitializePublishersAndMessages()
   // El3318
   vec_state_ptrs = device_type_vec_map_[fastcat::EL3318_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating El3318 pub");
+    RCLCPP_INFO(this->get_logger(), "Creating El3318 pub");
     el3318_pub_ = this->create_publisher<fcat_msgs::msg::El3318States>(
       "state/el3318s", qos_profile);
 
@@ -634,7 +633,7 @@ void Fcat::InitializePublishersAndMessages()
   // El3602
   vec_state_ptrs = device_type_vec_map_[fastcat::EL3602_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating El3602 pub");
+    RCLCPP_INFO(this->get_logger(), "Creating El3602 pub");
     el3602_pub_ = this->create_publisher<fcat_msgs::msg::El3602States>(
       "state/el3602s", qos_profile);
 
@@ -645,7 +644,7 @@ void Fcat::InitializePublishersAndMessages()
   // El4102
   vec_state_ptrs = device_type_vec_map_[fastcat::EL4102_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating El4102 pub");
+    RCLCPP_INFO(this->get_logger(), "Creating El4102 pub");
     el4102_pub_ = this->create_publisher<fcat_msgs::msg::El4102States>(
       "state/el4102s", qos_profile);
 
@@ -656,7 +655,7 @@ void Fcat::InitializePublishersAndMessages()
   // El5042
   vec_state_ptrs = device_type_vec_map_[fastcat::EL5042_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating El5042 pub");
+    RCLCPP_INFO(this->get_logger(), "Creating El5042 pub");
     el5042_pub_ = this->create_publisher<fcat_msgs::msg::El5042States>(
         "state/el5042s", qos_profile);
 
@@ -667,7 +666,7 @@ void Fcat::InitializePublishersAndMessages()
   // ILD1900
   vec_state_ptrs = device_type_vec_map_[fastcat::ILD1900_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating Ild1900 pub");
+    RCLCPP_INFO(this->get_logger(), "Creating Ild1900 pub");
     ild1900_pub_ = this->create_publisher<fcat_msgs::msg::Ild1900States>(
       "state/ild1900s", qos_profile);
 
@@ -678,7 +677,7 @@ void Fcat::InitializePublishersAndMessages()
   // Commander
   vec_state_ptrs = device_type_vec_map_[fastcat::COMMANDER_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating Commander pub");
+    RCLCPP_INFO(this->get_logger(), "Creating Commander pub");
     commander_pub_ = this->create_publisher<fcat_msgs::msg::CommanderStates>(
       "state/commanders", qos_profile);
 
@@ -689,7 +688,7 @@ void Fcat::InitializePublishersAndMessages()
   // Conditional
   vec_state_ptrs = device_type_vec_map_[fastcat::CONDITIONAL_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating Conditional pub");
+    RCLCPP_INFO(this->get_logger(), "Creating Conditional pub");
     conditional_pub_ =
       this->create_publisher<fcat_msgs::msg::ConditionalStates>(
         "state/conditionals", qos_profile);
@@ -701,7 +700,7 @@ void Fcat::InitializePublishersAndMessages()
   // Faulter
   vec_state_ptrs = device_type_vec_map_[fastcat::FAULTER_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating Faulter pub");
+    RCLCPP_INFO(this->get_logger(), "Creating Faulter pub");
     faulter_pub_ = this->create_publisher<fcat_msgs::msg::FaulterStates>(
       "state/faulters", qos_profile);
 
@@ -712,7 +711,7 @@ void Fcat::InitializePublishersAndMessages()
   // Filter
   vec_state_ptrs = device_type_vec_map_[fastcat::FILTER_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating Filter pub");
+    RCLCPP_INFO(this->get_logger(), "Creating Filter pub");
     filter_pub_ = this->create_publisher<fcat_msgs::msg::FilterStates>(
       "state/filter", qos_profile);
 
@@ -723,7 +722,7 @@ void Fcat::InitializePublishersAndMessages()
   // Function
   vec_state_ptrs = device_type_vec_map_[fastcat::FUNCTION_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating Function pub");
+    RCLCPP_INFO(this->get_logger(), "Creating Function pub");
     function_pub_ = this->create_publisher<fcat_msgs::msg::FunctionStates>(
       "state/functions", qos_profile);
 
@@ -734,7 +733,7 @@ void Fcat::InitializePublishersAndMessages()
   // Pid
   vec_state_ptrs = device_type_vec_map_[fastcat::PID_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating Pid pub");
+    RCLCPP_INFO(this->get_logger(), "Creating Pid pub");
     pid_pub_ = this->create_publisher<fcat_msgs::msg::PidStates>(
       "state/pids", qos_profile);
 
@@ -745,7 +744,7 @@ void Fcat::InitializePublishersAndMessages()
   // Saturation
   vec_state_ptrs = device_type_vec_map_[fastcat::SATURATION_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating Saturation pub");
+    RCLCPP_INFO(this->get_logger(), "Creating Saturation pub");
     saturation_pub_ = this->create_publisher<fcat_msgs::msg::SaturationStates>(
       "state/saturations", qos_profile);
 
@@ -756,7 +755,7 @@ void Fcat::InitializePublishersAndMessages()
   // Schmitt Trigger
   vec_state_ptrs = device_type_vec_map_[fastcat::SCHMITT_TRIGGER_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating Schmitt Trigger pub");
+    RCLCPP_INFO(this->get_logger(), "Creating Schmitt Trigger pub");
     schmitt_trigger_pub_ =
       this->create_publisher<fcat_msgs::msg::SchmittTriggerStates>(
         "state/schmitt_triggers", qos_profile);
@@ -768,7 +767,7 @@ void Fcat::InitializePublishersAndMessages()
   // Signal Generator
   vec_state_ptrs = device_type_vec_map_[fastcat::SIGNAL_GENERATOR_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating Signal Generator pub");
+    RCLCPP_INFO(this->get_logger(), "Creating Signal Generator pub");
     signal_generator_pub_ =
       this->create_publisher<fcat_msgs::msg::SignalGeneratorStates>(
         "state/signal_generators", qos_profile);
@@ -780,7 +779,7 @@ void Fcat::InitializePublishersAndMessages()
   // Linear Interpolation
   vec_state_ptrs = device_type_vec_map_[fastcat::LINEAR_INTERPOLATION_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating LinearInterpolation pub");
+    RCLCPP_INFO(this->get_logger(), "Creating LinearInterpolation pub");
     linear_interpolation_pub_ =
       this->create_publisher<fcat_msgs::msg::LinearInterpolationStates>(
         "state/linear_interpolators", qos_profile);
@@ -793,7 +792,7 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs =
     device_type_vec_map_[fastcat::THREE_NODE_THERMAL_MODEL_STATE];
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating ThreeNodeThermalModel pub");
+    RCLCPP_INFO(this->get_logger(), "Creating ThreeNodeThermalModel pub");
     three_node_thermal_model_pub_ =
       this->create_publisher<fcat_msgs::msg::ThreeNodeThermalModelStates>(
         "state/three_node_thermal_models", qos_profile);
@@ -806,7 +805,7 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs = device_type_vec_map_[fastcat::FTS_STATE];
 
   if (vec_state_ptrs.size() > 0) {
-    EVR_ACTIVITY_LO("Creating FTS pub");
+    RCLCPP_INFO(this->get_logger(), "Creating FTS pub");
 
     fts_pub_ = this->create_publisher<fcat_msgs::msg::FtsStates>(
       "state/fts", qos_profile);
@@ -826,7 +825,7 @@ void Fcat::InitializePublishersAndMessages()
           this->create_publisher<geometry_msgs::msg::WrenchStamped>(
             "fts/" + device + "/tared_wrench", qos_profile);
 
-        EVR_ACTIVITY_LO("Creating ROS WrenchStamped Topics for %s",
+        RCLCPP_INFO(this->get_logger(), "Creating ROS WrenchStamped Topics for %s",
                         device.c_str());
       }
     }
@@ -1634,9 +1633,9 @@ void Fcat::SetCpuAffinity() {
 #ifdef _GNU_SOURCE
     if (gettid() != getpid()) {
       int cpus_available = get_nprocs_conf();
-      EVR_ACTIVITY_LO("This system has %d CPUs configured", cpus_available);
+      RCLCPP_INFO(this->get_logger(), "This system has %d CPUs configured", cpus_available);
       if (process_loop_cpu_id_ >= cpus_available) {
-        EVR_FATAL(
+        RCLCPP_FATAL(this->get_logger(),
           "User requested to pin Process() function to CPU ID %d, but "
           "only %d CPUs are available on this machine",
           process_loop_cpu_id_, cpus_available);
@@ -1646,22 +1645,22 @@ void Fcat::SetCpuAffinity() {
         CPU_ZERO(&affinity);
         CPU_SET(process_loop_cpu_id_, &affinity);
 
-        EVR_ACTIVITY_LO("Setting CPU affinity for thread ID: %d", gettid());
+        RCLCPP_INFO(this->get_logger(), "Setting CPU affinity for thread ID: %d", gettid());
         int result = sched_setaffinity(gettid(), sizeof(cpu_set_t), &affinity);
         if (result != 0) {
-          EVR_WARNING_HI(
+          RCLCPP_WARN(this->get_logger(),
             "Could not set process affinity to CPU %d for thread ID: %d, "
             "sched_setaffinity returned result: %d",
             process_loop_cpu_id_, gettid(), result);
         } else {
-          EVR_ACTIVITY_LO("Set CPU affinity to CPU %d for thread ID: %d",
+          RCLCPP_INFO(this->get_logger(), "Set CPU affinity to CPU %d for thread ID: %d",
                          process_loop_cpu_id_, gettid());
         }
         process_loop_thread_id_ = gettid();
       }
     }
 #else
-  EVR_WARNING_HI(
+  RCLCPP_WARN(this->get_logger(),
     "GNU extensions are not available on this machine/compiler; the Process() "
     "loop "
     "cannot be moved to CPU %d",
@@ -1680,7 +1679,7 @@ void Fcat::Process()
       cpu_affinity_initialized_) {
     double dt = now.seconds() - publish_time_stamp_.seconds();
     if (dt > 2.0 * loop_period_sec_) {
-      EVR_WARNING_LO(
+      RCLCPP_WARN(this->get_logger(),
         "Cycle slip detected; seconds since last Process() call: "
         "%f",
         dt);
@@ -1706,9 +1705,9 @@ void Fcat::Process()
       cpu_affinity_initialized_ = true;
     } else if (gettid() != getpid()) {
       int cpus_available = get_nprocs_conf();
-      EVR_ACTIVITY_LO("This system has %d CPUs configured", cpus_available);
+      RCLCPP_INFO(this->get_logger(), "This system has %d CPUs configured", cpus_available);
       if (process_loop_cpu_id_ >= cpus_available) {
-        EVR_FATAL(
+        RCLCPP_FATAL(this->get_logger(),
           "User requested to pin Process() function to CPU ID %d, but "
           "only %d CPUs are available on this machine",
           process_loop_cpu_id_, cpus_available);
@@ -1718,15 +1717,15 @@ void Fcat::Process()
         CPU_ZERO(&affinity);
         CPU_SET(process_loop_cpu_id_, &affinity);
 
-        EVR_ACTIVITY_LO("Process loop started in thread ID: %d", gettid());
+        RCLCPP_INFO(this->get_logger(), "Process loop started in thread ID: %d", gettid());
         int result = sched_setaffinity(gettid(), sizeof(cpu_set_t), &affinity);
         if (result != 0) {
-          EVR_WARNING_HI(
+          RCLCPP_WARN(this->get_logger(),
             "Could not set process affinity to CPU %d for thread ID: %d, "
             "sched_setaffinity returned result: %d",
             process_loop_cpu_id_, gettid(), result);
         } else {
-          EVR_ACTIVITY_LO("Set CPU affinity to CPU %d for thread ID: %d",
+          RCLCPP_INFO(this->get_logger(), "Set CPU affinity to CPU %d for thread ID: %d",
                          process_loop_cpu_id_, gettid());
         }
         process_loop_thread_id_ = gettid();
@@ -1735,7 +1734,7 @@ void Fcat::Process()
     }
   }
 #else
-  EVR_WARNING_HI(
+  RCLCPP_WARN(this->get_logger(),
     "GNU extensions are not available on this machine/compiler; the Process() "
     "loop cannot be moved to CPU %d",
     process_loop_thread_id_);
@@ -1744,7 +1743,7 @@ void Fcat::Process()
 
   if(!process_loop_realtime_preempt_initialized_) {
     if(enable_realtime_preempt_) {
-      EVR_ACTIVITY_HI("Setting realtime priority for process loop to %d", scheduler_priority_);
+      RCLCPP_INFO(this->get_logger(), "Setting realtime priority for process loop to %d", scheduler_priority_);
       SetRealtimePreempt(scheduler_priority_);
     }
     process_loop_realtime_preempt_initialized_ = true;
@@ -1792,13 +1791,13 @@ void Fcat::Process()
 
 void Fcat::PublishFcatModuleState()
 {
-  // Check for fault status and emit EVRs
+  // Check for fault status and emit logs
   bool is_faulted = fcat_manager_.IsFaulted();
   if (!module_state_msg_.faulted && is_faulted) {
     Fault();
-    EVR_WARNING_LO("Fastcat bus fault detected");
+    RCLCPP_WARN(this->get_logger(), "Fastcat bus fault detected");
   } else if (module_state_msg_.faulted && !is_faulted) {
-    EVR_ACTIVITY_HI("Fastcat bus fault cleared");
+    RCLCPP_INFO(this->get_logger(), "Fastcat bus fault cleared");
   }
 
   module_state_msg_.faulted = is_faulted;

--- a/src/fcat.cpp
+++ b/src/fcat.cpp
@@ -1,4 +1,6 @@
-#include "fcat/fcat.hpp"
+// Copyright 2021 California Institute of Technology
+
+#include "fcat.hpp"
 
 #include <sched.h>
 #include <sys/mman.h>
@@ -688,12 +690,12 @@ bool Fcat::DeviceExistsOnBus(const std::string& name, fastcat::DeviceStateType t
                              std::string& error_message) {
   char str[512];
   if (!(device_name_state_map_.end() != device_name_state_map_.find(name))) {
-    snprintf(str, 512, "Device %s does not exist on bus", name.c_str());
+    snprintf(str, sizeof(str), "Device %s does not exist on bus", name.c_str());
     error_message = str;
     return false;
   }
   if (device_name_state_map_[name]->type != type) {
-    snprintf(str, 512, "Device type does not match for %s", name.c_str());
+    snprintf(str, sizeof(str), "Device type does not match for %s", name.c_str());
     error_message = str;
     return false;
   }
@@ -703,7 +705,7 @@ bool Fcat::DeviceExistsOnBus(const std::string& name, fastcat::DeviceStateType t
 bool Fcat::DeviceExistsOnBus(const std::string& name, fastcat::DeviceStateType type) {
   std::string error_message;
   bool success = DeviceExistsOnBus(name, type, error_message);
-  if (not success) {
+  if (!success) {
     RCLCPP_WARN(this->get_logger(), "%s", error_message.c_str());
   }
   return success;
@@ -1314,7 +1316,6 @@ void Fcat::InitializeServices() {
     services_.push_back(this->create_service<fcat_msgs::srv::ActuatorCalibrateService>(
         "cmd/actuator_calibrate", std::bind(&Fcat::ActuatorCalibrateSrvCb, this, _1, _2),
         service_qos_));
-
   }  // end Actuator Service Declarations
 
   // Commander
@@ -1337,7 +1338,6 @@ void Fcat::InitializeServices() {
     services_.push_back(this->create_service<fcat_msgs::srv::El2124WriteChannelService>(
         "cmd/el2124_write_channel", std::bind(&Fcat::El2124WriteChannelSrvCb, this, _1, _2),
         service_qos_));
-
   }  // end El2124 Service Declarations
 
   // El2809
@@ -1349,7 +1349,6 @@ void Fcat::InitializeServices() {
     services_.push_back(this->create_service<fcat_msgs::srv::El2809WriteChannelService>(
         "cmd/el2809_write_channel", std::bind(&Fcat::El2809WriteChannelSrvCb, this, _1, _2),
         service_qos_));
-
   }  // end El2809 Service Declarations
 
   // El2798
@@ -1361,7 +1360,6 @@ void Fcat::InitializeServices() {
     services_.push_back(this->create_service<fcat_msgs::srv::El2798WriteChannelService>(
         "cmd/el2798_write_channel", std::bind(&Fcat::El2798WriteChannelSrvCb, this, _1, _2),
         service_qos_));
-
   }  // end El2798 Service Declarations
 
   // El2828
@@ -1373,7 +1371,6 @@ void Fcat::InitializeServices() {
     services_.push_back(this->create_service<fcat_msgs::srv::El2828WriteChannelService>(
         "cmd/el2828_write_channel", std::bind(&Fcat::El2828WriteChannelSrvCb, this, _1, _2),
         service_qos_));
-
   }  // end El2828 Service Declarations
 
   // El4102
@@ -1385,28 +1382,24 @@ void Fcat::InitializeServices() {
     services_.push_back(this->create_service<fcat_msgs::srv::El4102WriteChannelService>(
         "cmd/el4102_write_channel", std::bind(&Fcat::El4102WriteChannelSrvCb, this, _1, _2),
         service_qos_));
-
   }  // end El4102 Service Declarations
 
   // Faulter
   if (TypeExistsOnBus(fastcat::FAULTER_STATE)) {
     services_.push_back(this->create_service<fcat_msgs::srv::FaulterEnableService>(
         "cmd/faulter_enable", std::bind(&Fcat::FaulterEnableSrvCb, this, _1, _2), service_qos_));
-
   }  // end Faulter Service Declarations
 
   // FTS
   if (TypeExistsOnBus(fastcat::FTS_STATE)) {
     services_.push_back(this->create_service<fcat_msgs::srv::DeviceTriggerService>(
         "cmd/fts_tare", std::bind(&Fcat::FtsTareSrvCb, this, _1, _2), service_qos_));
-
   }  // end FTS Service Declarations
 
   // PID
   if (TypeExistsOnBus(fastcat::PID_STATE)) {
     services_.push_back(this->create_service<fcat_msgs::srv::PidActivateService>(
         "cmd/pid_activate", std::bind(&Fcat::PidActivateSrvCb, this, _1, _2), service_qos_));
-
   }  // end PID Service Declarations
 }
 

--- a/src/fcat.cpp
+++ b/src/fcat.cpp
@@ -11,6 +11,7 @@
 #include <sys/mman.h>
 
 #include <chrono>
+#include <cstdio>
 #include <limits>
 
 using namespace std::chrono_literals;
@@ -22,7 +23,6 @@ Fcat::~Fcat() { fcat_manager_.Shutdown(); }
 
 Fcat::Fcat(const rclcpp::NodeOptions& options)
     : casah_node::BaseInterface("fcat", "fcat", options),
-      casah_node::FaultInterface("fcat", "fcat", options),
       service_qos_(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_services_default), rmw_qos_profile_services_default)
 {
   process_loop_callback_group_ =
@@ -1609,7 +1609,7 @@ void Fcat::SetCpuAffinity() {
 
 void Fcat::Process()
 {
-  CFW_TRACE("Handling Process() loop");
+  fprintf(stderr, "Handling Process() loop\n");
   auto now = this->get_clock()->now();
 
   bool report_cycle_slips = this->get_parameter("report_cycle_slips").as_bool();
@@ -1774,7 +1774,7 @@ void Fcat::PublishAsyncSdoResponse()
     msg.data = jsd_sdo_data_to_string(sdo_resp.response.data_type,
                                       sdo_resp.response.data);
 
-    CFW_TRACE("Publishing new AsyncSdoResponse");
+    fprintf(stderr, "Publishing new AsyncSdoResponse\n");
 
     async_sdo_response_pub_->publish(msg);
   }

--- a/src/fcat.cpp
+++ b/src/fcat.cpp
@@ -1,5 +1,8 @@
 #include "fcat/fcat.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "rcl_interfaces/msg/floating_point_range.hpp"
+#include "rcl_interfaces/msg/integer_range.hpp"
+#include "rcl_interfaces/msg/parameter_descriptor.hpp"
 
 #include <sched.h>
 #include <sys/sysinfo.h>
@@ -8,6 +11,7 @@
 #include <sys/mman.h>
 
 #include <chrono>
+#include <limits>
 
 using namespace std::chrono_literals;
 using std::placeholders::_1;
@@ -27,10 +31,16 @@ Fcat::Fcat(const rclcpp::NodeOptions& options)
   topic_callback_group_ =
     this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 
-  std::string fastcat_config_path = DeclareInitParameterString(
-    "fastcat_config_path",
-    "",  // must be passed, cannot generally reason about this file path
-    "Location of the the fastcat topology YAML file");
+  std::string fastcat_config_path;
+  {
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.description = "Location of the the fastcat topology YAML file";
+    descriptor.read_only = true;
+    fastcat_config_path = this->declare_parameter<std::string>(
+      "fastcat_config_path",
+      "",  // must be passed, cannot generally reason about this file path
+      descriptor);
+  }
 
   RCLCPP_INFO(this->get_logger(), "loading Yaml from %s", fastcat_config_path.c_str());
   YAML::Node node = YAML::LoadFile(fastcat_config_path);
@@ -48,100 +58,176 @@ Fcat::Fcat(const rclcpp::NodeOptions& options)
   fcat_manager_.GetDeviceNamesByType(platinum_actuator_names,
                                      fastcat::PLATINUM_ACTUATOR_STATE);
 
-  DeclareInitParameterInt("fastcat_actuator_count",
-                          static_cast<int>(gold_actuator_names.size() +
-                                           platinum_actuator_names.size()),
-                          "Total number of fastcat actuators", 0, -1, true);
+  {
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.description = "Total number of fastcat actuators";
+    descriptor.read_only = true;
+    rcl_interfaces::msg::IntegerRange range;
+    range.from_value = 0;
+    range.to_value = std::numeric_limits<int64_t>::max();
+    range.step = 1;
+    descriptor.integer_range.push_back(range);
+    this->declare_parameter<int64_t>(
+      "fastcat_actuator_count",
+      static_cast<int64_t>(
+        gold_actuator_names.size() + platinum_actuator_names.size()),
+      descriptor, true);
+  }
 
   int i = 0;
   InitializeActuatorParams(gold_actuator_names, i);
   InitializeActuatorParams(platinum_actuator_names, i);
 
   use_sim_time_ = this->get_parameter("use_sim_time").as_bool();
-  enable_js_pub_ = DeclareInitParameterBool(
-    "create_joint_state_pub", true,
-    "If true, FCAT creates and publishes the \"/joint_states\" topic");
+  {
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.description =
+      "If true, FCAT creates and publishes the \"/joint_states\" topic";
+    descriptor.read_only = true;
+    enable_js_pub_ = this->declare_parameter<bool>(
+      "create_joint_state_pub", true, descriptor);
+  }
 
-  enable_ros_wrench_pub_ = DeclareInitParameterBool(
-    "create_ros_wrench_pub", true,
-    "If true, FCAT creates and publishes individual topics for FTS devices");
+  {
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.description =
+      "If true, FCAT creates and publishes individual topics for FTS devices";
+    descriptor.read_only = true;
+    enable_ros_wrench_pub_ = this->declare_parameter<bool>(
+      "create_ros_wrench_pub", true, descriptor);
+  }
 
-  process_loop_cpu_id_ = DeclareInitParameterInt(
-    "process_loop_cpu_id", 0,
-    "Set the CPU ID for the main Process() thread; this settings should be "
-    "used in conjunction with setting the kernel parameter 'isolcpus=0', so "
-    "that the Process() thread is the only process running on CPU0; set to -1 "
-    "to disable CPU pinning; it is expected that most applications will use "
-    "either 0 or -1, but there may be exceptional cases where it is necessary "
-    "to pin to a different CPU core; fcat will throw a fatal error if you "
-    "attempt "
-    "to pin to a CPU core value greater than the number of cores available "
-    "(default: 0)",
-    -1, 128);
+  {
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.description =
+      "Set the CPU ID for the main Process() thread; this settings should be "
+      "used in conjunction with setting the kernel parameter 'isolcpus=0', so "
+      "that the Process() thread is the only process running on CPU0; set to -1 "
+      "to disable CPU pinning; it is expected that most applications will use "
+      "either 0 or -1, but there may be exceptional cases where it is necessary "
+      "to pin to a different CPU core; fcat will throw a fatal error if you "
+      "attempt "
+      "to pin to a CPU core value greater than the number of cores available "
+      "(default: 0)";
+    descriptor.read_only = true;
+    rcl_interfaces::msg::IntegerRange range;
+    range.from_value = -1;
+    range.to_value = 128;
+    range.step = 1;
+    descriptor.integer_range.push_back(range);
+    process_loop_cpu_id_ = static_cast<int>(this->declare_parameter<int64_t>(
+      "process_loop_cpu_id", 0, descriptor));
+  }
 
-  enable_realtime_preempt_ = DeclareInitParameterBool(
-    "enable_realtime_preempt", enable_realtime_preempt_,
-    "If true, FCAT's ethercat thread will use the FIFO scheduler, allowing it to "
-    "preempt the kernel. This setting requires the realtime kernel");
+  {
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.description =
+      "If true, FCAT's ethercat thread will use the FIFO scheduler, allowing "
+      "it to preempt the kernel. This setting requires the realtime kernel";
+    descriptor.read_only = true;
+    enable_realtime_preempt_ = this->declare_parameter<bool>(
+      "enable_realtime_preempt", enable_realtime_preempt_, descriptor);
+  }
 
-  scheduler_priority_ = DeclareInitParameterInt(
-    "scheduler_priority", scheduler_priority_,
-    "Set real-time scheduler priority level, only used if 'enable_realtime_preempt' "
-    "parameter is set to 'true', which requires the realtime kernel. Note that this "
-    "value is used to set the 'rt_priority' real-time priority setting which is "
-    "different from a processes 'niceness' setting. 'rt_priority' ranges from 1 to 99 "
-    "with 99 being the highest priority (default: 49), ", 1, 99);
+  {
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.description =
+      "Set real-time scheduler priority level, only used if "
+      "'enable_realtime_preempt' "
+      "parameter is set to 'true', which requires the realtime kernel. Note "
+      "that this value is used to set the 'rt_priority' real-time priority "
+      "setting which is different from a processes 'niceness' setting. "
+      "'rt_priority' ranges from 1 to 99 with 99 being the highest priority "
+      "(default: 49), ";
+    descriptor.read_only = true;
+    rcl_interfaces::msg::IntegerRange range;
+    range.from_value = 1;
+    range.to_value = 99;
+    range.step = 1;
+    descriptor.integer_range.push_back(range);
+    scheduler_priority_ = static_cast<int>(this->declare_parameter<int64_t>(
+      "scheduler_priority", scheduler_priority_, descriptor));
+  }
 
-  fault_on_cycle_slip_ = DeclareInitParameterBool(
-    "fault_on_cycle_slip", fault_on_cycle_slip_,
-    "Fault the ethercat bus if large cycle slips detected (default: true)");
+  {
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.description =
+      "Fault the ethercat bus if large cycle slips detected (default: true)";
+    descriptor.read_only = true;
+    fault_on_cycle_slip_ = this->declare_parameter<bool>(
+      "fault_on_cycle_slip", fault_on_cycle_slip_, descriptor);
+  }
 
-  cycle_slip_fault_magnitude_ = DeclareInitParameterDouble(
-    "cycle_slip_fault_magnitude", cycle_slip_fault_magnitude_,
-    "Fault if cycle slip is greater than a multiple of the the nominal process loop "
-    "period (default: 3.0)");
+  {
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.description =
+      "Fault if cycle slip is greater than a multiple of the the nominal "
+      "process loop period (default: 3.0)";
+    descriptor.read_only = true;
+    cycle_slip_fault_magnitude_ = this->declare_parameter<double>(
+      "cycle_slip_fault_magnitude", cycle_slip_fault_magnitude_, descriptor);
+  }
 
-  DeclareRuntimeParameterInt("csp_explicit_interpolation_cycles_delay", 3,
-                             "Delays the onset of a motion profile in explicit "
-                             "interpolation mode by a "
-                             "number of cycles of the calling module; if set "
-                             "to 3, then fcat will wait until "
-                             "4 messages csp messages accumulate in the buffer "
-                             "before initiating motion "
-                             "profile.",
-                             0, 10);
+  {
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.description =
+      "Delays the onset of a motion profile in explicit interpolation mode "
+      "by a number of cycles of the calling module; if set to 3, then fcat "
+      "will wait until 4 messages csp messages accumulate in the buffer "
+      "before initiating motion profile.";
+    rcl_interfaces::msg::IntegerRange range;
+    range.from_value = 0;
+    range.to_value = 10;
+    range.step = 1;
+    descriptor.integer_range.push_back(range);
+    this->declare_parameter<int64_t>(
+      "csp_explicit_interpolation_cycles_delay", 3, descriptor);
+  }
 
-  DeclareRuntimeParameterInt(
-    "csp_interpolation_cycles_stale", 10,
-    "When fastcat is in CSP interpolation mode, module will "
-    "transition to HOLDING state when it has not received a "
-    "new CSP setpoint within the number of internal loop "
-    "cycles configured by this parameter",
-    4, 40);
+  {
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.description =
+      "When fastcat is in CSP interpolation mode, module will transition to "
+      "HOLDING state when it has not received a new CSP setpoint within the "
+      "number of internal loop cycles configured by this parameter";
+    rcl_interfaces::msg::IntegerRange range;
+    range.from_value = 4;
+    range.to_value = 40;
+    range.step = 1;
+    descriptor.integer_range.push_back(range);
+    this->declare_parameter<int64_t>(
+      "csp_interpolation_cycles_stale", 10, descriptor);
+  }
 
-  DeclareRuntimeParameterString(
-    "csp_explicit_interpolation_algorithm", "cubic",
-    "Specify the algorithm used for explicit interpolation; "
-    "one of ['cubic', 'linear']: cubic interpolation is a third order "
-    "interpolation "
-    "of position and velocity with c2 continuity between csp set points; "
-    "linear interpolation linearly interpolates both position and "
-    "velocity between csp setpoints");
+  {
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.description =
+      "Specify the algorithm used for explicit interpolation; one of "
+      "['cubic', 'linear']: cubic interpolation is a third order "
+      "interpolation of position and velocity with c2 continuity between csp "
+      "set points; linear interpolation linearly interpolates both position "
+      "and velocity between csp setpoints";
+    this->declare_parameter<std::string>(
+      "csp_explicit_interpolation_algorithm", "cubic", descriptor);
+  }
 
-  DeclareRuntimeParameterString("csp_explicit_interpolation_timestamp_source",
-                                "csp_message",
-                                "Specify the source for the timestamp used for "
-                                "csp interpolation in explicit mode; "
-                                "If set to 'csp_message', fastcat uses the "
-                                "request_time from the csp message, "
-                                "if set to 'clock', fastcat uses the current "
-                                "clock on receipt of the message; "
-                                "['csp_message', 'clock']");
+  {
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.description =
+      "Specify the source for the timestamp used for csp interpolation in "
+      "explicit mode; If set to 'csp_message', fastcat uses the request_time "
+      "from the csp message, if set to 'clock', fastcat uses the current "
+      "clock on receipt of the message; ['csp_message', 'clock']";
+    this->declare_parameter<std::string>(
+      "csp_explicit_interpolation_timestamp_source", "csp_message",
+      descriptor);
+  }
 
-  DeclareRuntimeParameterBool(
-    "report_cycle_slips", true,
-    "If true, fcat emits logs to report timer "
-    "slips");
+  {
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.description = "If true, fcat emits logs to report timer slips";
+    this->declare_parameter<bool>("report_cycle_slips", true, descriptor);
+  }
 
   PopulateDeviceStateFields();
 
@@ -265,115 +351,361 @@ void Fcat::InitializeActuatorParams(
       std::string parameter_prefix =
         "fastcat_actuator_" + std::to_string(++i) + "_";
       std::string description_prefix = "Actuator " + std::to_string(i) + " ";
-      DeclareInitParameterString(parameter_prefix + "name", actuator_name,
-                                 description_prefix + "name", true);
-      DeclareInitParameterString(parameter_prefix + "actuator_type",
-                                 actuator_params.actuator_type_str,
-                                 description_prefix + "actuator type", true);
-      DeclareInitParameterDouble(
-        parameter_prefix + "gear_ratio", actuator_params.gear_ratio,
-        description_prefix + "gear ratio", 0.0, -1.0, true);
-      DeclareInitParameterDouble(
-        parameter_prefix + "counts_per_rev", actuator_params.counts_per_rev,
-        description_prefix + "counts per revolution", 0.0, -1.0, true);
-      DeclareInitParameterDouble(parameter_prefix + "max_speed_eu_per_sec",
-                                 actuator_params.max_speed_eu_per_sec,
-                                 description_prefix + "max speed [eu/sec]", 0.0,
-                                 -1.0, true);
-      DeclareInitParameterDouble(
-        parameter_prefix + "max_accel_eu_per_sec2",
-        actuator_params.max_accel_eu_per_sec2,
-        description_prefix + "max acceleration [eu/sec^2]", 0.0, -1.0, true);
-      DeclareInitParameterDouble(parameter_prefix + "over_speed_multiplier",
-                                 actuator_params.over_speed_multiplier,
-                                 description_prefix + "over speed multiplier",
-                                 0.0, -1.0, true);
-      DeclareInitParameterDouble(
-        parameter_prefix + "vel_tracking_error_eu_per_sec",
-        actuator_params.vel_tracking_error_eu_per_sec,
-        description_prefix + "velocity tracking error [eu/sec]", 0.0, -1.0,
-        true);
-      DeclareInitParameterDouble(
-        parameter_prefix + "pos_tracking_error_eu",
-        actuator_params.pos_tracking_error_eu,
-        description_prefix + "position tracking error [eu]", 0.0, -1.0, true);
-      DeclareInitParameterDouble(
-        parameter_prefix + "peak_current_limit_amps",
-        actuator_params.peak_current_limit_amps,
-        description_prefix + "peak current limit [amps]", 0.0, -1.0, true);
-      DeclareInitParameterDouble(parameter_prefix + "peak_current_time_sec",
-                                 actuator_params.peak_current_time_sec,
-                                 description_prefix + "peak current time [sec]",
-                                 0.0, -1.0, true);
-      DeclareInitParameterDouble(
-        parameter_prefix + "continuous_current_limit_amps",
-        actuator_params.continuous_current_limit_amps,
-        description_prefix + "continuous current limit [amps]", 0.0, -1.0,
-        true);
-      DeclareInitParameterDouble(parameter_prefix + "torque_slope_amps_per_sec",
-                                 actuator_params.torque_slope_amps_per_sec,
-                                 description_prefix + "torque slope [amps/sec]",
-                                 0.0, -1.0, true);
-      DeclareInitParameterDouble(
-        parameter_prefix + "low_pos_cal_limit_eu",
-        actuator_params.low_pos_cal_limit_eu,
-        description_prefix + "low position calibration limit [eu]", 0.0, -1.0,
-        true);
-      DeclareInitParameterDouble(
-        parameter_prefix + "low_pos_cmd_limit_eu",
-        actuator_params.low_pos_cmd_limit_eu,
-        description_prefix + "low position command limit [eu]", 0.0, -1.0,
-        true);
-      DeclareInitParameterDouble(
-        parameter_prefix + "high_pos_cal_limit_eu",
-        actuator_params.high_pos_cal_limit_eu,
-        description_prefix + "high position calibration limit [eu]", 0.0, -1.0,
-        true);
-      DeclareInitParameterDouble(
-        parameter_prefix + "high_pos_cmd_limit_eu",
-        actuator_params.high_pos_cmd_limit_eu,
-        description_prefix + "high position command limit [eu]", 0.0, -1.0,
-        true);
-      DeclareInitParameterDouble(parameter_prefix + "holding_duration_sec",
-                                 actuator_params.holding_duration_sec,
-                                 description_prefix + "holding duration [sec]",
-                                 0.0, -1.0, true);
-      DeclareInitParameterDouble(
-        parameter_prefix + "elmo_brake_engage_msec",
-        actuator_params.elmo_brake_engage_msec,
-        description_prefix + "brake engage time [msec]", 0.0, -1.0, true);
-      DeclareInitParameterDouble(
-        parameter_prefix + "elmo_brake_disengage_msec",
-        actuator_params.elmo_brake_disengage_msec,
-        description_prefix + "brake disengage time [msec]", 0.0, -1.0, true);
-      DeclareInitParameterDouble(
-        parameter_prefix + "elmo_crc", actuator_params.elmo_crc,
-        description_prefix + "crc value", 0.0, -1.0, true);
-      DeclareInitParameterDouble(
-        parameter_prefix + "elmo_drive_max_cur_limit_amps",
-        actuator_params.elmo_drive_max_cur_limit_amps,
-        description_prefix + "drive max current limit [amps]", 0.0, -1.0, true);
-      DeclareInitParameterDouble(
-        parameter_prefix + "smooth_factor", actuator_params.smooth_factor,
-        description_prefix + "smoothing factor", 0.0, -1.0, true);
-      DeclareInitParameterDouble(
-        parameter_prefix + "torque_constant", actuator_params.torque_constant,
-        description_prefix + "torque constant", 0.0, -1.0, true);
-      DeclareInitParameterDouble(parameter_prefix + "winding_resistance",
-                                 actuator_params.winding_resistance,
-                                 description_prefix + "winding resistance", 0.0,
-                                 -1.0, true);
-      DeclareInitParameterDouble(
-        parameter_prefix + "brake_power", actuator_params.brake_power,
-        description_prefix + "brake power", 0.0, -1.0, true);
-      DeclareInitParameterDouble(
-        parameter_prefix + "motor_encoder_gear_ratio",
-        actuator_params.motor_encoder_gear_ratio,
-        description_prefix + "motor encoder gear ratio", 0.0, -1.0, true);
-      DeclareInitParameterBool(parameter_prefix + "has_absolute_encoder",
-                               actuator_params.actuator_absolute_encoder,
-                               description_prefix + "has absolute encoder",
-                               true);
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description = description_prefix + "name";
+        descriptor.read_only = true;
+        this->declare_parameter<std::string>(
+          parameter_prefix + "name", actuator_name, descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description = description_prefix + "actuator type";
+        descriptor.read_only = true;
+        this->declare_parameter<std::string>(parameter_prefix + "actuator_type",
+                                             actuator_params.actuator_type_str,
+                                             descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description = description_prefix + "gear ratio";
+        descriptor.read_only = true;
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = 0.0;
+        range.to_value = std::numeric_limits<double>::max();
+        range.step = 0.0;
+        descriptor.floating_point_range.push_back(range);
+        this->declare_parameter<double>(
+          parameter_prefix + "gear_ratio", actuator_params.gear_ratio,
+          descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description = description_prefix + "counts per revolution";
+        descriptor.read_only = true;
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = 0.0;
+        range.to_value = std::numeric_limits<double>::max();
+        range.step = 0.0;
+        descriptor.floating_point_range.push_back(range);
+        this->declare_parameter<double>(
+          parameter_prefix + "counts_per_rev", actuator_params.counts_per_rev,
+          descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description = description_prefix + "max speed [eu/sec]";
+        descriptor.read_only = true;
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = 0.0;
+        range.to_value = std::numeric_limits<double>::max();
+        range.step = 0.0;
+        descriptor.floating_point_range.push_back(range);
+        this->declare_parameter<double>(
+          parameter_prefix + "max_speed_eu_per_sec",
+          actuator_params.max_speed_eu_per_sec, descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description = description_prefix + "max acceleration [eu/sec^2]";
+        descriptor.read_only = true;
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = 0.0;
+        range.to_value = std::numeric_limits<double>::max();
+        range.step = 0.0;
+        descriptor.floating_point_range.push_back(range);
+        this->declare_parameter<double>(
+          parameter_prefix + "max_accel_eu_per_sec2",
+          actuator_params.max_accel_eu_per_sec2, descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description = description_prefix + "over speed multiplier";
+        descriptor.read_only = true;
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = 0.0;
+        range.to_value = std::numeric_limits<double>::max();
+        range.step = 0.0;
+        descriptor.floating_point_range.push_back(range);
+        this->declare_parameter<double>(
+          parameter_prefix + "over_speed_multiplier",
+          actuator_params.over_speed_multiplier, descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description =
+          description_prefix + "velocity tracking error [eu/sec]";
+        descriptor.read_only = true;
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = 0.0;
+        range.to_value = std::numeric_limits<double>::max();
+        range.step = 0.0;
+        descriptor.floating_point_range.push_back(range);
+        this->declare_parameter<double>(
+          parameter_prefix + "vel_tracking_error_eu_per_sec",
+          actuator_params.vel_tracking_error_eu_per_sec, descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description = description_prefix + "position tracking error [eu]";
+        descriptor.read_only = true;
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = 0.0;
+        range.to_value = std::numeric_limits<double>::max();
+        range.step = 0.0;
+        descriptor.floating_point_range.push_back(range);
+        this->declare_parameter<double>(
+          parameter_prefix + "pos_tracking_error_eu",
+          actuator_params.pos_tracking_error_eu, descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description = description_prefix + "peak current limit [amps]";
+        descriptor.read_only = true;
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = 0.0;
+        range.to_value = std::numeric_limits<double>::max();
+        range.step = 0.0;
+        descriptor.floating_point_range.push_back(range);
+        this->declare_parameter<double>(
+          parameter_prefix + "peak_current_limit_amps",
+          actuator_params.peak_current_limit_amps, descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description = description_prefix + "peak current time [sec]";
+        descriptor.read_only = true;
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = 0.0;
+        range.to_value = std::numeric_limits<double>::max();
+        range.step = 0.0;
+        descriptor.floating_point_range.push_back(range);
+        this->declare_parameter<double>(
+          parameter_prefix + "peak_current_time_sec",
+          actuator_params.peak_current_time_sec, descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description =
+          description_prefix + "continuous current limit [amps]";
+        descriptor.read_only = true;
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = 0.0;
+        range.to_value = std::numeric_limits<double>::max();
+        range.step = 0.0;
+        descriptor.floating_point_range.push_back(range);
+        this->declare_parameter<double>(
+          parameter_prefix + "continuous_current_limit_amps",
+          actuator_params.continuous_current_limit_amps, descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description = description_prefix + "torque slope [amps/sec]";
+        descriptor.read_only = true;
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = 0.0;
+        range.to_value = std::numeric_limits<double>::max();
+        range.step = 0.0;
+        descriptor.floating_point_range.push_back(range);
+        this->declare_parameter<double>(
+          parameter_prefix + "torque_slope_amps_per_sec",
+          actuator_params.torque_slope_amps_per_sec, descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description =
+          description_prefix + "low position calibration limit [eu]";
+        descriptor.read_only = true;
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = 0.0;
+        range.to_value = std::numeric_limits<double>::max();
+        range.step = 0.0;
+        descriptor.floating_point_range.push_back(range);
+        this->declare_parameter<double>(
+          parameter_prefix + "low_pos_cal_limit_eu",
+          actuator_params.low_pos_cal_limit_eu, descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description =
+          description_prefix + "low position command limit [eu]";
+        descriptor.read_only = true;
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = 0.0;
+        range.to_value = std::numeric_limits<double>::max();
+        range.step = 0.0;
+        descriptor.floating_point_range.push_back(range);
+        this->declare_parameter<double>(
+          parameter_prefix + "low_pos_cmd_limit_eu",
+          actuator_params.low_pos_cmd_limit_eu, descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description =
+          description_prefix + "high position calibration limit [eu]";
+        descriptor.read_only = true;
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = 0.0;
+        range.to_value = std::numeric_limits<double>::max();
+        range.step = 0.0;
+        descriptor.floating_point_range.push_back(range);
+        this->declare_parameter<double>(
+          parameter_prefix + "high_pos_cal_limit_eu",
+          actuator_params.high_pos_cal_limit_eu, descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description =
+          description_prefix + "high position command limit [eu]";
+        descriptor.read_only = true;
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = 0.0;
+        range.to_value = std::numeric_limits<double>::max();
+        range.step = 0.0;
+        descriptor.floating_point_range.push_back(range);
+        this->declare_parameter<double>(
+          parameter_prefix + "high_pos_cmd_limit_eu",
+          actuator_params.high_pos_cmd_limit_eu, descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description = description_prefix + "holding duration [sec]";
+        descriptor.read_only = true;
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = 0.0;
+        range.to_value = std::numeric_limits<double>::max();
+        range.step = 0.0;
+        descriptor.floating_point_range.push_back(range);
+        this->declare_parameter<double>(
+          parameter_prefix + "holding_duration_sec",
+          actuator_params.holding_duration_sec, descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description = description_prefix + "brake engage time [msec]";
+        descriptor.read_only = true;
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = 0.0;
+        range.to_value = std::numeric_limits<double>::max();
+        range.step = 0.0;
+        descriptor.floating_point_range.push_back(range);
+        this->declare_parameter<double>(
+          parameter_prefix + "elmo_brake_engage_msec",
+          actuator_params.elmo_brake_engage_msec, descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description = description_prefix + "brake disengage time [msec]";
+        descriptor.read_only = true;
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = 0.0;
+        range.to_value = std::numeric_limits<double>::max();
+        range.step = 0.0;
+        descriptor.floating_point_range.push_back(range);
+        this->declare_parameter<double>(
+          parameter_prefix + "elmo_brake_disengage_msec",
+          actuator_params.elmo_brake_disengage_msec, descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description = description_prefix + "crc value";
+        descriptor.read_only = true;
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = 0.0;
+        range.to_value = std::numeric_limits<double>::max();
+        range.step = 0.0;
+        descriptor.floating_point_range.push_back(range);
+        this->declare_parameter<double>(
+          parameter_prefix + "elmo_crc", actuator_params.elmo_crc,
+          descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description =
+          description_prefix + "drive max current limit [amps]";
+        descriptor.read_only = true;
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = 0.0;
+        range.to_value = std::numeric_limits<double>::max();
+        range.step = 0.0;
+        descriptor.floating_point_range.push_back(range);
+        this->declare_parameter<double>(
+          parameter_prefix + "elmo_drive_max_cur_limit_amps",
+          actuator_params.elmo_drive_max_cur_limit_amps, descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description = description_prefix + "smoothing factor";
+        descriptor.read_only = true;
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = 0.0;
+        range.to_value = std::numeric_limits<double>::max();
+        range.step = 0.0;
+        descriptor.floating_point_range.push_back(range);
+        this->declare_parameter<double>(
+          parameter_prefix + "smooth_factor", actuator_params.smooth_factor,
+          descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description = description_prefix + "torque constant";
+        descriptor.read_only = true;
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = 0.0;
+        range.to_value = std::numeric_limits<double>::max();
+        range.step = 0.0;
+        descriptor.floating_point_range.push_back(range);
+        this->declare_parameter<double>(
+          parameter_prefix + "torque_constant",
+          actuator_params.torque_constant, descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description = description_prefix + "winding resistance";
+        descriptor.read_only = true;
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = 0.0;
+        range.to_value = std::numeric_limits<double>::max();
+        range.step = 0.0;
+        descriptor.floating_point_range.push_back(range);
+        this->declare_parameter<double>(
+          parameter_prefix + "winding_resistance",
+          actuator_params.winding_resistance, descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description = description_prefix + "brake power";
+        descriptor.read_only = true;
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = 0.0;
+        range.to_value = std::numeric_limits<double>::max();
+        range.step = 0.0;
+        descriptor.floating_point_range.push_back(range);
+        this->declare_parameter<double>(
+          parameter_prefix + "brake_power", actuator_params.brake_power,
+          descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description = description_prefix + "motor encoder gear ratio";
+        descriptor.read_only = true;
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = 0.0;
+        range.to_value = std::numeric_limits<double>::max();
+        range.step = 0.0;
+        descriptor.floating_point_range.push_back(range);
+        this->declare_parameter<double>(
+          parameter_prefix + "motor_encoder_gear_ratio",
+          actuator_params.motor_encoder_gear_ratio, descriptor, true);
+      }
+      {
+        rcl_interfaces::msg::ParameterDescriptor descriptor;
+        descriptor.description = description_prefix + "has absolute encoder";
+        descriptor.read_only = true;
+        this->declare_parameter<bool>(
+          parameter_prefix + "has_absolute_encoder",
+          actuator_params.actuator_absolute_encoder, descriptor, true);
+      }
     }
   }
 }

--- a/src/fcat.cpp
+++ b/src/fcat.cpp
@@ -1,35 +1,34 @@
 #include "fcat/fcat.hpp"
-#include "rclcpp/rclcpp.hpp"
-#include "rcl_interfaces/msg/floating_point_range.hpp"
-#include "rcl_interfaces/msg/integer_range.hpp"
-#include "rcl_interfaces/msg/parameter_descriptor.hpp"
 
 #include <sched.h>
+#include <sys/mman.h>
 #include <sys/sysinfo.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <sys/mman.h>
 
 #include <chrono>
 #include <cstdio>
 #include <limits>
 
+#include "rcl_interfaces/msg/floating_point_range.hpp"
+#include "rcl_interfaces/msg/integer_range.hpp"
+#include "rcl_interfaces/msg/parameter_descriptor.hpp"
+#include "rclcpp/rclcpp.hpp"
+
 using namespace std::chrono_literals;
 using std::placeholders::_1;
 using std::placeholders::_2;
-
 
 Fcat::~Fcat() { fcat_manager_.Shutdown(); }
 
 Fcat::Fcat(const rclcpp::NodeOptions& options)
     : FcatNode("fcat", "fcat", options),
-      service_qos_(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_services_default), rmw_qos_profile_services_default)
-{
+      service_qos_(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_services_default),
+                   rmw_qos_profile_services_default) {
   process_loop_callback_group_ =
-    this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+      this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 
-  topic_callback_group_ =
-    this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  topic_callback_group_ = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 
   SetTimerCallbackGroup(process_loop_callback_group_);
 
@@ -39,26 +38,23 @@ Fcat::Fcat(const rclcpp::NodeOptions& options)
     descriptor.description = "Location of the the fastcat topology YAML file";
     descriptor.read_only = true;
     fastcat_config_path = this->declare_parameter<std::string>(
-      "fastcat_config_path",
-      "",  // must be passed, cannot generally reason about this file path
-      descriptor);
+        "fastcat_config_path",
+        "",  // must be passed, cannot generally reason about this file path
+        descriptor);
   }
 
   RCLCPP_INFO(this->get_logger(), "loading Yaml from %s", fastcat_config_path.c_str());
   YAML::Node node = YAML::LoadFile(fastcat_config_path);
 
   if (!fcat_manager_.ConfigFromYaml(node)) {
-    throw std::invalid_argument(
-      "Fastcat Manager failed to process bus configuration YAML file.");
+    throw std::invalid_argument("Fastcat Manager failed to process bus configuration YAML file.");
   }
 
   std::vector<std::string> gold_actuator_names;
-  fcat_manager_.GetDeviceNamesByType(gold_actuator_names,
-                                     fastcat::GOLD_ACTUATOR_STATE);
+  fcat_manager_.GetDeviceNamesByType(gold_actuator_names, fastcat::GOLD_ACTUATOR_STATE);
 
   std::vector<std::string> platinum_actuator_names;
-  fcat_manager_.GetDeviceNamesByType(platinum_actuator_names,
-                                     fastcat::PLATINUM_ACTUATOR_STATE);
+  fcat_manager_.GetDeviceNamesByType(platinum_actuator_names, fastcat::PLATINUM_ACTUATOR_STATE);
 
   {
     rcl_interfaces::msg::ParameterDescriptor descriptor;
@@ -70,10 +66,9 @@ Fcat::Fcat(const rclcpp::NodeOptions& options)
     range.step = 1;
     descriptor.integer_range.push_back(range);
     this->declare_parameter<int64_t>(
-      "fastcat_actuator_count",
-      static_cast<int64_t>(
-        gold_actuator_names.size() + platinum_actuator_names.size()),
-      descriptor, true);
+        "fastcat_actuator_count",
+        static_cast<int64_t>(gold_actuator_names.size() + platinum_actuator_names.size()),
+        descriptor, true);
   }
 
   int i = 0;
@@ -83,146 +78,140 @@ Fcat::Fcat(const rclcpp::NodeOptions& options)
   use_sim_time_ = this->get_parameter("use_sim_time").as_bool();
   {
     rcl_interfaces::msg::ParameterDescriptor descriptor;
-    descriptor.description =
-      "If true, FCAT creates and publishes the \"/joint_states\" topic";
+    descriptor.description = "If true, FCAT creates and publishes the \"/joint_states\" topic";
     descriptor.read_only = true;
-    enable_js_pub_ = this->declare_parameter<bool>(
-      "create_joint_state_pub", true, descriptor);
+    enable_js_pub_ = this->declare_parameter<bool>("create_joint_state_pub", true, descriptor);
   }
 
   {
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description =
-      "If true, FCAT creates and publishes individual topics for FTS devices";
+        "If true, FCAT creates and publishes individual topics for FTS devices";
     descriptor.read_only = true;
-    enable_ros_wrench_pub_ = this->declare_parameter<bool>(
-      "create_ros_wrench_pub", true, descriptor);
+    enable_ros_wrench_pub_ =
+        this->declare_parameter<bool>("create_ros_wrench_pub", true, descriptor);
   }
 
   {
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description =
-      "Set the CPU ID for the main Process() thread; this settings should be "
-      "used in conjunction with setting the kernel parameter 'isolcpus=0', so "
-      "that the Process() thread is the only process running on CPU0; set to -1 "
-      "to disable CPU pinning; it is expected that most applications will use "
-      "either 0 or -1, but there may be exceptional cases where it is necessary "
-      "to pin to a different CPU core; fcat will throw a fatal error if you "
-      "attempt "
-      "to pin to a CPU core value greater than the number of cores available "
-      "(default: 0)";
+        "Set the CPU ID for the main Process() thread; this settings should be "
+        "used in conjunction with setting the kernel parameter 'isolcpus=0', so "
+        "that the Process() thread is the only process running on CPU0; set to -1 "
+        "to disable CPU pinning; it is expected that most applications will use "
+        "either 0 or -1, but there may be exceptional cases where it is necessary "
+        "to pin to a different CPU core; fcat will throw a fatal error if you "
+        "attempt "
+        "to pin to a CPU core value greater than the number of cores available "
+        "(default: 0)";
     descriptor.read_only = true;
     rcl_interfaces::msg::IntegerRange range;
     range.from_value = -1;
     range.to_value = 128;
     range.step = 1;
     descriptor.integer_range.push_back(range);
-    process_loop_cpu_id_ = static_cast<int>(this->declare_parameter<int64_t>(
-      "process_loop_cpu_id", 0, descriptor));
+    process_loop_cpu_id_ =
+        static_cast<int>(this->declare_parameter<int64_t>("process_loop_cpu_id", 0, descriptor));
   }
 
   {
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description =
-      "If true, FCAT's ethercat thread will use the FIFO scheduler, allowing "
-      "it to preempt the kernel. This setting requires the realtime kernel";
+        "If true, FCAT's ethercat thread will use the FIFO scheduler, allowing "
+        "it to preempt the kernel. This setting requires the realtime kernel";
     descriptor.read_only = true;
-    enable_realtime_preempt_ = this->declare_parameter<bool>(
-      "enable_realtime_preempt", enable_realtime_preempt_, descriptor);
+    enable_realtime_preempt_ = this->declare_parameter<bool>("enable_realtime_preempt",
+                                                             enable_realtime_preempt_, descriptor);
   }
 
   {
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description =
-      "Set real-time scheduler priority level, only used if "
-      "'enable_realtime_preempt' "
-      "parameter is set to 'true', which requires the realtime kernel. Note "
-      "that this value is used to set the 'rt_priority' real-time priority "
-      "setting which is different from a processes 'niceness' setting. "
-      "'rt_priority' ranges from 1 to 99 with 99 being the highest priority "
-      "(default: 49), ";
+        "Set real-time scheduler priority level, only used if "
+        "'enable_realtime_preempt' "
+        "parameter is set to 'true', which requires the realtime kernel. Note "
+        "that this value is used to set the 'rt_priority' real-time priority "
+        "setting which is different from a processes 'niceness' setting. "
+        "'rt_priority' ranges from 1 to 99 with 99 being the highest priority "
+        "(default: 49), ";
     descriptor.read_only = true;
     rcl_interfaces::msg::IntegerRange range;
     range.from_value = 1;
     range.to_value = 99;
     range.step = 1;
     descriptor.integer_range.push_back(range);
-    scheduler_priority_ = static_cast<int>(this->declare_parameter<int64_t>(
-      "scheduler_priority", scheduler_priority_, descriptor));
+    scheduler_priority_ = static_cast<int>(
+        this->declare_parameter<int64_t>("scheduler_priority", scheduler_priority_, descriptor));
   }
 
   {
     rcl_interfaces::msg::ParameterDescriptor descriptor;
-    descriptor.description =
-      "Fault the ethercat bus if large cycle slips detected (default: true)";
+    descriptor.description = "Fault the ethercat bus if large cycle slips detected (default: true)";
     descriptor.read_only = true;
-    fault_on_cycle_slip_ = this->declare_parameter<bool>(
-      "fault_on_cycle_slip", fault_on_cycle_slip_, descriptor);
+    fault_on_cycle_slip_ =
+        this->declare_parameter<bool>("fault_on_cycle_slip", fault_on_cycle_slip_, descriptor);
   }
 
   {
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description =
-      "Fault if cycle slip is greater than a multiple of the the nominal "
-      "process loop period (default: 3.0)";
+        "Fault if cycle slip is greater than a multiple of the the nominal "
+        "process loop period (default: 3.0)";
     descriptor.read_only = true;
     cycle_slip_fault_magnitude_ = this->declare_parameter<double>(
-      "cycle_slip_fault_magnitude", cycle_slip_fault_magnitude_, descriptor);
+        "cycle_slip_fault_magnitude", cycle_slip_fault_magnitude_, descriptor);
   }
 
   {
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description =
-      "Delays the onset of a motion profile in explicit interpolation mode "
-      "by a number of cycles of the calling module; if set to 3, then fcat "
-      "will wait until 4 messages csp messages accumulate in the buffer "
-      "before initiating motion profile.";
+        "Delays the onset of a motion profile in explicit interpolation mode "
+        "by a number of cycles of the calling module; if set to 3, then fcat "
+        "will wait until 4 messages csp messages accumulate in the buffer "
+        "before initiating motion profile.";
     rcl_interfaces::msg::IntegerRange range;
     range.from_value = 0;
     range.to_value = 10;
     range.step = 1;
     descriptor.integer_range.push_back(range);
-    this->declare_parameter<int64_t>(
-      "csp_explicit_interpolation_cycles_delay", 3, descriptor);
+    this->declare_parameter<int64_t>("csp_explicit_interpolation_cycles_delay", 3, descriptor);
   }
 
   {
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description =
-      "When fastcat is in CSP interpolation mode, module will transition to "
-      "HOLDING state when it has not received a new CSP setpoint within the "
-      "number of internal loop cycles configured by this parameter";
+        "When fastcat is in CSP interpolation mode, module will transition to "
+        "HOLDING state when it has not received a new CSP setpoint within the "
+        "number of internal loop cycles configured by this parameter";
     rcl_interfaces::msg::IntegerRange range;
     range.from_value = 4;
     range.to_value = 40;
     range.step = 1;
     descriptor.integer_range.push_back(range);
-    this->declare_parameter<int64_t>(
-      "csp_interpolation_cycles_stale", 10, descriptor);
+    this->declare_parameter<int64_t>("csp_interpolation_cycles_stale", 10, descriptor);
   }
 
   {
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description =
-      "Specify the algorithm used for explicit interpolation; one of "
-      "['cubic', 'linear']: cubic interpolation is a third order "
-      "interpolation of position and velocity with c2 continuity between csp "
-      "set points; linear interpolation linearly interpolates both position "
-      "and velocity between csp setpoints";
-    this->declare_parameter<std::string>(
-      "csp_explicit_interpolation_algorithm", "cubic", descriptor);
+        "Specify the algorithm used for explicit interpolation; one of "
+        "['cubic', 'linear']: cubic interpolation is a third order "
+        "interpolation of position and velocity with c2 continuity between csp "
+        "set points; linear interpolation linearly interpolates both position "
+        "and velocity between csp setpoints";
+    this->declare_parameter<std::string>("csp_explicit_interpolation_algorithm", "cubic",
+                                         descriptor);
   }
 
   {
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description =
-      "Specify the source for the timestamp used for csp interpolation in "
-      "explicit mode; If set to 'csp_message', fastcat uses the request_time "
-      "from the csp message, if set to 'clock', fastcat uses the current "
-      "clock on receipt of the message; ['csp_message', 'clock']";
-    this->declare_parameter<std::string>(
-      "csp_explicit_interpolation_timestamp_source", "csp_message",
-      descriptor);
+        "Specify the source for the timestamp used for csp interpolation in "
+        "explicit mode; If set to 'csp_message', fastcat uses the request_time "
+        "from the csp message, if set to 'clock', fastcat uses the current "
+        "clock on receipt of the message; ['csp_message', 'clock']";
+    this->declare_parameter<std::string>("csp_explicit_interpolation_timestamp_source",
+                                         "csp_message", descriptor);
   }
 
   {
@@ -238,13 +227,13 @@ Fcat::Fcat(const rclcpp::NodeOptions& options)
   InitializeSubscribers();
   InitializeServices();
 
-  param_cb_handles_.push_back(this->add_on_set_parameters_callback(
-    std::bind(&Fcat::SetParametersCb, this, _1)));
+  param_cb_handles_.push_back(
+      this->add_on_set_parameters_callback(std::bind(&Fcat::SetParametersCb, this, _1)));
 
   // pull the Timer Rate from the Fastcat YAML
   InitializeTimerRate(fcat_manager_.GetTargetLoopRate());
   RCLCPP_INFO(this->get_logger(), "Starting Wall Timer at %lf hz",
-                  fcat_manager_.GetTargetLoopRate());
+              fcat_manager_.GetTargetLoopRate());
 
   loop_period_sec_ = 1.0 / fcat_manager_.GetTargetLoopRate();
   last_time_ = this->now().seconds();
@@ -258,30 +247,27 @@ void Fcat::SetRealtimePreempt(int scheduler_priority) {
   // this method must be called from within a thread
   struct sched_param param;
   param.sched_priority = scheduler_priority;
-  if(sched_setscheduler(0, SCHED_FIFO, &param) == -1) {
+  if (sched_setscheduler(0, SCHED_FIFO, &param) == -1) {
     RCLCPP_WARN(this->get_logger(),
-      "Unable to set realtime FIFO scheduler with priority of "
-      "%d; the realtime kernel must be installed to use this feature",
-      scheduler_priority
-    );
+                "Unable to set realtime FIFO scheduler with priority of "
+                "%d; the realtime kernel must be installed to use this feature",
+                scheduler_priority);
     return;
   }
-  
+
   // Lock memory
-  if(mlockall(MCL_CURRENT | MCL_FUTURE) == -1) {
+  if (mlockall(MCL_CURRENT | MCL_FUTURE) == -1) {
     RCLCPP_WARN(this->get_logger(), "Unable to lock memory; 'mlockall' failed");
   }
-  
+
   // Pre-fault our stack
   const size_t max_safe_stack = 8 * 1024;
   unsigned char dummy[max_safe_stack];
   memset(dummy, 0, max_safe_stack);
 }
 
-
 rcl_interfaces::msg::SetParametersResult Fcat::SetParametersCb(
-  const std::vector<rclcpp::Parameter>& parameters)
-{
+    const std::vector<rclcpp::Parameter>& parameters) {
   rcl_interfaces::msg::SetParametersResult result;
   result.successful = true;
 
@@ -303,12 +289,10 @@ rcl_interfaces::msg::SetParametersResult Fcat::SetParametersCb(
         fcat_manager_.SetExplicitInterpolationAlgorithmLinear();
         result.successful = true;
       } else {
-        result.reason =
-          "Invalid algorithm requested, must be one of ['cubic', 'linear']";
+        result.reason = "Invalid algorithm requested, must be one of ['cubic', 'linear']";
         result.successful = false;
       }
-    } else if (parameter.get_name() ==
-               "csp_explicit_interpolation_timestamp_source") {
+    } else if (parameter.get_name() == "csp_explicit_interpolation_timestamp_source") {
       auto value = parameter.as_string();
       if (value == "csp_message") {
         fcat_manager_.SetExplicitInterpolationTimestampSourceCspMessage();
@@ -318,8 +302,8 @@ rcl_interfaces::msg::SetParametersResult Fcat::SetParametersCb(
         result.successful = true;
       } else {
         result.reason =
-          "Invalid algorithm requested, must be one of ['csp_message', "
-          "'clock']";
+            "Invalid algorithm requested, must be one of ['csp_message', "
+            "'clock']";
         result.successful = false;
       }
     }
@@ -327,29 +311,25 @@ rcl_interfaces::msg::SetParametersResult Fcat::SetParametersCb(
   return result;
 }
 
-void Fcat::InitializeActuatorParams(
-  const std::vector<std::string>& actuator_names, int& i)
-{
+void Fcat::InitializeActuatorParams(const std::vector<std::string>& actuator_names, int& i) {
   fastcat::Actuator::ActuatorParams actuator_params;
   for (auto& actuator_name : actuator_names) {
     if (fcat_manager_.GetActuatorParams(actuator_name, actuator_params)) {
-      std::string parameter_prefix =
-        "fastcat_actuator_" + std::to_string(++i) + "_";
+      std::string parameter_prefix = "fastcat_actuator_" + std::to_string(++i) + "_";
       std::string description_prefix = "Actuator " + std::to_string(i) + " ";
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
         descriptor.description = description_prefix + "name";
         descriptor.read_only = true;
-        this->declare_parameter<std::string>(
-          parameter_prefix + "name", actuator_name, descriptor, true);
+        this->declare_parameter<std::string>(parameter_prefix + "name", actuator_name, descriptor,
+                                             true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
         descriptor.description = description_prefix + "actuator type";
         descriptor.read_only = true;
         this->declare_parameter<std::string>(parameter_prefix + "actuator_type",
-                                             actuator_params.actuator_type_str,
-                                             descriptor, true);
+                                             actuator_params.actuator_type_str, descriptor, true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
@@ -360,9 +340,8 @@ void Fcat::InitializeActuatorParams(
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
-        this->declare_parameter<double>(
-          parameter_prefix + "gear_ratio", actuator_params.gear_ratio,
-          descriptor, true);
+        this->declare_parameter<double>(parameter_prefix + "gear_ratio", actuator_params.gear_ratio,
+                                        descriptor, true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
@@ -373,9 +352,8 @@ void Fcat::InitializeActuatorParams(
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
-        this->declare_parameter<double>(
-          parameter_prefix + "counts_per_rev", actuator_params.counts_per_rev,
-          descriptor, true);
+        this->declare_parameter<double>(parameter_prefix + "counts_per_rev",
+                                        actuator_params.counts_per_rev, descriptor, true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
@@ -386,9 +364,8 @@ void Fcat::InitializeActuatorParams(
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
-        this->declare_parameter<double>(
-          parameter_prefix + "max_speed_eu_per_sec",
-          actuator_params.max_speed_eu_per_sec, descriptor, true);
+        this->declare_parameter<double>(parameter_prefix + "max_speed_eu_per_sec",
+                                        actuator_params.max_speed_eu_per_sec, descriptor, true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
@@ -399,9 +376,8 @@ void Fcat::InitializeActuatorParams(
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
-        this->declare_parameter<double>(
-          parameter_prefix + "max_accel_eu_per_sec2",
-          actuator_params.max_accel_eu_per_sec2, descriptor, true);
+        this->declare_parameter<double>(parameter_prefix + "max_accel_eu_per_sec2",
+                                        actuator_params.max_accel_eu_per_sec2, descriptor, true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
@@ -412,23 +388,21 @@ void Fcat::InitializeActuatorParams(
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
-        this->declare_parameter<double>(
-          parameter_prefix + "over_speed_multiplier",
-          actuator_params.over_speed_multiplier, descriptor, true);
+        this->declare_parameter<double>(parameter_prefix + "over_speed_multiplier",
+                                        actuator_params.over_speed_multiplier, descriptor, true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
-        descriptor.description =
-          description_prefix + "velocity tracking error [eu/sec]";
+        descriptor.description = description_prefix + "velocity tracking error [eu/sec]";
         descriptor.read_only = true;
         rcl_interfaces::msg::FloatingPointRange range;
         range.from_value = 0.0;
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
-        this->declare_parameter<double>(
-          parameter_prefix + "vel_tracking_error_eu_per_sec",
-          actuator_params.vel_tracking_error_eu_per_sec, descriptor, true);
+        this->declare_parameter<double>(parameter_prefix + "vel_tracking_error_eu_per_sec",
+                                        actuator_params.vel_tracking_error_eu_per_sec, descriptor,
+                                        true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
@@ -439,9 +413,8 @@ void Fcat::InitializeActuatorParams(
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
-        this->declare_parameter<double>(
-          parameter_prefix + "pos_tracking_error_eu",
-          actuator_params.pos_tracking_error_eu, descriptor, true);
+        this->declare_parameter<double>(parameter_prefix + "pos_tracking_error_eu",
+                                        actuator_params.pos_tracking_error_eu, descriptor, true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
@@ -452,9 +425,8 @@ void Fcat::InitializeActuatorParams(
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
-        this->declare_parameter<double>(
-          parameter_prefix + "peak_current_limit_amps",
-          actuator_params.peak_current_limit_amps, descriptor, true);
+        this->declare_parameter<double>(parameter_prefix + "peak_current_limit_amps",
+                                        actuator_params.peak_current_limit_amps, descriptor, true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
@@ -465,23 +437,21 @@ void Fcat::InitializeActuatorParams(
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
-        this->declare_parameter<double>(
-          parameter_prefix + "peak_current_time_sec",
-          actuator_params.peak_current_time_sec, descriptor, true);
+        this->declare_parameter<double>(parameter_prefix + "peak_current_time_sec",
+                                        actuator_params.peak_current_time_sec, descriptor, true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
-        descriptor.description =
-          description_prefix + "continuous current limit [amps]";
+        descriptor.description = description_prefix + "continuous current limit [amps]";
         descriptor.read_only = true;
         rcl_interfaces::msg::FloatingPointRange range;
         range.from_value = 0.0;
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
-        this->declare_parameter<double>(
-          parameter_prefix + "continuous_current_limit_amps",
-          actuator_params.continuous_current_limit_amps, descriptor, true);
+        this->declare_parameter<double>(parameter_prefix + "continuous_current_limit_amps",
+                                        actuator_params.continuous_current_limit_amps, descriptor,
+                                        true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
@@ -492,65 +462,57 @@ void Fcat::InitializeActuatorParams(
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
-        this->declare_parameter<double>(
-          parameter_prefix + "torque_slope_amps_per_sec",
-          actuator_params.torque_slope_amps_per_sec, descriptor, true);
+        this->declare_parameter<double>(parameter_prefix + "torque_slope_amps_per_sec",
+                                        actuator_params.torque_slope_amps_per_sec, descriptor,
+                                        true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
-        descriptor.description =
-          description_prefix + "low position calibration limit [eu]";
+        descriptor.description = description_prefix + "low position calibration limit [eu]";
         descriptor.read_only = true;
         rcl_interfaces::msg::FloatingPointRange range;
         range.from_value = std::numeric_limits<double>::lowest();
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
-        this->declare_parameter<double>(
-          parameter_prefix + "low_pos_cal_limit_eu",
-          actuator_params.low_pos_cal_limit_eu, descriptor, true);
+        this->declare_parameter<double>(parameter_prefix + "low_pos_cal_limit_eu",
+                                        actuator_params.low_pos_cal_limit_eu, descriptor, true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
-        descriptor.description =
-          description_prefix + "low position command limit [eu]";
+        descriptor.description = description_prefix + "low position command limit [eu]";
         descriptor.read_only = true;
         rcl_interfaces::msg::FloatingPointRange range;
         range.from_value = std::numeric_limits<double>::lowest();
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
-        this->declare_parameter<double>(
-          parameter_prefix + "low_pos_cmd_limit_eu",
-          actuator_params.low_pos_cmd_limit_eu, descriptor, true);
+        this->declare_parameter<double>(parameter_prefix + "low_pos_cmd_limit_eu",
+                                        actuator_params.low_pos_cmd_limit_eu, descriptor, true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
-        descriptor.description =
-          description_prefix + "high position calibration limit [eu]";
+        descriptor.description = description_prefix + "high position calibration limit [eu]";
         descriptor.read_only = true;
         rcl_interfaces::msg::FloatingPointRange range;
         range.from_value = std::numeric_limits<double>::lowest();
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
-        this->declare_parameter<double>(
-          parameter_prefix + "high_pos_cal_limit_eu",
-          actuator_params.high_pos_cal_limit_eu, descriptor, true);
+        this->declare_parameter<double>(parameter_prefix + "high_pos_cal_limit_eu",
+                                        actuator_params.high_pos_cal_limit_eu, descriptor, true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
-        descriptor.description =
-          description_prefix + "high position command limit [eu]";
+        descriptor.description = description_prefix + "high position command limit [eu]";
         descriptor.read_only = true;
         rcl_interfaces::msg::FloatingPointRange range;
         range.from_value = std::numeric_limits<double>::lowest();
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
-        this->declare_parameter<double>(
-          parameter_prefix + "high_pos_cmd_limit_eu",
-          actuator_params.high_pos_cmd_limit_eu, descriptor, true);
+        this->declare_parameter<double>(parameter_prefix + "high_pos_cmd_limit_eu",
+                                        actuator_params.high_pos_cmd_limit_eu, descriptor, true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
@@ -561,9 +523,8 @@ void Fcat::InitializeActuatorParams(
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
-        this->declare_parameter<double>(
-          parameter_prefix + "holding_duration_sec",
-          actuator_params.holding_duration_sec, descriptor, true);
+        this->declare_parameter<double>(parameter_prefix + "holding_duration_sec",
+                                        actuator_params.holding_duration_sec, descriptor, true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
@@ -574,9 +535,8 @@ void Fcat::InitializeActuatorParams(
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
-        this->declare_parameter<double>(
-          parameter_prefix + "elmo_brake_engage_msec",
-          actuator_params.elmo_brake_engage_msec, descriptor, true);
+        this->declare_parameter<double>(parameter_prefix + "elmo_brake_engage_msec",
+                                        actuator_params.elmo_brake_engage_msec, descriptor, true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
@@ -587,9 +547,9 @@ void Fcat::InitializeActuatorParams(
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
-        this->declare_parameter<double>(
-          parameter_prefix + "elmo_brake_disengage_msec",
-          actuator_params.elmo_brake_disengage_msec, descriptor, true);
+        this->declare_parameter<double>(parameter_prefix + "elmo_brake_disengage_msec",
+                                        actuator_params.elmo_brake_disengage_msec, descriptor,
+                                        true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
@@ -600,23 +560,21 @@ void Fcat::InitializeActuatorParams(
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
-        this->declare_parameter<double>(
-          parameter_prefix + "elmo_crc", actuator_params.elmo_crc,
-          descriptor, true);
+        this->declare_parameter<double>(parameter_prefix + "elmo_crc", actuator_params.elmo_crc,
+                                        descriptor, true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
-        descriptor.description =
-          description_prefix + "drive max current limit [amps]";
+        descriptor.description = description_prefix + "drive max current limit [amps]";
         descriptor.read_only = true;
         rcl_interfaces::msg::FloatingPointRange range;
         range.from_value = 0.0;
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
-        this->declare_parameter<double>(
-          parameter_prefix + "elmo_drive_max_cur_limit_amps",
-          actuator_params.elmo_drive_max_cur_limit_amps, descriptor, true);
+        this->declare_parameter<double>(parameter_prefix + "elmo_drive_max_cur_limit_amps",
+                                        actuator_params.elmo_drive_max_cur_limit_amps, descriptor,
+                                        true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
@@ -627,9 +585,8 @@ void Fcat::InitializeActuatorParams(
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
-        this->declare_parameter<double>(
-          parameter_prefix + "smooth_factor", actuator_params.smooth_factor,
-          descriptor, true);
+        this->declare_parameter<double>(parameter_prefix + "smooth_factor",
+                                        actuator_params.smooth_factor, descriptor, true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
@@ -640,9 +597,8 @@ void Fcat::InitializeActuatorParams(
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
-        this->declare_parameter<double>(
-          parameter_prefix + "torque_constant",
-          actuator_params.torque_constant, descriptor, true);
+        this->declare_parameter<double>(parameter_prefix + "torque_constant",
+                                        actuator_params.torque_constant, descriptor, true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
@@ -653,9 +609,8 @@ void Fcat::InitializeActuatorParams(
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
-        this->declare_parameter<double>(
-          parameter_prefix + "winding_resistance",
-          actuator_params.winding_resistance, descriptor, true);
+        this->declare_parameter<double>(parameter_prefix + "winding_resistance",
+                                        actuator_params.winding_resistance, descriptor, true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
@@ -666,9 +621,8 @@ void Fcat::InitializeActuatorParams(
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
-        this->declare_parameter<double>(
-          parameter_prefix + "brake_power", actuator_params.brake_power,
-          descriptor, true);
+        this->declare_parameter<double>(parameter_prefix + "brake_power",
+                                        actuator_params.brake_power, descriptor, true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
@@ -679,42 +633,36 @@ void Fcat::InitializeActuatorParams(
         range.to_value = std::numeric_limits<double>::max();
         range.step = 0.0;
         descriptor.floating_point_range.push_back(range);
-        this->declare_parameter<double>(
-          parameter_prefix + "motor_encoder_gear_ratio",
-          actuator_params.motor_encoder_gear_ratio, descriptor, true);
+        this->declare_parameter<double>(parameter_prefix + "motor_encoder_gear_ratio",
+                                        actuator_params.motor_encoder_gear_ratio, descriptor, true);
       }
       {
         rcl_interfaces::msg::ParameterDescriptor descriptor;
         descriptor.description = description_prefix + "has absolute encoder";
         descriptor.read_only = true;
-        this->declare_parameter<bool>(
-          parameter_prefix + "has_absolute_encoder",
-          actuator_params.actuator_absolute_encoder, descriptor, true);
+        this->declare_parameter<bool>(parameter_prefix + "has_absolute_encoder",
+                                      actuator_params.actuator_absolute_encoder, descriptor, true);
       }
     }
   }
 }
 
-void Fcat::PopulateDeviceStateFields()
-{
+void Fcat::PopulateDeviceStateFields() {
   device_state_ptrs_ = fcat_manager_.GetDeviceStatePointers();
 
-  for (auto it = device_state_ptrs_.begin(); it != device_state_ptrs_.end();
-       ++it) {
-    RCLCPP_INFO(this->get_logger(), "Populating device_name_state_map_[%s]",
-                    (*it)->name.c_str());
+  for (auto it = device_state_ptrs_.begin(); it != device_state_ptrs_.end(); ++it) {
+    RCLCPP_INFO(this->get_logger(), "Populating device_name_state_map_[%s]", (*it)->name.c_str());
 
     device_name_state_map_[(*it)->name] = *it;
 
     device_type_vec_map_[(*it)->type].push_back(*it);
 
     RCLCPP_INFO(this->get_logger(), "counts[%d] = %ld", (*it)->type,
-                    device_type_vec_map_[(*it)->type].size());
+                device_type_vec_map_[(*it)->type].size());
   }
 }
 
-bool Fcat::ActuatorExistsOnBus(const std::string& name)
-{
+bool Fcat::ActuatorExistsOnBus(const std::string& name) {
   std::string error_message;
   if (DeviceExistsOnBus(name, fastcat::GOLD_ACTUATOR_STATE, error_message)) {
     return true;
@@ -726,23 +674,18 @@ bool Fcat::ActuatorExistsOnBus(const std::string& name)
   return false;
 }
 
-bool Fcat::ActuatorExistsOnBus(const std::string& name,
-                               std::string& error_message)
-{
+bool Fcat::ActuatorExistsOnBus(const std::string& name, std::string& error_message) {
   if (DeviceExistsOnBus(name, fastcat::GOLD_ACTUATOR_STATE, error_message)) {
     return true;
-  } else if (DeviceExistsOnBus(name, fastcat::PLATINUM_ACTUATOR_STATE,
-                               error_message)) {
+  } else if (DeviceExistsOnBus(name, fastcat::PLATINUM_ACTUATOR_STATE, error_message)) {
     return true;
   }
   // handle other future Actuator device types here
   return false;
 }
 
-bool Fcat::DeviceExistsOnBus(const std::string& name,
-                             fastcat::DeviceStateType type,
-                             std::string& error_message)
-{
+bool Fcat::DeviceExistsOnBus(const std::string& name, fastcat::DeviceStateType type,
+                             std::string& error_message) {
   char str[512];
   if (!(device_name_state_map_.end() != device_name_state_map_.find(name))) {
     snprintf(str, 512, "Device %s does not exist on bus", name.c_str());
@@ -757,9 +700,7 @@ bool Fcat::DeviceExistsOnBus(const std::string& name,
   return true;
 }
 
-bool Fcat::DeviceExistsOnBus(const std::string& name,
-                             fastcat::DeviceStateType type)
-{
+bool Fcat::DeviceExistsOnBus(const std::string& name, fastcat::DeviceStateType type) {
   std::string error_message;
   bool success = DeviceExistsOnBus(name, type, error_message);
   if (not success) {
@@ -768,37 +709,32 @@ bool Fcat::DeviceExistsOnBus(const std::string& name,
   return success;
 }
 
-bool Fcat::TypeExistsOnBus(fastcat::DeviceStateType type)
-{
+bool Fcat::TypeExistsOnBus(fastcat::DeviceStateType type) {
   if (device_type_vec_map_[type].size() > 0) {
     return true;
   }
   return false;
 }
 
-void Fcat::InitializePublishersAndMessages()
-{
+void Fcat::InitializePublishersAndMessages() {
   RCLCPP_INFO(this->get_logger(), "Fcat::InitializePublishers()");
 
   rclcpp::QoS qos_profile(publisher_queue_size_);
   qos_profile.best_effort();
 
   // Async SDO Response
-  async_sdo_response_pub_ =
-    this->create_publisher<fcat_msgs::msg::AsyncSdoResponse>(
+  async_sdo_response_pub_ = this->create_publisher<fcat_msgs::msg::AsyncSdoResponse>(
       "state/async_sdo_response", qos_profile);
 
   // Actuators
   auto gold_vec_state_ptrs = device_type_vec_map_[fastcat::GOLD_ACTUATOR_STATE];
-  auto platinum_vec_state_ptrs =
-    device_type_vec_map_[fastcat::PLATINUM_ACTUATOR_STATE];
-  size_t num_actuators =
-    gold_vec_state_ptrs.size() + platinum_vec_state_ptrs.size();
+  auto platinum_vec_state_ptrs = device_type_vec_map_[fastcat::PLATINUM_ACTUATOR_STATE];
+  size_t num_actuators = gold_vec_state_ptrs.size() + platinum_vec_state_ptrs.size();
 
   if (num_actuators > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating actuator pub");
-    actuator_pub_ = this->create_publisher<fcat_msgs::msg::ActuatorStates>(
-      "state/actuators", qos_profile);
+    actuator_pub_ =
+        this->create_publisher<fcat_msgs::msg::ActuatorStates>("state/actuators", qos_profile);
 
     actuator_states_msg_.names.resize(num_actuators);
     actuator_states_msg_.states.resize(num_actuators);
@@ -810,8 +746,8 @@ void Fcat::InitializePublishersAndMessages()
       // namespace. This prevents needing to remap `fcat/state/joint_states`
       // to `/joint_states` in launch files or through command line args.
       // It can always be reverted if this causes any issues down the road.
-      joint_state_pub_ = this->create_publisher<sensor_msgs::msg::JointState>(
-        "/joint_states", qos_profile);
+      joint_state_pub_ =
+          this->create_publisher<sensor_msgs::msg::JointState>("/joint_states", qos_profile);
     }
   }
 
@@ -819,8 +755,7 @@ void Fcat::InitializePublishersAndMessages()
   auto vec_state_ptrs = device_type_vec_map_[fastcat::EGD_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating Egd pub");
-    egd_pub_ = this->create_publisher<fcat_msgs::msg::EgdStates>(
-      "state/egds", qos_profile);
+    egd_pub_ = this->create_publisher<fcat_msgs::msg::EgdStates>("state/egds", qos_profile);
 
     egd_states_msg_.names.resize(vec_state_ptrs.size());
     egd_states_msg_.states.resize(vec_state_ptrs.size());
@@ -830,8 +765,8 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs = device_type_vec_map_[fastcat::EL1008_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating El1008 pub");
-    el1008_pub_ = this->create_publisher<fcat_msgs::msg::El1008States>(
-      "state/el1008s", qos_profile);
+    el1008_pub_ =
+        this->create_publisher<fcat_msgs::msg::El1008States>("state/el1008s", qos_profile);
 
     el1008_states_msg_.names.resize(vec_state_ptrs.size());
     el1008_states_msg_.states.resize(vec_state_ptrs.size());
@@ -841,8 +776,8 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs = device_type_vec_map_[fastcat::EL2124_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating El2124 pub");
-    el2124_pub_ = this->create_publisher<fcat_msgs::msg::El2124States>(
-      "state/el2124s", qos_profile);
+    el2124_pub_ =
+        this->create_publisher<fcat_msgs::msg::El2124States>("state/el2124s", qos_profile);
 
     el2124_states_msg_.names.resize(vec_state_ptrs.size());
     el2124_states_msg_.states.resize(vec_state_ptrs.size());
@@ -852,8 +787,8 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs = device_type_vec_map_[fastcat::EL2809_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating El2809 pub");
-    el2809_pub_ = this->create_publisher<fcat_msgs::msg::El2809States>(
-      "state/el2809s", qos_profile);
+    el2809_pub_ =
+        this->create_publisher<fcat_msgs::msg::El2809States>("state/el2809s", qos_profile);
 
     el2809_states_msg_.names.resize(vec_state_ptrs.size());
     el2809_states_msg_.states.resize(vec_state_ptrs.size());
@@ -863,8 +798,8 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs = device_type_vec_map_[fastcat::EL2798_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating El2798 pub");
-    el2798_pub_ = this->create_publisher<fcat_msgs::msg::El2798States>(
-        "state/el2798s", qos_profile);
+    el2798_pub_ =
+        this->create_publisher<fcat_msgs::msg::El2798States>("state/el2798s", qos_profile);
 
     el2798_states_msg_.names.resize(vec_state_ptrs.size());
     el2798_states_msg_.states.resize(vec_state_ptrs.size());
@@ -874,8 +809,8 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs = device_type_vec_map_[fastcat::EL2828_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating El2828 pub");
-    el2828_pub_ = this->create_publisher<fcat_msgs::msg::El2828States>(
-        "state/el2828s", qos_profile);
+    el2828_pub_ =
+        this->create_publisher<fcat_msgs::msg::El2828States>("state/el2828s", qos_profile);
 
     el2828_states_msg_.names.resize(vec_state_ptrs.size());
     el2828_states_msg_.states.resize(vec_state_ptrs.size());
@@ -885,8 +820,8 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs = device_type_vec_map_[fastcat::EL3104_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating El3104 pub");
-    el3104_pub_ = this->create_publisher<fcat_msgs::msg::El3104States>(
-      "state/el3104s", qos_profile);
+    el3104_pub_ =
+        this->create_publisher<fcat_msgs::msg::El3104States>("state/el3104s", qos_profile);
 
     el3104_states_msg_.names.resize(vec_state_ptrs.size());
     el3104_states_msg_.states.resize(vec_state_ptrs.size());
@@ -896,8 +831,8 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs = device_type_vec_map_[fastcat::EL3162_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating El3162 pub");
-    el3162_pub_ = this->create_publisher<fcat_msgs::msg::El3162States>(
-      "state/el3162s", qos_profile);
+    el3162_pub_ =
+        this->create_publisher<fcat_msgs::msg::El3162States>("state/el3162s", qos_profile);
 
     el3162_states_msg_.names.resize(vec_state_ptrs.size());
     el3162_states_msg_.states.resize(vec_state_ptrs.size());
@@ -907,8 +842,8 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs = device_type_vec_map_[fastcat::EL3202_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating El3202 pub");
-    el3202_pub_ = this->create_publisher<fcat_msgs::msg::El3202States>(
-      "state/el3202s", qos_profile);
+    el3202_pub_ =
+        this->create_publisher<fcat_msgs::msg::El3202States>("state/el3202s", qos_profile);
 
     el3202_states_msg_.names.resize(vec_state_ptrs.size());
     el3202_states_msg_.states.resize(vec_state_ptrs.size());
@@ -918,8 +853,8 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs = device_type_vec_map_[fastcat::EL3208_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating El3208 pub");
-    el3208_pub_ = this->create_publisher<fcat_msgs::msg::El3208States>(
-      "state/el3208s", qos_profile);
+    el3208_pub_ =
+        this->create_publisher<fcat_msgs::msg::El3208States>("state/el3208s", qos_profile);
 
     el3208_states_msg_.names.resize(vec_state_ptrs.size());
     el3208_states_msg_.states.resize(vec_state_ptrs.size());
@@ -929,8 +864,8 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs = device_type_vec_map_[fastcat::EL3314_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating El3314 pub");
-    el3314_pub_ = this->create_publisher<fcat_msgs::msg::El3314States>(
-      "state/el3314s", qos_profile);
+    el3314_pub_ =
+        this->create_publisher<fcat_msgs::msg::El3314States>("state/el3314s", qos_profile);
 
     el3314_states_msg_.names.resize(vec_state_ptrs.size());
     el3314_states_msg_.states.resize(vec_state_ptrs.size());
@@ -940,8 +875,8 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs = device_type_vec_map_[fastcat::EL3318_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating El3318 pub");
-    el3318_pub_ = this->create_publisher<fcat_msgs::msg::El3318States>(
-      "state/el3318s", qos_profile);
+    el3318_pub_ =
+        this->create_publisher<fcat_msgs::msg::El3318States>("state/el3318s", qos_profile);
 
     el3318_states_msg_.names.resize(vec_state_ptrs.size());
     el3318_states_msg_.states.resize(vec_state_ptrs.size());
@@ -951,8 +886,8 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs = device_type_vec_map_[fastcat::EL3602_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating El3602 pub");
-    el3602_pub_ = this->create_publisher<fcat_msgs::msg::El3602States>(
-      "state/el3602s", qos_profile);
+    el3602_pub_ =
+        this->create_publisher<fcat_msgs::msg::El3602States>("state/el3602s", qos_profile);
 
     el3602_states_msg_.names.resize(vec_state_ptrs.size());
     el3602_states_msg_.states.resize(vec_state_ptrs.size());
@@ -962,8 +897,8 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs = device_type_vec_map_[fastcat::EL4102_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating El4102 pub");
-    el4102_pub_ = this->create_publisher<fcat_msgs::msg::El4102States>(
-      "state/el4102s", qos_profile);
+    el4102_pub_ =
+        this->create_publisher<fcat_msgs::msg::El4102States>("state/el4102s", qos_profile);
 
     el4102_states_msg_.names.resize(vec_state_ptrs.size());
     el4102_states_msg_.states.resize(vec_state_ptrs.size());
@@ -973,8 +908,8 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs = device_type_vec_map_[fastcat::EL5042_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating El5042 pub");
-    el5042_pub_ = this->create_publisher<fcat_msgs::msg::El5042States>(
-        "state/el5042s", qos_profile);
+    el5042_pub_ =
+        this->create_publisher<fcat_msgs::msg::El5042States>("state/el5042s", qos_profile);
 
     el5042_states_msg_.names.resize(vec_state_ptrs.size());
     el5042_states_msg_.states.resize(vec_state_ptrs.size());
@@ -984,8 +919,8 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs = device_type_vec_map_[fastcat::ILD1900_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating Ild1900 pub");
-    ild1900_pub_ = this->create_publisher<fcat_msgs::msg::Ild1900States>(
-      "state/ild1900s", qos_profile);
+    ild1900_pub_ =
+        this->create_publisher<fcat_msgs::msg::Ild1900States>("state/ild1900s", qos_profile);
 
     ild1900_states_msg_.names.resize(vec_state_ptrs.size());
     ild1900_states_msg_.states.resize(vec_state_ptrs.size());
@@ -995,8 +930,8 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs = device_type_vec_map_[fastcat::COMMANDER_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating Commander pub");
-    commander_pub_ = this->create_publisher<fcat_msgs::msg::CommanderStates>(
-      "state/commanders", qos_profile);
+    commander_pub_ =
+        this->create_publisher<fcat_msgs::msg::CommanderStates>("state/commanders", qos_profile);
 
     commander_states_msg_.names.resize(vec_state_ptrs.size());
     commander_states_msg_.states.resize(vec_state_ptrs.size());
@@ -1006,8 +941,7 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs = device_type_vec_map_[fastcat::CONDITIONAL_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating Conditional pub");
-    conditional_pub_ =
-      this->create_publisher<fcat_msgs::msg::ConditionalStates>(
+    conditional_pub_ = this->create_publisher<fcat_msgs::msg::ConditionalStates>(
         "state/conditionals", qos_profile);
 
     conditional_states_msg_.names.resize(vec_state_ptrs.size());
@@ -1018,8 +952,8 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs = device_type_vec_map_[fastcat::FAULTER_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating Faulter pub");
-    faulter_pub_ = this->create_publisher<fcat_msgs::msg::FaulterStates>(
-      "state/faulters", qos_profile);
+    faulter_pub_ =
+        this->create_publisher<fcat_msgs::msg::FaulterStates>("state/faulters", qos_profile);
 
     faulter_states_msg_.names.resize(vec_state_ptrs.size());
     faulter_states_msg_.states.resize(vec_state_ptrs.size());
@@ -1029,8 +963,7 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs = device_type_vec_map_[fastcat::FILTER_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating Filter pub");
-    filter_pub_ = this->create_publisher<fcat_msgs::msg::FilterStates>(
-      "state/filter", qos_profile);
+    filter_pub_ = this->create_publisher<fcat_msgs::msg::FilterStates>("state/filter", qos_profile);
 
     filter_states_msg_.names.resize(vec_state_ptrs.size());
     filter_states_msg_.states.resize(vec_state_ptrs.size());
@@ -1040,8 +973,8 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs = device_type_vec_map_[fastcat::FUNCTION_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating Function pub");
-    function_pub_ = this->create_publisher<fcat_msgs::msg::FunctionStates>(
-      "state/functions", qos_profile);
+    function_pub_ =
+        this->create_publisher<fcat_msgs::msg::FunctionStates>("state/functions", qos_profile);
 
     function_states_msg_.names.resize(vec_state_ptrs.size());
     function_states_msg_.states.resize(vec_state_ptrs.size());
@@ -1051,8 +984,7 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs = device_type_vec_map_[fastcat::PID_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating Pid pub");
-    pid_pub_ = this->create_publisher<fcat_msgs::msg::PidStates>(
-      "state/pids", qos_profile);
+    pid_pub_ = this->create_publisher<fcat_msgs::msg::PidStates>("state/pids", qos_profile);
 
     pid_states_msg_.names.resize(vec_state_ptrs.size());
     pid_states_msg_.states.resize(vec_state_ptrs.size());
@@ -1062,8 +994,8 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs = device_type_vec_map_[fastcat::SATURATION_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating Saturation pub");
-    saturation_pub_ = this->create_publisher<fcat_msgs::msg::SaturationStates>(
-      "state/saturations", qos_profile);
+    saturation_pub_ =
+        this->create_publisher<fcat_msgs::msg::SaturationStates>("state/saturations", qos_profile);
 
     saturation_states_msg_.names.resize(vec_state_ptrs.size());
     saturation_states_msg_.states.resize(vec_state_ptrs.size());
@@ -1073,8 +1005,7 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs = device_type_vec_map_[fastcat::SCHMITT_TRIGGER_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating Schmitt Trigger pub");
-    schmitt_trigger_pub_ =
-      this->create_publisher<fcat_msgs::msg::SchmittTriggerStates>(
+    schmitt_trigger_pub_ = this->create_publisher<fcat_msgs::msg::SchmittTriggerStates>(
         "state/schmitt_triggers", qos_profile);
 
     schmitt_trigger_states_msg_.names.resize(vec_state_ptrs.size());
@@ -1085,8 +1016,7 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs = device_type_vec_map_[fastcat::SIGNAL_GENERATOR_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating Signal Generator pub");
-    signal_generator_pub_ =
-      this->create_publisher<fcat_msgs::msg::SignalGeneratorStates>(
+    signal_generator_pub_ = this->create_publisher<fcat_msgs::msg::SignalGeneratorStates>(
         "state/signal_generators", qos_profile);
 
     signal_generator_states_msg_.names.resize(vec_state_ptrs.size());
@@ -1097,8 +1027,7 @@ void Fcat::InitializePublishersAndMessages()
   vec_state_ptrs = device_type_vec_map_[fastcat::LINEAR_INTERPOLATION_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating LinearInterpolation pub");
-    linear_interpolation_pub_ =
-      this->create_publisher<fcat_msgs::msg::LinearInterpolationStates>(
+    linear_interpolation_pub_ = this->create_publisher<fcat_msgs::msg::LinearInterpolationStates>(
         "state/linear_interpolators", qos_profile);
 
     linear_interpolation_states_msg_.names.resize(vec_state_ptrs.size());
@@ -1106,13 +1035,12 @@ void Fcat::InitializePublishersAndMessages()
   }
 
   // Three Node Thermal Model
-  vec_state_ptrs =
-    device_type_vec_map_[fastcat::THREE_NODE_THERMAL_MODEL_STATE];
+  vec_state_ptrs = device_type_vec_map_[fastcat::THREE_NODE_THERMAL_MODEL_STATE];
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating ThreeNodeThermalModel pub");
     three_node_thermal_model_pub_ =
-      this->create_publisher<fcat_msgs::msg::ThreeNodeThermalModelStates>(
-        "state/three_node_thermal_models", qos_profile);
+        this->create_publisher<fcat_msgs::msg::ThreeNodeThermalModelStates>(
+            "state/three_node_thermal_models", qos_profile);
 
     three_node_thermal_model_states_msg_.names.resize(vec_state_ptrs.size());
     three_node_thermal_model_states_msg_.states.resize(vec_state_ptrs.size());
@@ -1124,488 +1052,417 @@ void Fcat::InitializePublishersAndMessages()
   if (vec_state_ptrs.size() > 0) {
     RCLCPP_INFO(this->get_logger(), "Creating FTS pub");
 
-    fts_pub_ = this->create_publisher<fcat_msgs::msg::FtsStates>(
-      "state/fts", qos_profile);
+    fts_pub_ = this->create_publisher<fcat_msgs::msg::FtsStates>("state/fts", qos_profile);
 
     fts_states_msg_.names.resize(vec_state_ptrs.size());
     fts_states_msg_.states.resize(vec_state_ptrs.size());
 
     if (enable_ros_wrench_pub_) {
-      for (auto dev_state_ptr = vec_state_ptrs.begin();
-           dev_state_ptr != vec_state_ptrs.end(); dev_state_ptr++) {
+      for (auto dev_state_ptr = vec_state_ptrs.begin(); dev_state_ptr != vec_state_ptrs.end();
+           dev_state_ptr++) {
         std::string device = (*dev_state_ptr)->name;
-        fts_raw_pub_map_[device] =
-          this->create_publisher<geometry_msgs::msg::WrenchStamped>(
+        fts_raw_pub_map_[device] = this->create_publisher<geometry_msgs::msg::WrenchStamped>(
             "fts/" + device + "/raw_wrench", qos_profile);
 
-        fts_tared_pub_map_[device] =
-          this->create_publisher<geometry_msgs::msg::WrenchStamped>(
+        fts_tared_pub_map_[device] = this->create_publisher<geometry_msgs::msg::WrenchStamped>(
             "fts/" + device + "/tared_wrench", qos_profile);
 
-        RCLCPP_INFO(this->get_logger(), "Creating ROS WrenchStamped Topics for %s",
-                        device.c_str());
+        RCLCPP_INFO(this->get_logger(), "Creating ROS WrenchStamped Topics for %s", device.c_str());
       }
     }
   }
 
   // Module State (always published)
-  module_state_pub_ = this->create_publisher<fcat_msgs::msg::ModuleState>(
-    "state/module_state", qos_profile);
+  module_state_pub_ =
+      this->create_publisher<fcat_msgs::msg::ModuleState>("state/module_state", qos_profile);
 }
 
-void Fcat::InitializeSubscribers()
-{
+void Fcat::InitializeSubscribers() {
   rclcpp::SubscriptionOptions options;
 
   options.callback_group = topic_callback_group_;
 
   // bus reset/fault
   subscriptions_.push_back(this->create_subscription<std_msgs::msg::Empty>(
-    "impl/reset", 1, std::bind(&Fcat::ResetCmdCb, this, _1), options));
+      "impl/reset", 1, std::bind(&Fcat::ResetCmdCb, this, _1), options));
 
   subscriptions_.push_back(this->create_subscription<std_msgs::msg::Empty>(
-    "impl/fault", 1, std::bind(&Fcat::FaultCmdCb, this, _1), options));
+      "impl/fault", 1, std::bind(&Fcat::FaultCmdCb, this, _1), options));
 
   // Async SDO
-  subscriptions_.push_back(
-    this->create_subscription<fcat_msgs::msg::AsyncSdoReadCmd>(
+  subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::AsyncSdoReadCmd>(
       "impl/async_sdo_read", subscription_queue_size_,
       std::bind(&Fcat::AsyncSdoReadCmdCb, this, _1), options));
 
-  subscriptions_.push_back(
-    this->create_subscription<fcat_msgs::msg::AsyncSdoWriteCmd>(
+  subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::AsyncSdoWriteCmd>(
       "impl/async_sdo_write", subscription_queue_size_,
       std::bind(&Fcat::AsyncSdoWriteCmdCb, this, _1), options));
 
   // Actuator
   if (TypeExistsOnBus(fastcat::GOLD_ACTUATOR_STATE) ||
       TypeExistsOnBus(fastcat::PLATINUM_ACTUATOR_STATE)) {
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::ActuatorCspCmd>(
-        "impl/actuator_csp", subscription_queue_size_,
-        std::bind(&Fcat::ActuatorCSPCmdCb, this, _1), options));
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::ActuatorCspCmd>(
+        "impl/actuator_csp", subscription_queue_size_, std::bind(&Fcat::ActuatorCSPCmdCb, this, _1),
+        options));
 
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::ActuatorCsvCmd>(
-        "impl/actuator_csv", subscription_queue_size_,
-        std::bind(&Fcat::ActuatorCSVCmdCb, this, _1), options));
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::ActuatorCsvCmd>(
+        "impl/actuator_csv", subscription_queue_size_, std::bind(&Fcat::ActuatorCSVCmdCb, this, _1),
+        options));
 
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::ActuatorCstCmd>(
-        "impl/actuator_cst", subscription_queue_size_,
-        std::bind(&Fcat::ActuatorCSTCmdCb, this, _1), options));
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::ActuatorCstCmd>(
+        "impl/actuator_cst", subscription_queue_size_, std::bind(&Fcat::ActuatorCSTCmdCb, this, _1),
+        options));
 
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::ActuatorCspCmds>(
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::ActuatorCspCmds>(
         "impl/actuator_csp_multi", subscription_queue_size_,
         std::bind(&Fcat::ActuatorCSPCmdsCb, this, _1), options));
 
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::ActuatorCsvCmds>(
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::ActuatorCsvCmds>(
         "impl/actuator_csv_multi", subscription_queue_size_,
         std::bind(&Fcat::ActuatorCSVCmdsCb, this, _1), options));
 
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::ActuatorCstCmds>(
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::ActuatorCstCmds>(
         "impl/actuator_cst_multi", subscription_queue_size_,
         std::bind(&Fcat::ActuatorCSTCmdsCb, this, _1), options));
 
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::ActuatorCalibrateCmd>(
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::ActuatorCalibrateCmd>(
         "impl/actuator_calibrate", subscription_queue_size_,
         std::bind(&Fcat::ActuatorCalibrateCmdCb, this, _1), options));
 
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::ActuatorProfPosCmd>(
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::ActuatorProfPosCmd>(
         "impl/actuator_prof_pos", subscription_queue_size_,
         std::bind(&Fcat::ActuatorProfPosCmdCb, this, _1), options));
 
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::ActuatorProfTorqueCmd>(
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::ActuatorProfTorqueCmd>(
         "impl/actuator_prof_torque", subscription_queue_size_,
         std::bind(&Fcat::ActuatorProfTorqueCmdCb, this, _1), options));
 
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::ActuatorProfVelCmd>(
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::ActuatorProfVelCmd>(
         "impl/actuator_prof_vel", subscription_queue_size_,
         std::bind(&Fcat::ActuatorProfVelCmdCb, this, _1), options));
 
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::ActuatorProfPosCmds>(
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::ActuatorProfPosCmds>(
         "impl/actuator_prof_pos_multi", subscription_queue_size_,
         std::bind(&Fcat::ActuatorProfPosCmdsCb, this, _1), options));
 
     subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::ActuatorSetOutputPositionCmd>(
-        "impl/actuator_set_output_position", subscription_queue_size_,
-        std::bind(&Fcat::ActuatorSetOutputPositionCmdCb, this, _1), options));
+        this->create_subscription<fcat_msgs::msg::ActuatorSetOutputPositionCmd>(
+            "impl/actuator_set_output_position", subscription_queue_size_,
+            std::bind(&Fcat::ActuatorSetOutputPositionCmdCb, this, _1), options));
 
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::ActuatorSetDigitalOutputCmd>(
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::ActuatorSetDigitalOutputCmd>(
         "impl/actuator_set_digital_output", subscription_queue_size_,
         std::bind(&Fcat::ActuatorSetDigitalOutputCmdCb, this, _1), options));
 
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::ActuatorSetMaxCurrentCmd>(
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::ActuatorSetMaxCurrentCmd>(
         "impl/actuator_set_max_current", subscription_queue_size_,
         std::bind(&Fcat::ActuatorSetMaxCurrentCmdCb, this, _1), options));
 
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::ActuatorSetUnitModeCmd>(
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::ActuatorSetUnitModeCmd>(
         "impl/actuator_set_unit_mode", subscription_queue_size_,
         std::bind(&Fcat::ActuatorSetUnitModeCmdCb, this, _1), options));
 
     subscriptions_.push_back(
-      this->create_subscription<
-        fcat_msgs::msg::ActuatorSetProfDisengagingTimeoutCmd>(
-        "impl/actuator_set_prof_disengaging_timeout", subscription_queue_size_,
-        std::bind(&Fcat::ActuatorSetProfDisengagingTimeoutCmdCb, this, _1),
-        options));
+        this->create_subscription<fcat_msgs::msg::ActuatorSetProfDisengagingTimeoutCmd>(
+            "impl/actuator_set_prof_disengaging_timeout", subscription_queue_size_,
+            std::bind(&Fcat::ActuatorSetProfDisengagingTimeoutCmdCb, this, _1), options));
 
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::ActuatorHaltCmd>(
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::ActuatorHaltCmd>(
         "impl/actuator_halt", subscription_queue_size_,
         std::bind(&Fcat::ActuatorHaltCmdCb, this, _1), options));
 
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::ActuatorHaltCmds>(
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::ActuatorHaltCmds>(
         "impl/actuator_halt_multi", subscription_queue_size_,
         std::bind(&Fcat::ActuatorHaltCmdsCb, this, _1), options));
   }
 
   // Commander
   if (TypeExistsOnBus(fastcat::COMMANDER_STATE)) {
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::CommanderEnableCmd>(
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::CommanderEnableCmd>(
         "impl/commander_enable", subscription_queue_size_,
         std::bind(&Fcat::CommanderEnableCmdCb, this, _1), options));
 
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::CommanderDisableCmd>(
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::CommanderDisableCmd>(
         "impl/commander_disable", subscription_queue_size_,
         std::bind(&Fcat::CommanderDisableCmdCb, this, _1), options));
   }
 
   // El2124
   if (TypeExistsOnBus(fastcat::EL2124_STATE)) {
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::El2124WriteAllChannelsCmd>(
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::El2124WriteAllChannelsCmd>(
         "impl/el2124_write_all_channels", subscription_queue_size_,
         std::bind(&Fcat::El2124WriteAllChannelsCmdCb, this, _1), options));
 
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::El2124WriteChannelCmd>(
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::El2124WriteChannelCmd>(
         "impl/el2124_write_channel", subscription_queue_size_,
         std::bind(&Fcat::El2124WriteChannelCmdCb, this, _1), options));
   }
 
   // El2809
   if (TypeExistsOnBus(fastcat::EL2809_STATE)) {
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::El2809WriteAllChannelsCmd>(
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::El2809WriteAllChannelsCmd>(
         "impl/el2809_write_all_channels", subscription_queue_size_,
         std::bind(&Fcat::El2809WriteAllChannelsCmdCb, this, _1), options));
 
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::El2809WriteChannelCmd>(
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::El2809WriteChannelCmd>(
         "impl/el2809_write_channel", subscription_queue_size_,
         std::bind(&Fcat::El2809WriteChannelCmdCb, this, _1), options));
   }
 
   // El2798
   if (TypeExistsOnBus(fastcat::EL2798_STATE)) {
-    subscriptions_.push_back(
-        this->create_subscription<fcat_msgs::msg::El2798WriteAllChannelsCmd>(
-            "impl/el2798_write_all_channels", subscription_queue_size_,
-            std::bind(&Fcat::El2798WriteAllChannelsCmdCb, this, _1), options));
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::El2798WriteAllChannelsCmd>(
+        "impl/el2798_write_all_channels", subscription_queue_size_,
+        std::bind(&Fcat::El2798WriteAllChannelsCmdCb, this, _1), options));
 
-    subscriptions_.push_back(
-        this->create_subscription<fcat_msgs::msg::El2798WriteChannelCmd>(
-            "impl/el2798_write_channel", subscription_queue_size_,
-            std::bind(&Fcat::El2798WriteChannelCmdCb, this, _1), options));
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::El2798WriteChannelCmd>(
+        "impl/el2798_write_channel", subscription_queue_size_,
+        std::bind(&Fcat::El2798WriteChannelCmdCb, this, _1), options));
   }
 
   // El2828
   if (TypeExistsOnBus(fastcat::EL2828_STATE)) {
-    subscriptions_.push_back(
-        this->create_subscription<fcat_msgs::msg::El2828WriteAllChannelsCmd>(
-            "impl/el2828_write_all_channels", subscription_queue_size_,
-            std::bind(&Fcat::El2828WriteAllChannelsCmdCb, this, _1), options));
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::El2828WriteAllChannelsCmd>(
+        "impl/el2828_write_all_channels", subscription_queue_size_,
+        std::bind(&Fcat::El2828WriteAllChannelsCmdCb, this, _1), options));
 
-    subscriptions_.push_back(
-        this->create_subscription<fcat_msgs::msg::El2828WriteChannelCmd>(
-            "impl/el2828_write_channel", subscription_queue_size_,
-            std::bind(&Fcat::El2828WriteChannelCmdCb, this, _1), options));
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::El2828WriteChannelCmd>(
+        "impl/el2828_write_channel", subscription_queue_size_,
+        std::bind(&Fcat::El2828WriteChannelCmdCb, this, _1), options));
   }
 
   // EL4102
   if (TypeExistsOnBus(fastcat::EL4102_STATE)) {
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::El4102WriteAllChannelsCmd>(
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::El4102WriteAllChannelsCmd>(
         "impl/el4102_write_all_channels", subscription_queue_size_,
         std::bind(&Fcat::El4102WriteAllChannelsCmdCb, this, _1), options));
 
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::El4102WriteChannelCmd>(
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::El4102WriteChannelCmd>(
         "impl/el4102_write_channel", subscription_queue_size_,
         std::bind(&Fcat::El4102WriteChannelCmdCb, this, _1), options));
   }
 
   // Faulter
   if (TypeExistsOnBus(fastcat::FAULTER_STATE)) {
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::FaulterEnableCmd>(
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::FaulterEnableCmd>(
         "impl/faulter_enable", subscription_queue_size_,
         std::bind(&Fcat::FaulterEnableCmdCb, this, _1), options));
   }
 
   // Fts
   if (TypeExistsOnBus(fastcat::FTS_STATE)) {
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::FtsTareCmd>(
-        "impl/fts_tare", subscription_queue_size_,
-        std::bind(&Fcat::FtsTareCmdCb, this, _1), options));
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::FtsTareCmd>(
+        "impl/fts_tare", subscription_queue_size_, std::bind(&Fcat::FtsTareCmdCb, this, _1),
+        options));
   }
 
   // Pid
   if (TypeExistsOnBus(fastcat::PID_STATE)) {
-    subscriptions_.push_back(
-      this->create_subscription<fcat_msgs::msg::PidActivateCmd>(
-        "impl/pid_activate", subscription_queue_size_,
-        std::bind(&Fcat::PidActivateCmdCb, this, _1), options));
+    subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::PidActivateCmd>(
+        "impl/pid_activate", subscription_queue_size_, std::bind(&Fcat::PidActivateCmdCb, this, _1),
+        options));
   }
 }
 
-void Fcat::InitializeServices()
-{
+void Fcat::InitializeServices() {
   // bus reset/fault
   services_.push_back(this->create_service<std_srvs::srv::Trigger>(
-    "cmd/reset", std::bind(&Fcat::ResetSrvCb, this, _1, _2), service_qos_));
+      "cmd/reset", std::bind(&Fcat::ResetSrvCb, this, _1, _2), service_qos_));
 
   services_.push_back(this->create_service<std_srvs::srv::Trigger>(
-    "cmd/fault", std::bind(&Fcat::FaultSrvCb, this, _1, _2), service_qos_));
+      "cmd/fault", std::bind(&Fcat::FaultSrvCb, this, _1, _2), service_qos_));
 
   // Actuator
   if (TypeExistsOnBus(fastcat::GOLD_ACTUATOR_STATE) ||
       TypeExistsOnBus(fastcat::PLATINUM_ACTUATOR_STATE)) {
     services_.push_back(this->create_service<fcat_msgs::srv::ActuatorHaltService>(
-      "cmd/actuator_halt",
-      std::bind(&Fcat::ActuatorHaltSrvCb, this, _1, _2), service_qos_));
+        "cmd/actuator_halt", std::bind(&Fcat::ActuatorHaltSrvCb, this, _1, _2), service_qos_));
 
-    services_.push_back(
-      this->create_service<fcat_msgs::srv::ActuatorSetGainSchedulingIndexService>(
+    services_.push_back(this->create_service<fcat_msgs::srv::ActuatorSetGainSchedulingIndexService>(
         "cmd/actuator_set_gain_scheduling_index",
-        std::bind(&Fcat::ActuatorSetGainSchedulingIndexSrvCb, this, _1, _2),
+        std::bind(&Fcat::ActuatorSetGainSchedulingIndexSrvCb, this, _1, _2), service_qos_));
+
+    services_.push_back(this->create_service<fcat_msgs::srv::ActuatorSetMaxCurrentService>(
+        "cmd/actuator_set_max_current", std::bind(&Fcat::ActuatorSetMaxCurrentSrvCb, this, _1, _2),
         service_qos_));
 
-    services_.push_back(
-      this->create_service<fcat_msgs::srv::ActuatorSetMaxCurrentService>(
-        "cmd/actuator_set_max_current",
-        std::bind(&Fcat::ActuatorSetMaxCurrentSrvCb, this, _1, _2),
-        service_qos_));
-
-    services_.push_back(
-      this->create_service<fcat_msgs::srv::ActuatorSetOutputPositionService>(
+    services_.push_back(this->create_service<fcat_msgs::srv::ActuatorSetOutputPositionService>(
         "cmd/actuator_set_output_position",
-        std::bind(&Fcat::ActuatorSetOutputPositionSrvCb, this, _1, _2),
-        service_qos_));
+        std::bind(&Fcat::ActuatorSetOutputPositionSrvCb, this, _1, _2), service_qos_));
 
-    services_.push_back(
-      this->create_service<fcat_msgs::srv::ActuatorSetDigitalOutputService>(
+    services_.push_back(this->create_service<fcat_msgs::srv::ActuatorSetDigitalOutputService>(
         "cmd/actuator_set_digital_output",
-        std::bind(&Fcat::ActuatorSetDigitalOutputSrvCb, this, _1, _2),
-        service_qos_));
+        std::bind(&Fcat::ActuatorSetDigitalOutputSrvCb, this, _1, _2), service_qos_));
 
     services_.push_back(
-      this->create_service<
-        fcat_msgs::srv::ActuatorSetProfDisengagingTimeoutService>(
-        "cmd/actuator_set_prof_disengaging_timeout",
-        std::bind(&Fcat::ActuatorSetProfDisengagingTimeoutSrvCb, this, _1, _2),
-        service_qos_));
+        this->create_service<fcat_msgs::srv::ActuatorSetProfDisengagingTimeoutService>(
+            "cmd/actuator_set_prof_disengaging_timeout",
+            std::bind(&Fcat::ActuatorSetProfDisengagingTimeoutSrvCb, this, _1, _2), service_qos_));
 
     services_.push_back(this->create_service<fcat_msgs::srv::ActuatorProfPosService>(
-      "cmd/actuator_prof_pos",
-      std::bind(&Fcat::ActuatorProfPosSrvCb, this, _1, _2), service_qos_));
+        "cmd/actuator_prof_pos", std::bind(&Fcat::ActuatorProfPosSrvCb, this, _1, _2),
+        service_qos_));
 
     services_.push_back(this->create_service<fcat_msgs::srv::ActuatorProfVelService>(
-      "cmd/actuator_prof_vel",
-      std::bind(&Fcat::ActuatorProfVelSrvCb, this, _1, _2), service_qos_));
+        "cmd/actuator_prof_vel", std::bind(&Fcat::ActuatorProfVelSrvCb, this, _1, _2),
+        service_qos_));
 
-    services_.push_back(
-      this->create_service<fcat_msgs::srv::ActuatorProfTorqueService>(
-        "cmd/actuator_prof_torque",
-        std::bind(&Fcat::ActuatorProfTorqueSrvCb, this, _1, _2),
+    services_.push_back(this->create_service<fcat_msgs::srv::ActuatorProfTorqueService>(
+        "cmd/actuator_prof_torque", std::bind(&Fcat::ActuatorProfTorqueSrvCb, this, _1, _2),
         service_qos_));
 
     services_.push_back(this->create_service<fcat_msgs::srv::ActuatorCalibrateService>(
-      "cmd/actuator_calibrate",
-      std::bind(&Fcat::ActuatorCalibrateSrvCb, this, _1, _2), service_qos_));
+        "cmd/actuator_calibrate", std::bind(&Fcat::ActuatorCalibrateSrvCb, this, _1, _2),
+        service_qos_));
 
   }  // end Actuator Service Declarations
 
   // Commander
   if (TypeExistsOnBus(fastcat::COMMANDER_STATE)) {
     services_.push_back(this->create_service<fcat_msgs::srv::CommanderEnableService>(
-      "cmd/commander_enable",
-      std::bind(&Fcat::CommanderEnableSrvCb, this, _1, _2), service_qos_));
+        "cmd/commander_enable", std::bind(&Fcat::CommanderEnableSrvCb, this, _1, _2),
+        service_qos_));
 
     services_.push_back(this->create_service<fcat_msgs::srv::CommanderDisableService>(
-      "cmd/commander_disable",
-      std::bind(&Fcat::CommanderDisableSrvCb, this, _1, _2), service_qos_));
+        "cmd/commander_disable", std::bind(&Fcat::CommanderDisableSrvCb, this, _1, _2),
+        service_qos_));
   }  // end Commander Service Declarations
 
   // El2124
   if (TypeExistsOnBus(fastcat::EL2124_STATE)) {
-    services_.push_back(
-      this->create_service<fcat_msgs::srv::El2124WriteAllChannelsService>(
+    services_.push_back(this->create_service<fcat_msgs::srv::El2124WriteAllChannelsService>(
         "cmd/el2124_write_all_channels",
-        std::bind(&Fcat::El2124WriteAllChannelsSrvCb, this, _1, _2),
-        service_qos_));
+        std::bind(&Fcat::El2124WriteAllChannelsSrvCb, this, _1, _2), service_qos_));
 
     services_.push_back(this->create_service<fcat_msgs::srv::El2124WriteChannelService>(
-      "cmd/el2124_write_channel",
-      std::bind(&Fcat::El2124WriteChannelSrvCb, this, _1, _2), service_qos_));
+        "cmd/el2124_write_channel", std::bind(&Fcat::El2124WriteChannelSrvCb, this, _1, _2),
+        service_qos_));
 
   }  // end El2124 Service Declarations
 
   // El2809
   if (TypeExistsOnBus(fastcat::EL2809_STATE)) {
-    services_.push_back(
-      this->create_service<fcat_msgs::srv::El2809WriteAllChannelsService>(
+    services_.push_back(this->create_service<fcat_msgs::srv::El2809WriteAllChannelsService>(
         "cmd/el2809_write_all_channels",
-        std::bind(&Fcat::El2809WriteAllChannelsSrvCb, this, _1, _2),
-        service_qos_));
+        std::bind(&Fcat::El2809WriteAllChannelsSrvCb, this, _1, _2), service_qos_));
 
     services_.push_back(this->create_service<fcat_msgs::srv::El2809WriteChannelService>(
-      "cmd/el2809_write_channel",
-      std::bind(&Fcat::El2809WriteChannelSrvCb, this, _1, _2), service_qos_));
+        "cmd/el2809_write_channel", std::bind(&Fcat::El2809WriteChannelSrvCb, this, _1, _2),
+        service_qos_));
 
   }  // end El2809 Service Declarations
 
   // El2798
   if (TypeExistsOnBus(fastcat::EL2798_STATE)) {
-    services_.push_back(
-      this->create_service<fcat_msgs::srv::El2798WriteAllChannelsService>(
+    services_.push_back(this->create_service<fcat_msgs::srv::El2798WriteAllChannelsService>(
         "cmd/el2798_write_all_channels",
-        std::bind(&Fcat::El2798WriteAllChannelsSrvCb, this, _1, _2),
-        service_qos_));
+        std::bind(&Fcat::El2798WriteAllChannelsSrvCb, this, _1, _2), service_qos_));
 
     services_.push_back(this->create_service<fcat_msgs::srv::El2798WriteChannelService>(
-      "cmd/el2798_write_channel",
-      std::bind(&Fcat::El2798WriteChannelSrvCb, this, _1, _2), service_qos_));
+        "cmd/el2798_write_channel", std::bind(&Fcat::El2798WriteChannelSrvCb, this, _1, _2),
+        service_qos_));
 
   }  // end El2798 Service Declarations
 
   // El2828
   if (TypeExistsOnBus(fastcat::EL2828_STATE)) {
-    services_.push_back(
-      this->create_service<fcat_msgs::srv::El2828WriteAllChannelsService>(
+    services_.push_back(this->create_service<fcat_msgs::srv::El2828WriteAllChannelsService>(
         "cmd/el2828_write_all_channels",
-        std::bind(&Fcat::El2828WriteAllChannelsSrvCb, this, _1, _2),
-        service_qos_));
+        std::bind(&Fcat::El2828WriteAllChannelsSrvCb, this, _1, _2), service_qos_));
 
     services_.push_back(this->create_service<fcat_msgs::srv::El2828WriteChannelService>(
-      "cmd/el2828_write_channel",
-      std::bind(&Fcat::El2828WriteChannelSrvCb, this, _1, _2), service_qos_));
+        "cmd/el2828_write_channel", std::bind(&Fcat::El2828WriteChannelSrvCb, this, _1, _2),
+        service_qos_));
 
   }  // end El2828 Service Declarations
 
-
   // El4102
   if (TypeExistsOnBus(fastcat::EL4102_STATE)) {
-    services_.push_back(
-      this->create_service<fcat_msgs::srv::El4102WriteAllChannelsService>(
+    services_.push_back(this->create_service<fcat_msgs::srv::El4102WriteAllChannelsService>(
         "cmd/el4102_write_all_channels",
-        std::bind(&Fcat::El4102WriteAllChannelsSrvCb, this, _1, _2),
-        service_qos_));
+        std::bind(&Fcat::El4102WriteAllChannelsSrvCb, this, _1, _2), service_qos_));
 
     services_.push_back(this->create_service<fcat_msgs::srv::El4102WriteChannelService>(
-      "cmd/el4102_write_channel",
-      std::bind(&Fcat::El4102WriteChannelSrvCb, this, _1, _2), service_qos_));
+        "cmd/el4102_write_channel", std::bind(&Fcat::El4102WriteChannelSrvCb, this, _1, _2),
+        service_qos_));
 
   }  // end El4102 Service Declarations
 
   // Faulter
   if (TypeExistsOnBus(fastcat::FAULTER_STATE)) {
     services_.push_back(this->create_service<fcat_msgs::srv::FaulterEnableService>(
-      "cmd/faulter_enable",
-      std::bind(&Fcat::FaulterEnableSrvCb, this, _1, _2), service_qos_));
+        "cmd/faulter_enable", std::bind(&Fcat::FaulterEnableSrvCb, this, _1, _2), service_qos_));
 
   }  // end Faulter Service Declarations
 
   // FTS
   if (TypeExistsOnBus(fastcat::FTS_STATE)) {
     services_.push_back(this->create_service<fcat_msgs::srv::DeviceTriggerService>(
-      "cmd/fts_tare",
-      std::bind(&Fcat::FtsTareSrvCb, this, _1, _2), service_qos_));
+        "cmd/fts_tare", std::bind(&Fcat::FtsTareSrvCb, this, _1, _2), service_qos_));
 
   }  // end FTS Service Declarations
 
   // PID
   if (TypeExistsOnBus(fastcat::PID_STATE)) {
     services_.push_back(this->create_service<fcat_msgs::srv::PidActivateService>(
-      "cmd/pid_activate",
-      std::bind(&Fcat::PidActivateSrvCb, this, _1, _2), service_qos_));
+        "cmd/pid_activate", std::bind(&Fcat::PidActivateSrvCb, this, _1, _2), service_qos_));
 
   }  // end PID Service Declarations
 }
 
 void Fcat::SetCpuAffinity() {
 #ifdef _GNU_SOURCE
-    if (gettid() != getpid()) {
-      int cpus_available = get_nprocs_conf();
-      RCLCPP_INFO(this->get_logger(), "This system has %d CPUs configured", cpus_available);
-      if (process_loop_cpu_id_ >= cpus_available) {
-        RCLCPP_FATAL(this->get_logger(),
-          "User requested to pin Process() function to CPU ID %d, but "
-          "only %d CPUs are available on this machine",
-          process_loop_cpu_id_, cpus_available);
-        rclcpp::shutdown();
-      } else {
-        cpu_set_t affinity;
-        CPU_ZERO(&affinity);
-        CPU_SET(process_loop_cpu_id_, &affinity);
+  if (gettid() != getpid()) {
+    int cpus_available = get_nprocs_conf();
+    RCLCPP_INFO(this->get_logger(), "This system has %d CPUs configured", cpus_available);
+    if (process_loop_cpu_id_ >= cpus_available) {
+      RCLCPP_FATAL(this->get_logger(),
+                   "User requested to pin Process() function to CPU ID %d, but "
+                   "only %d CPUs are available on this machine",
+                   process_loop_cpu_id_, cpus_available);
+      rclcpp::shutdown();
+    } else {
+      cpu_set_t affinity;
+      CPU_ZERO(&affinity);
+      CPU_SET(process_loop_cpu_id_, &affinity);
 
-        RCLCPP_INFO(this->get_logger(), "Setting CPU affinity for thread ID: %d", gettid());
-        int result = sched_setaffinity(gettid(), sizeof(cpu_set_t), &affinity);
-        if (result != 0) {
-          RCLCPP_WARN(this->get_logger(),
-            "Could not set process affinity to CPU %d for thread ID: %d, "
-            "sched_setaffinity returned result: %d",
-            process_loop_cpu_id_, gettid(), result);
-        } else {
-          RCLCPP_INFO(this->get_logger(), "Set CPU affinity to CPU %d for thread ID: %d",
-                         process_loop_cpu_id_, gettid());
-        }
-        process_loop_thread_id_ = gettid();
+      RCLCPP_INFO(this->get_logger(), "Setting CPU affinity for thread ID: %d", gettid());
+      int result = sched_setaffinity(gettid(), sizeof(cpu_set_t), &affinity);
+      if (result != 0) {
+        RCLCPP_WARN(this->get_logger(),
+                    "Could not set process affinity to CPU %d for thread ID: %d, "
+                    "sched_setaffinity returned result: %d",
+                    process_loop_cpu_id_, gettid(), result);
+      } else {
+        RCLCPP_INFO(this->get_logger(), "Set CPU affinity to CPU %d for thread ID: %d",
+                    process_loop_cpu_id_, gettid());
       }
+      process_loop_thread_id_ = gettid();
     }
+  }
 #else
   RCLCPP_WARN(this->get_logger(),
-    "GNU extensions are not available on this machine/compiler; the Process() "
-    "loop "
-    "cannot be moved to CPU %d",
-    process_loop_thread_id_);
+              "GNU extensions are not available on this machine/compiler; the Process() "
+              "loop "
+              "cannot be moved to CPU %d",
+              process_loop_thread_id_);
 #endif
 }
 
-
-void Fcat::Process()
-{
+void Fcat::Process() {
   fprintf(stderr, "Handling Process() loop\n");
   auto now = this->get_clock()->now();
 
   bool report_cycle_slips = this->get_parameter("report_cycle_slips").as_bool();
-  if (report_cycle_slips && time_stamp_initialized_ &&
-      cpu_affinity_initialized_) {
+  if (report_cycle_slips && time_stamp_initialized_ && cpu_affinity_initialized_) {
     double dt = now.seconds() - publish_time_stamp_.seconds();
     if (dt > 2.0 * loop_period_sec_) {
       RCLCPP_WARN(this->get_logger(),
-        "Cycle slip detected; seconds since last Process() call: "
-        "%f",
-        dt);
+                  "Cycle slip detected; seconds since last Process() call: "
+                  "%f",
+                  dt);
     }
-    if(fault_on_cycle_slip_ && dt > cycle_slip_fault_magnitude_ * loop_period_sec_) {      
+    if (fault_on_cycle_slip_ && dt > cycle_slip_fault_magnitude_ * loop_period_sec_) {
       fcat_manager_.ExecuteAllDeviceFaults();
       const std::shared_ptr<std_msgs::msg::Empty> msg;
       // FaultInterface::FaultCmdCb(msg); // TODO: use lifecyle nodes
@@ -1629,9 +1486,9 @@ void Fcat::Process()
       RCLCPP_INFO(this->get_logger(), "This system has %d CPUs configured", cpus_available);
       if (process_loop_cpu_id_ >= cpus_available) {
         RCLCPP_FATAL(this->get_logger(),
-          "User requested to pin Process() function to CPU ID %d, but "
-          "only %d CPUs are available on this machine",
-          process_loop_cpu_id_, cpus_available);
+                     "User requested to pin Process() function to CPU ID %d, but "
+                     "only %d CPUs are available on this machine",
+                     process_loop_cpu_id_, cpus_available);
         rclcpp::shutdown();
       } else {
         cpu_set_t affinity;
@@ -1642,12 +1499,12 @@ void Fcat::Process()
         int result = sched_setaffinity(gettid(), sizeof(cpu_set_t), &affinity);
         if (result != 0) {
           RCLCPP_WARN(this->get_logger(),
-            "Could not set process affinity to CPU %d for thread ID: %d, "
-            "sched_setaffinity returned result: %d",
-            process_loop_cpu_id_, gettid(), result);
+                      "Could not set process affinity to CPU %d for thread ID: %d, "
+                      "sched_setaffinity returned result: %d",
+                      process_loop_cpu_id_, gettid(), result);
         } else {
           RCLCPP_INFO(this->get_logger(), "Set CPU affinity to CPU %d for thread ID: %d",
-                         process_loop_cpu_id_, gettid());
+                      process_loop_cpu_id_, gettid());
         }
         process_loop_thread_id_ = gettid();
         cpu_affinity_initialized_ = true;
@@ -1656,15 +1513,16 @@ void Fcat::Process()
   }
 #else
   RCLCPP_WARN(this->get_logger(),
-    "GNU extensions are not available on this machine/compiler; the Process() "
-    "loop cannot be moved to CPU %d",
-    process_loop_thread_id_);
+              "GNU extensions are not available on this machine/compiler; the Process() "
+              "loop cannot be moved to CPU %d",
+              process_loop_thread_id_);
   cpu_affinity_initialized_ = true;
 #endif
 
-  if(!process_loop_realtime_preempt_initialized_) {
-    if(enable_realtime_preempt_) {
-      RCLCPP_INFO(this->get_logger(), "Setting realtime priority for process loop to %d", scheduler_priority_);
+  if (!process_loop_realtime_preempt_initialized_) {
+    if (enable_realtime_preempt_) {
+      RCLCPP_INFO(this->get_logger(), "Setting realtime priority for process loop to %d",
+                  scheduler_priority_);
       SetRealtimePreempt(scheduler_priority_);
     }
     process_loop_realtime_preempt_initialized_ = true;
@@ -1710,8 +1568,7 @@ void Fcat::Process()
   PublishThreeNodeThermalModelStates();
 }
 
-void Fcat::PublishFcatModuleState()
-{
+void Fcat::PublishFcatModuleState() {
   // Check for fault status and emit logs
   bool is_faulted = fcat_manager_.IsFaulted();
   if (!module_state_msg_.faulted && is_faulted) {
@@ -1739,23 +1596,20 @@ void Fcat::PublishFcatModuleState()
   module_state_pub_->publish(module_state_msg_);
 }
 
-void Fcat::PublishAsyncSdoResponse()
-{
+void Fcat::PublishAsyncSdoResponse() {
   fastcat::SdoResponse sdo_resp;
   if (fcat_manager_.PopSdoResponseQueue(sdo_resp)) {
     fcat_msgs::msg::AsyncSdoResponse msg;
 
     msg.device_name = sdo_resp.device_name;
-    msg.request_type =
-      jsd_sdo_request_type_to_string(sdo_resp.response.request_type);
+    msg.request_type = jsd_sdo_request_type_to_string(sdo_resp.response.request_type);
     msg.sdo_index = sdo_resp.response.sdo_index;
     msg.sdo_subindex = sdo_resp.response.sdo_subindex;
     msg.data_type = jsd_sdo_data_type_to_string(sdo_resp.response.data_type);
     msg.app_id = sdo_resp.response.app_id;
     msg.success = sdo_resp.response.success;
 
-    msg.data = jsd_sdo_data_to_string(sdo_resp.response.data_type,
-                                      sdo_resp.response.data);
+    msg.data = jsd_sdo_data_to_string(sdo_resp.response.data_type, sdo_resp.response.data);
 
     fprintf(stderr, "Publishing new AsyncSdoResponse\n");
 
@@ -1763,16 +1617,15 @@ void Fcat::PublishAsyncSdoResponse()
   }
 }
 
-void Fcat::PublishFtsStates()
-{
+void Fcat::PublishFtsStates() {
   // FTS, AtiFts, VirtualFts
   auto vec_state_ptrs = device_type_vec_map_[fastcat::FTS_STATE];
   if (vec_state_ptrs.size() > 0) {
     size_t index = 0;
 
     fts_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto dev_state_ptr = vec_state_ptrs.begin();
-         dev_state_ptr != vec_state_ptrs.end(); dev_state_ptr++) {
+    for (auto dev_state_ptr = vec_state_ptrs.begin(); dev_state_ptr != vec_state_ptrs.end();
+         dev_state_ptr++) {
       // Aggregate FTS state message
       fts_states_msg_.names[index] = (*dev_state_ptr)->name;
       fts_states_msg_.states[index] = FtsStateToMsg(*dev_state_ptr);
@@ -1819,13 +1672,10 @@ void Fcat::PublishFtsStates()
   }
 }
 
-void Fcat::PublishActuatorStates()
-{
+void Fcat::PublishActuatorStates() {
   auto& gold_act_state_vec = device_type_vec_map_[fastcat::GOLD_ACTUATOR_STATE];
-  auto& platinum_act_state_vec =
-    device_type_vec_map_[fastcat::PLATINUM_ACTUATOR_STATE];
-  size_t num_actuators =
-    gold_act_state_vec.size() + platinum_act_state_vec.size();
+  auto& platinum_act_state_vec = device_type_vec_map_[fastcat::PLATINUM_ACTUATOR_STATE];
+  size_t num_actuators = gold_act_state_vec.size() + platinum_act_state_vec.size();
 
   if (num_actuators > 0) {
     size_t index = 0;
@@ -1857,10 +1707,8 @@ void Fcat::PublishActuatorStates()
 
       // Populate JointState message
       js_msg.name.push_back(state_ptr->name);
-      js_msg.position.push_back(
-        state_ptr->platinum_actuator_state.actual_position);
-      js_msg.velocity.push_back(
-        state_ptr->platinum_actuator_state.actual_velocity);
+      js_msg.position.push_back(state_ptr->platinum_actuator_state.actual_position);
+      js_msg.velocity.push_back(state_ptr->platinum_actuator_state.actual_velocity);
     }
 
     actuator_pub_->publish(actuator_states_msg_);
@@ -1872,15 +1720,13 @@ void Fcat::PublishActuatorStates()
   }
 }
 
-void Fcat::PublishEgdStates()
-{
+void Fcat::PublishEgdStates() {
   auto state_vec = device_type_vec_map_[fastcat::EGD_STATE];
   if (state_vec.size() > 0) {
     size_t index = 0;
 
     egd_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
-         state_ptr++) {
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++) {
       egd_states_msg_.names[index] = (*state_ptr)->name;
       egd_states_msg_.states[index] = EgdStateToMsg(*state_ptr);
       index++;
@@ -1889,37 +1735,31 @@ void Fcat::PublishEgdStates()
   }
 }
 
-void Fcat::PublishThreeNodeThermalModelStates()
-{
+void Fcat::PublishThreeNodeThermalModelStates() {
   // FTS, AtiFts, VirtualFts
-  auto vec_state_ptrs =
-    device_type_vec_map_[fastcat::THREE_NODE_THERMAL_MODEL_STATE];
+  auto vec_state_ptrs = device_type_vec_map_[fastcat::THREE_NODE_THERMAL_MODEL_STATE];
   if (vec_state_ptrs.size() > 0) {
     size_t index = 0;
 
     three_node_thermal_model_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto dev_state_ptr = vec_state_ptrs.begin();
-         dev_state_ptr != vec_state_ptrs.end(); dev_state_ptr++) {
-      three_node_thermal_model_states_msg_.names[index] =
-        (*dev_state_ptr)->name;
+    for (auto dev_state_ptr = vec_state_ptrs.begin(); dev_state_ptr != vec_state_ptrs.end();
+         dev_state_ptr++) {
+      three_node_thermal_model_states_msg_.names[index] = (*dev_state_ptr)->name;
       three_node_thermal_model_states_msg_.states[index] =
-        ThreeNodeThermalModelStateToMsg(*dev_state_ptr);
+          ThreeNodeThermalModelStateToMsg(*dev_state_ptr);
       index++;
     }
-    three_node_thermal_model_pub_->publish(
-      three_node_thermal_model_states_msg_);
+    three_node_thermal_model_pub_->publish(three_node_thermal_model_states_msg_);
   }
 }
 
-void Fcat::PublishEl1008States()
-{
+void Fcat::PublishEl1008States() {
   auto state_vec = device_type_vec_map_[fastcat::EL1008_STATE];
   if (state_vec.size() > 0) {
     size_t index = 0;
 
     el1008_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
-         state_ptr++) {
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++) {
       el1008_states_msg_.names[index] = (*state_ptr)->name;
       el1008_states_msg_.states[index] = El1008StateToMsg(*state_ptr);
       index++;
@@ -1928,15 +1768,13 @@ void Fcat::PublishEl1008States()
   }
 }
 
-void Fcat::PublishEl2124States()
-{
+void Fcat::PublishEl2124States() {
   auto state_vec = device_type_vec_map_[fastcat::EL2124_STATE];
   if (state_vec.size() > 0) {
     size_t index = 0;
 
     el2124_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
-         state_ptr++) {
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++) {
       el2124_states_msg_.names[index] = (*state_ptr)->name;
       el2124_states_msg_.states[index] = El2124StateToMsg(*state_ptr);
       index++;
@@ -1945,15 +1783,13 @@ void Fcat::PublishEl2124States()
   }
 }
 
-void Fcat::PublishEl2809States()
-{
+void Fcat::PublishEl2809States() {
   auto state_vec = device_type_vec_map_[fastcat::EL2809_STATE];
   if (state_vec.size() > 0) {
     size_t index = 0;
 
     el2809_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
-         state_ptr++) {
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++) {
       el2809_states_msg_.names[index] = (*state_ptr)->name;
       el2809_states_msg_.states[index] = El2809StateToMsg(*state_ptr);
       index++;
@@ -1962,16 +1798,14 @@ void Fcat::PublishEl2809States()
   }
 }
 
-void Fcat::PublishEl2798States()
-{
+void Fcat::PublishEl2798States() {
   auto state_vec = device_type_vec_map_[fastcat::EL2798_STATE];
   if (state_vec.size() > 0) {
     size_t index = 0;
 
     el2798_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
-         state_ptr++) {
-      el2798_states_msg_.names[index]  = (*state_ptr)->name;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++) {
+      el2798_states_msg_.names[index] = (*state_ptr)->name;
       el2798_states_msg_.states[index] = El2798StateToMsg(*state_ptr);
       index++;
     }
@@ -1979,16 +1813,14 @@ void Fcat::PublishEl2798States()
   }
 }
 
-void Fcat::PublishEl2828States()
-{
+void Fcat::PublishEl2828States() {
   auto state_vec = device_type_vec_map_[fastcat::EL2828_STATE];
   if (state_vec.size() > 0) {
     size_t index = 0;
 
     el2828_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
-         state_ptr++) {
-      el2828_states_msg_.names[index]  = (*state_ptr)->name;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++) {
+      el2828_states_msg_.names[index] = (*state_ptr)->name;
       el2828_states_msg_.states[index] = El2828StateToMsg(*state_ptr);
       index++;
     }
@@ -1996,15 +1828,13 @@ void Fcat::PublishEl2828States()
   }
 }
 
-void Fcat::PublishEl3104States()
-{
+void Fcat::PublishEl3104States() {
   auto state_vec = device_type_vec_map_[fastcat::EL3104_STATE];
   if (state_vec.size() > 0) {
     size_t index = 0;
 
     el3104_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
-         state_ptr++) {
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++) {
       el3104_states_msg_.names[index] = (*state_ptr)->name;
       el3104_states_msg_.states[index] = El3104StateToMsg(*state_ptr);
       index++;
@@ -2013,15 +1843,13 @@ void Fcat::PublishEl3104States()
   }
 }
 
-void Fcat::PublishEl3162States()
-{
+void Fcat::PublishEl3162States() {
   auto state_vec = device_type_vec_map_[fastcat::EL3162_STATE];
   if (state_vec.size() > 0) {
     size_t index = 0;
 
     el3162_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
-         state_ptr++) {
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++) {
       el3162_states_msg_.names[index] = (*state_ptr)->name;
       el3162_states_msg_.states[index] = El3162StateToMsg(*state_ptr);
       index++;
@@ -2030,15 +1858,13 @@ void Fcat::PublishEl3162States()
   }
 }
 
-void Fcat::PublishEl3202States()
-{
+void Fcat::PublishEl3202States() {
   auto state_vec = device_type_vec_map_[fastcat::EL3202_STATE];
   if (state_vec.size() > 0) {
     size_t index = 0;
 
     el3202_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
-         state_ptr++) {
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++) {
       el3202_states_msg_.names[index] = (*state_ptr)->name;
       el3202_states_msg_.states[index] = El3202StateToMsg(*state_ptr);
       index++;
@@ -2047,15 +1873,13 @@ void Fcat::PublishEl3202States()
   }
 }
 
-void Fcat::PublishEl3208States()
-{
+void Fcat::PublishEl3208States() {
   auto state_vec = device_type_vec_map_[fastcat::EL3208_STATE];
   if (state_vec.size() > 0) {
     size_t index = 0;
 
     el3208_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
-         state_ptr++) {
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++) {
       el3208_states_msg_.names[index] = (*state_ptr)->name;
       el3208_states_msg_.states[index] = El3208StateToMsg(*state_ptr);
       index++;
@@ -2064,15 +1888,13 @@ void Fcat::PublishEl3208States()
   }
 }
 
-void Fcat::PublishEl3314States()
-{
+void Fcat::PublishEl3314States() {
   auto state_vec = device_type_vec_map_[fastcat::EL3314_STATE];
   if (state_vec.size() > 0) {
     size_t index = 0;
 
     el3314_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
-         state_ptr++) {
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++) {
       el3314_states_msg_.names[index] = (*state_ptr)->name;
       el3314_states_msg_.states[index] = El3314StateToMsg(*state_ptr);
       index++;
@@ -2081,15 +1903,13 @@ void Fcat::PublishEl3314States()
   }
 }
 
-void Fcat::PublishEl3318States()
-{
+void Fcat::PublishEl3318States() {
   auto state_vec = device_type_vec_map_[fastcat::EL3318_STATE];
   if (state_vec.size() > 0) {
     size_t index = 0;
 
     el3318_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
-         state_ptr++) {
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++) {
       el3318_states_msg_.names[index] = (*state_ptr)->name;
       el3318_states_msg_.states[index] = El3318StateToMsg(*state_ptr);
       index++;
@@ -2098,15 +1918,13 @@ void Fcat::PublishEl3318States()
   }
 }
 
-void Fcat::PublishEl3602States()
-{
+void Fcat::PublishEl3602States() {
   auto state_vec = device_type_vec_map_[fastcat::EL3602_STATE];
   if (state_vec.size() > 0) {
     size_t index = 0;
 
     el3602_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
-         state_ptr++) {
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++) {
       el3602_states_msg_.names[index] = (*state_ptr)->name;
       el3602_states_msg_.states[index] = El3602StateToMsg(*state_ptr);
       index++;
@@ -2115,15 +1933,13 @@ void Fcat::PublishEl3602States()
   }
 }
 
-void Fcat::PublishEl4102States()
-{
+void Fcat::PublishEl4102States() {
   auto state_vec = device_type_vec_map_[fastcat::EL4102_STATE];
   if (state_vec.size() > 0) {
     size_t index = 0;
 
     el4102_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
-         state_ptr++) {
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++) {
       el4102_states_msg_.names[index] = (*state_ptr)->name;
       el4102_states_msg_.states[index] = El4102StateToMsg(*state_ptr);
       index++;
@@ -2132,16 +1948,14 @@ void Fcat::PublishEl4102States()
   }
 }
 
-void Fcat::PublishEl5042States()
-{
+void Fcat::PublishEl5042States() {
   auto state_vec = device_type_vec_map_[fastcat::EL5042_STATE];
   if (state_vec.size() > 0) {
     size_t index = 0;
 
     el5042_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
-         state_ptr++) {
-      el5042_states_msg_.names[index]  = (*state_ptr)->name;
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++) {
+      el5042_states_msg_.names[index] = (*state_ptr)->name;
       el5042_states_msg_.states[index] = El5042StateToMsg(*state_ptr);
       index++;
     }
@@ -2149,15 +1963,13 @@ void Fcat::PublishEl5042States()
   }
 }
 
-void Fcat::PublishIld1900States()
-{
+void Fcat::PublishIld1900States() {
   auto state_vec = device_type_vec_map_[fastcat::ILD1900_STATE];
   if (state_vec.size() > 0) {
     size_t index = 0;
 
     ild1900_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
-         state_ptr++) {
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++) {
       ild1900_states_msg_.names[index] = (*state_ptr)->name;
       ild1900_states_msg_.states[index] = Ild1900StateToMsg(*state_ptr);
       index++;
@@ -2166,15 +1978,13 @@ void Fcat::PublishIld1900States()
   }
 }
 
-void Fcat::PublishCommanderStates()
-{
+void Fcat::PublishCommanderStates() {
   auto state_vec = device_type_vec_map_[fastcat::COMMANDER_STATE];
   if (state_vec.size() > 0) {
     size_t index = 0;
 
     commander_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
-         state_ptr++) {
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++) {
       commander_states_msg_.names[index] = (*state_ptr)->name;
       commander_states_msg_.states[index] = CommanderStateToMsg(*state_ptr);
       index++;
@@ -2183,15 +1993,13 @@ void Fcat::PublishCommanderStates()
   }
 }
 
-void Fcat::PublishConditionalStates()
-{
+void Fcat::PublishConditionalStates() {
   auto state_vec = device_type_vec_map_[fastcat::CONDITIONAL_STATE];
   if (state_vec.size() > 0) {
     size_t index = 0;
 
     conditional_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
-         state_ptr++) {
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++) {
       conditional_states_msg_.names[index] = (*state_ptr)->name;
       conditional_states_msg_.states[index] = ConditionalStateToMsg(*state_ptr);
       index++;
@@ -2200,15 +2008,13 @@ void Fcat::PublishConditionalStates()
   }
 }
 
-void Fcat::PublishFaulterStates()
-{
+void Fcat::PublishFaulterStates() {
   auto state_vec = device_type_vec_map_[fastcat::FAULTER_STATE];
   if (state_vec.size() > 0) {
     size_t index = 0;
 
     faulter_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
-         state_ptr++) {
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++) {
       faulter_states_msg_.names[index] = (*state_ptr)->name;
       faulter_states_msg_.states[index] = FaulterStateToMsg(*state_ptr);
       index++;
@@ -2217,15 +2023,13 @@ void Fcat::PublishFaulterStates()
   }
 }
 
-void Fcat::PublishFilterStates()
-{
+void Fcat::PublishFilterStates() {
   auto state_vec = device_type_vec_map_[fastcat::FILTER_STATE];
   if (state_vec.size() > 0) {
     size_t index = 0;
 
     filter_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
-         state_ptr++) {
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++) {
       filter_states_msg_.names[index] = (*state_ptr)->name;
       filter_states_msg_.states[index] = FilterStateToMsg(*state_ptr);
       index++;
@@ -2234,15 +2038,13 @@ void Fcat::PublishFilterStates()
   }
 }
 
-void Fcat::PublishFunctionStates()
-{
+void Fcat::PublishFunctionStates() {
   auto state_vec = device_type_vec_map_[fastcat::FUNCTION_STATE];
   if (state_vec.size() > 0) {
     size_t index = 0;
 
     function_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
-         state_ptr++) {
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++) {
       function_states_msg_.names[index] = (*state_ptr)->name;
       function_states_msg_.states[index] = FunctionStateToMsg(*state_ptr);
       index++;
@@ -2251,15 +2053,13 @@ void Fcat::PublishFunctionStates()
   }
 }
 
-void Fcat::PublishPidStates()
-{
+void Fcat::PublishPidStates() {
   auto state_vec = device_type_vec_map_[fastcat::PID_STATE];
   if (state_vec.size() > 0) {
     size_t index = 0;
 
     pid_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
-         state_ptr++) {
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++) {
       pid_states_msg_.names[index] = (*state_ptr)->name;
       pid_states_msg_.states[index] = PidStateToMsg(*state_ptr);
       index++;
@@ -2268,15 +2068,13 @@ void Fcat::PublishPidStates()
   }
 }
 
-void Fcat::PublishSaturationStates()
-{
+void Fcat::PublishSaturationStates() {
   auto state_vec = device_type_vec_map_[fastcat::SATURATION_STATE];
   if (state_vec.size() > 0) {
     size_t index = 0;
 
     saturation_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
-         state_ptr++) {
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++) {
       saturation_states_msg_.names[index] = (*state_ptr)->name;
       saturation_states_msg_.states[index] = SaturationStateToMsg(*state_ptr);
       index++;
@@ -2285,54 +2083,45 @@ void Fcat::PublishSaturationStates()
   }
 }
 
-void Fcat::PublishSchmittTriggerStates()
-{
+void Fcat::PublishSchmittTriggerStates() {
   auto state_vec = device_type_vec_map_[fastcat::SCHMITT_TRIGGER_STATE];
   if (state_vec.size() > 0) {
     size_t index = 0;
 
     schmitt_trigger_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
-         state_ptr++) {
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++) {
       schmitt_trigger_states_msg_.names[index] = (*state_ptr)->name;
-      schmitt_trigger_states_msg_.states[index] =
-        SchmittTriggerStateToMsg(*state_ptr);
+      schmitt_trigger_states_msg_.states[index] = SchmittTriggerStateToMsg(*state_ptr);
       index++;
     }
     schmitt_trigger_pub_->publish(schmitt_trigger_states_msg_);
   }
 }
 
-void Fcat::PublishSignalGeneratorStates()
-{
+void Fcat::PublishSignalGeneratorStates() {
   auto state_vec = device_type_vec_map_[fastcat::SIGNAL_GENERATOR_STATE];
   if (state_vec.size() > 0) {
     size_t index = 0;
 
     signal_generator_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
-         state_ptr++) {
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++) {
       signal_generator_states_msg_.names[index] = (*state_ptr)->name;
-      signal_generator_states_msg_.states[index] =
-        SignalGeneratorStateToMsg(*state_ptr);
+      signal_generator_states_msg_.states[index] = SignalGeneratorStateToMsg(*state_ptr);
       index++;
     }
     signal_generator_pub_->publish(signal_generator_states_msg_);
   }
 }
 
-void Fcat::PublishLinearInterpolationStates()
-{
+void Fcat::PublishLinearInterpolationStates() {
   auto state_vec = device_type_vec_map_[fastcat::LINEAR_INTERPOLATION_STATE];
   if (state_vec.size() > 0) {
     size_t index = 0;
 
     linear_interpolation_states_msg_.header.stamp = publish_time_stamp_;
-    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end();
-         state_ptr++) {
+    for (auto state_ptr = state_vec.begin(); state_ptr != state_vec.end(); state_ptr++) {
       linear_interpolation_states_msg_.names[index] = (*state_ptr)->name;
-      linear_interpolation_states_msg_.states[index] =
-        LinearInterpolationStateToMsg(*state_ptr);
+      linear_interpolation_states_msg_.states[index] = LinearInterpolationStateToMsg(*state_ptr);
       index++;
     }
     linear_interpolation_pub_->publish(linear_interpolation_states_msg_);

--- a/src/fcat.hpp
+++ b/src/fcat.hpp
@@ -514,6 +514,7 @@ class Fcat : public casah_node::FaultInterface
   std::unordered_map<fastcat::DeviceStateType,
                      std::vector<std::shared_ptr<const fastcat::DeviceState>>>
     device_type_vec_map_;
+  std::vector<std::any> services_;
   std::vector<std::any> subscriptions_;
 
   double loop_period_sec_ = 0.0;

--- a/src/fcat.hpp
+++ b/src/fcat.hpp
@@ -1,7 +1,6 @@
 #ifndef FCAT__FCAT_HPP_
 #define FCAT__FCAT_HPP_
 
-#include "casah_node/evr_interface.hpp"
 #include "casah_node/fault_interface.hpp"
 
 #include "rclcpp/rclcpp.hpp"
@@ -96,7 +95,7 @@
 
 using WrenchPublisher = rclcpp::Publisher<geometry_msgs::msg::WrenchStamped>;
 
-class Fcat : public casah_node::FaultInterface, public casah_node::EvrInterface
+class Fcat : public casah_node::FaultInterface
 {
  public:
   ~Fcat();

--- a/src/fcat.hpp
+++ b/src/fcat.hpp
@@ -3,6 +3,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 
+#include <any>
 #include <sys/time.h>
 #include <functional>
 #include <memory>
@@ -90,6 +91,7 @@
 #include "fcat_msgs/msg/module_state.hpp"
 
 #include "fcat/fcat_utils.hpp"
+#include "fcat/fcat_node.hpp"
 
 using WrenchPublisher = rclcpp::Publisher<geometry_msgs::msg::WrenchStamped>;
 
@@ -179,8 +181,8 @@ class Fcat : public FcatNode
   /////// Topic Callbacks //////////
   /////////////////////////////////////
 
-  void ResetCmdCb(const std::shared_ptr<std_msgs::msg::Empty> msg) override;
-  void FaultCmdCb(const std::shared_ptr<std_msgs::msg::Empty> msg) override;
+  void ResetCmdCb(const std::shared_ptr<std_msgs::msg::Empty> msg);
+  void FaultCmdCb(const std::shared_ptr<std_msgs::msg::Empty> msg);
 
   void AsyncSdoReadCmdCb(
     const std::shared_ptr<fcat_msgs::msg::AsyncSdoReadCmd> msg);
@@ -327,11 +329,11 @@ class Fcat : public FcatNode
 
   void ResetSrvCb(
     const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-    std::shared_ptr<std_srvs::srv::Trigger::Response> response) override;
+    std::shared_ptr<std_srvs::srv::Trigger::Response> response);
 
   void FaultSrvCb(
     const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-    std::shared_ptr<std_srvs::srv::Trigger::Response> response) override;
+    std::shared_ptr<std_srvs::srv::Trigger::Response> response);
 
   void ActuatorHaltSrvCb(
     const std::shared_ptr<fcat_msgs::srv::ActuatorHaltService::Request> request,
@@ -564,5 +566,8 @@ class Fcat : public FcatNode
     three_node_thermal_model_states_msg_;
 
   size_t command_queue_size_ = 0;
+  bool reset_in_progress_ = false;
+  std::vector<rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr>
+    param_cb_handles_;
 };
 #endif

--- a/src/fcat.hpp
+++ b/src/fcat.hpp
@@ -1,10 +1,9 @@
 #ifndef FCAT__FCAT_HPP_
 #define FCAT__FCAT_HPP_
 
-#include "rclcpp/rclcpp.hpp"
+#include <sys/time.h>
 
 #include <any>
-#include <sys/time.h>
 #include <functional>
 #include <memory>
 #include <string>
@@ -12,6 +11,7 @@
 
 #include "fastcat/fastcat.h"
 #include "jsd/jsd_print.h"
+#include "rclcpp/rclcpp.hpp"
 
 // Standard Messages
 #include "geometry_msgs/msg/wrench_stamped.hpp"
@@ -35,10 +35,10 @@
 #include "fcat_msgs/srv/device_trigger_service.hpp"
 #include "fcat_msgs/srv/el2124_write_all_channels_service.hpp"
 #include "fcat_msgs/srv/el2124_write_channel_service.hpp"
-#include "fcat_msgs/srv/el2809_write_all_channels_service.hpp"
-#include "fcat_msgs/srv/el2809_write_channel_service.hpp"
 #include "fcat_msgs/srv/el2798_write_all_channels_service.hpp"
 #include "fcat_msgs/srv/el2798_write_channel_service.hpp"
+#include "fcat_msgs/srv/el2809_write_all_channels_service.hpp"
+#include "fcat_msgs/srv/el2809_write_channel_service.hpp"
 #include "fcat_msgs/srv/el2828_write_all_channels_service.hpp"
 #include "fcat_msgs/srv/el2828_write_channel_service.hpp"
 #include "fcat_msgs/srv/el4102_write_all_channels_service.hpp"
@@ -47,9 +47,6 @@
 #include "fcat_msgs/srv/pid_activate_service.hpp"
 
 // Cmd Messages
-#include "fcat_msgs/msg/async_sdo_read_cmd.hpp"
-#include "fcat_msgs/msg/async_sdo_write_cmd.hpp"
-
 #include "fcat_msgs/msg/actuator_calibrate_cmd.hpp"
 #include "fcat_msgs/msg/actuator_csp_cmd.hpp"
 #include "fcat_msgs/msg/actuator_csp_cmds.hpp"
@@ -68,16 +65,16 @@
 #include "fcat_msgs/msg/actuator_set_output_position_cmd.hpp"
 #include "fcat_msgs/msg/actuator_set_prof_disengaging_timeout_cmd.hpp"
 #include "fcat_msgs/msg/actuator_set_unit_mode_cmd.hpp"
-
+#include "fcat_msgs/msg/async_sdo_read_cmd.hpp"
+#include "fcat_msgs/msg/async_sdo_write_cmd.hpp"
 #include "fcat_msgs/msg/commander_disable_cmd.hpp"
 #include "fcat_msgs/msg/commander_enable_cmd.hpp"
-
 #include "fcat_msgs/msg/el2124_write_all_channels_cmd.hpp"
 #include "fcat_msgs/msg/el2124_write_channel_cmd.hpp"
-#include "fcat_msgs/msg/el2809_write_all_channels_cmd.hpp"
-#include "fcat_msgs/msg/el2809_write_channel_cmd.hpp"
 #include "fcat_msgs/msg/el2798_write_all_channels_cmd.hpp"
 #include "fcat_msgs/msg/el2798_write_channel_cmd.hpp"
+#include "fcat_msgs/msg/el2809_write_all_channels_cmd.hpp"
+#include "fcat_msgs/msg/el2809_write_channel_cmd.hpp"
 #include "fcat_msgs/msg/el2828_write_all_channels_cmd.hpp"
 #include "fcat_msgs/msg/el2828_write_channel_cmd.hpp"
 #include "fcat_msgs/msg/el4102_write_all_channels_cmd.hpp"
@@ -87,46 +84,37 @@
 #include "fcat_msgs/msg/pid_activate_cmd.hpp"
 
 // State Messages
+#include "fcat/fcat_node.hpp"
+#include "fcat/fcat_utils.hpp"
 #include "fcat_msgs/msg/async_sdo_response.hpp"
 #include "fcat_msgs/msg/module_state.hpp"
 
-#include "fcat/fcat_utils.hpp"
-#include "fcat/fcat_node.hpp"
-
 using WrenchPublisher = rclcpp::Publisher<geometry_msgs::msg::WrenchStamped>;
 
-class Fcat : public FcatNode
-{
+class Fcat : public FcatNode {
  public:
   ~Fcat();
   Fcat(const rclcpp::NodeOptions& options = rclcpp::NodeOptions());
-  rclcpp::CallbackGroup::SharedPtr get_process_loop_callback_group()
-  {
+  rclcpp::CallbackGroup::SharedPtr get_process_loop_callback_group() {
     return process_loop_callback_group_;
   }
-  rclcpp::CallbackGroup::SharedPtr get_topic_callback_group()
-  {
-    return topic_callback_group_;
-  }
+  rclcpp::CallbackGroup::SharedPtr get_topic_callback_group() { return topic_callback_group_; }
 
  private:
   void Process() override;
   void SetRealtimePreempt(int scheduler_priority);
   void PopulateDeviceStateFields();
   void SetCpuAffinity();
-  void InitializeActuatorParams(const std::vector<std::string>& actuator_names,
-                                int& i);
+  void InitializeActuatorParams(const std::vector<std::string>& actuator_names, int& i);
 
-  void QueueCommand(fastcat::DeviceCmd& cmd)
-  {
+  void QueueCommand(fastcat::DeviceCmd& cmd) {
     command_queue_size_++;
     fcat_manager_.QueueCommand(cmd);
   }
 
   bool ActuatorExistsOnBus(const std::string& name);
   bool ActuatorExistsOnBus(const std::string& name, std::string& error_message);
-  bool DeviceExistsOnBus(const std::string& name,
-                         fastcat::DeviceStateType type);
+  bool DeviceExistsOnBus(const std::string& name, fastcat::DeviceStateType type);
   bool DeviceExistsOnBus(const std::string& name, fastcat::DeviceStateType type,
                          std::string& error_message);
 
@@ -184,89 +172,62 @@ class Fcat : public FcatNode
   void ResetCmdCb(const std::shared_ptr<std_msgs::msg::Empty> msg);
   void FaultCmdCb(const std::shared_ptr<std_msgs::msg::Empty> msg);
 
-  void AsyncSdoReadCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::AsyncSdoReadCmd> msg);
-  void AsyncSdoWriteCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::AsyncSdoWriteCmd> msg);
+  void AsyncSdoReadCmdCb(const std::shared_ptr<fcat_msgs::msg::AsyncSdoReadCmd> msg);
+  void AsyncSdoWriteCmdCb(const std::shared_ptr<fcat_msgs::msg::AsyncSdoWriteCmd> msg);
 
-  void ActuatorCSPCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::ActuatorCspCmd> msg);
-  void ActuatorCSVCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::ActuatorCsvCmd> msg);
-  void ActuatorCSTCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::ActuatorCstCmd> msg);
-  void ActuatorCSPCmdsCb(
-    const std::shared_ptr<fcat_msgs::msg::ActuatorCspCmds> msg);
-  void ActuatorCSVCmdsCb(
-    const std::shared_ptr<fcat_msgs::msg::ActuatorCsvCmds> msg);
-  void ActuatorCSTCmdsCb(
-    const std::shared_ptr<fcat_msgs::msg::ActuatorCstCmds> msg);
-  void ActuatorCalibrateCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::ActuatorCalibrateCmd> msg);
-  void ActuatorProfPosCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::ActuatorProfPosCmd> msg);
-  void ActuatorProfTorqueCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::ActuatorProfTorqueCmd> msg);
-  void ActuatorProfVelCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::ActuatorProfVelCmd> msg);
-  void ActuatorProfPosCmdsCb(
-    const std::shared_ptr<fcat_msgs::msg::ActuatorProfPosCmds> msg);
+  void ActuatorCSPCmdCb(const std::shared_ptr<fcat_msgs::msg::ActuatorCspCmd> msg);
+  void ActuatorCSVCmdCb(const std::shared_ptr<fcat_msgs::msg::ActuatorCsvCmd> msg);
+  void ActuatorCSTCmdCb(const std::shared_ptr<fcat_msgs::msg::ActuatorCstCmd> msg);
+  void ActuatorCSPCmdsCb(const std::shared_ptr<fcat_msgs::msg::ActuatorCspCmds> msg);
+  void ActuatorCSVCmdsCb(const std::shared_ptr<fcat_msgs::msg::ActuatorCsvCmds> msg);
+  void ActuatorCSTCmdsCb(const std::shared_ptr<fcat_msgs::msg::ActuatorCstCmds> msg);
+  void ActuatorCalibrateCmdCb(const std::shared_ptr<fcat_msgs::msg::ActuatorCalibrateCmd> msg);
+  void ActuatorProfPosCmdCb(const std::shared_ptr<fcat_msgs::msg::ActuatorProfPosCmd> msg);
+  void ActuatorProfTorqueCmdCb(const std::shared_ptr<fcat_msgs::msg::ActuatorProfTorqueCmd> msg);
+  void ActuatorProfVelCmdCb(const std::shared_ptr<fcat_msgs::msg::ActuatorProfVelCmd> msg);
+  void ActuatorProfPosCmdsCb(const std::shared_ptr<fcat_msgs::msg::ActuatorProfPosCmds> msg);
   void ActuatorSetOutputPositionCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::ActuatorSetOutputPositionCmd> msg);
+      const std::shared_ptr<fcat_msgs::msg::ActuatorSetOutputPositionCmd> msg);
   void ActuatorSetDigitalOutputCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::ActuatorSetDigitalOutputCmd> msg);
+      const std::shared_ptr<fcat_msgs::msg::ActuatorSetDigitalOutputCmd> msg);
   void ActuatorSetMaxCurrentCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::ActuatorSetMaxCurrentCmd> msg);
-  void ActuatorSetUnitModeCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::ActuatorSetUnitModeCmd> msg);
+      const std::shared_ptr<fcat_msgs::msg::ActuatorSetMaxCurrentCmd> msg);
+  void ActuatorSetUnitModeCmdCb(const std::shared_ptr<fcat_msgs::msg::ActuatorSetUnitModeCmd> msg);
   void ActuatorSetProfDisengagingTimeoutCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::ActuatorSetProfDisengagingTimeoutCmd>
-      msg);
-  void ActuatorHaltCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::ActuatorHaltCmd> msg);
-  void ActuatorHaltCmdsCb(
-    const std::shared_ptr<fcat_msgs::msg::ActuatorHaltCmds> msg);
+      const std::shared_ptr<fcat_msgs::msg::ActuatorSetProfDisengagingTimeoutCmd> msg);
+  void ActuatorHaltCmdCb(const std::shared_ptr<fcat_msgs::msg::ActuatorHaltCmd> msg);
+  void ActuatorHaltCmdsCb(const std::shared_ptr<fcat_msgs::msg::ActuatorHaltCmds> msg);
 
-  void CommanderEnableCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::CommanderEnableCmd> msg);
-  void CommanderDisableCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::CommanderDisableCmd> msg);
+  void CommanderEnableCmdCb(const std::shared_ptr<fcat_msgs::msg::CommanderEnableCmd> msg);
+  void CommanderDisableCmdCb(const std::shared_ptr<fcat_msgs::msg::CommanderDisableCmd> msg);
 
   void El2124WriteAllChannelsCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::El2124WriteAllChannelsCmd> msg);
-  void El2124WriteChannelCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::El2124WriteChannelCmd> msg);
+      const std::shared_ptr<fcat_msgs::msg::El2124WriteAllChannelsCmd> msg);
+  void El2124WriteChannelCmdCb(const std::shared_ptr<fcat_msgs::msg::El2124WriteChannelCmd> msg);
 
   void El2809WriteAllChannelsCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::El2809WriteAllChannelsCmd> msg);
-  void El2809WriteChannelCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::El2809WriteChannelCmd> msg);
-  
+      const std::shared_ptr<fcat_msgs::msg::El2809WriteAllChannelsCmd> msg);
+  void El2809WriteChannelCmdCb(const std::shared_ptr<fcat_msgs::msg::El2809WriteChannelCmd> msg);
+
   void El2828WriteAllChannelsCmdCb(
       const std::shared_ptr<fcat_msgs::msg::El2828WriteAllChannelsCmd> msg);
-  void El2828WriteChannelCmdCb(
-      const std::shared_ptr<fcat_msgs::msg::El2828WriteChannelCmd> msg);
+  void El2828WriteChannelCmdCb(const std::shared_ptr<fcat_msgs::msg::El2828WriteChannelCmd> msg);
 
   void El2798WriteAllChannelsCmdCb(
       const std::shared_ptr<fcat_msgs::msg::El2798WriteAllChannelsCmd> msg);
-  void El2798WriteChannelCmdCb(
-      const std::shared_ptr<fcat_msgs::msg::El2798WriteChannelCmd> msg);
+  void El2798WriteChannelCmdCb(const std::shared_ptr<fcat_msgs::msg::El2798WriteChannelCmd> msg);
 
   void El4102WriteAllChannelsCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::El4102WriteAllChannelsCmd> msg);
-  void El4102WriteChannelCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::El4102WriteChannelCmd> msg);
+      const std::shared_ptr<fcat_msgs::msg::El4102WriteAllChannelsCmd> msg);
+  void El4102WriteChannelCmdCb(const std::shared_ptr<fcat_msgs::msg::El4102WriteChannelCmd> msg);
 
-  void FaulterEnableCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::FaulterEnableCmd> msg);
+  void FaulterEnableCmdCb(const std::shared_ptr<fcat_msgs::msg::FaulterEnableCmd> msg);
 
   void FtsTareCmdCb(const std::shared_ptr<fcat_msgs::msg::FtsTareCmd> msg);
 
-  void PidActivateCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::PidActivateCmd> msg);
+  void PidActivateCmdCb(const std::shared_ptr<fcat_msgs::msg::PidActivateCmd> msg);
 
-  rcl_interfaces::msg::SetParametersResult SetParametersCb(
-    const std::vector<rclcpp::Parameter>&);
+  rcl_interfaces::msg::SetParametersResult SetParametersCb(const std::vector<rclcpp::Parameter>&);
 
   ////////////////
   // Publishers //
@@ -278,8 +239,7 @@ class Fcat : public FcatNode
 
   rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr joint_state_pub_;
   rclcpp::Publisher<fcat_msgs::msg::ModuleState>::SharedPtr module_state_pub_;
-  rclcpp::Publisher<fcat_msgs::msg::AsyncSdoResponse>::SharedPtr
-    async_sdo_response_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::AsyncSdoResponse>::SharedPtr async_sdo_response_pub_;
 
   rclcpp::Publisher<fcat_msgs::msg::ActuatorStates>::SharedPtr actuator_pub_;
   rclcpp::Publisher<fcat_msgs::msg::EgdStates>::SharedPtr egd_pub_;
@@ -299,193 +259,132 @@ class Fcat : public FcatNode
   rclcpp::Publisher<fcat_msgs::msg::El5042States>::SharedPtr el5042_pub_;
   rclcpp::Publisher<fcat_msgs::msg::Ild1900States>::SharedPtr ild1900_pub_;
 
-  rclcpp::Publisher<fcat_msgs::msg::SaturationStates>::SharedPtr
-    saturation_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::SaturationStates>::SharedPtr saturation_pub_;
   rclcpp::Publisher<fcat_msgs::msg::FilterStates>::SharedPtr filter_pub_;
   rclcpp::Publisher<fcat_msgs::msg::PidStates>::SharedPtr pid_pub_;
   rclcpp::Publisher<fcat_msgs::msg::CommanderStates>::SharedPtr commander_pub_;
-  rclcpp::Publisher<fcat_msgs::msg::SignalGeneratorStates>::SharedPtr
-    signal_generator_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::SignalGeneratorStates>::SharedPtr signal_generator_pub_;
   rclcpp::Publisher<fcat_msgs::msg::FaulterStates>::SharedPtr faulter_pub_;
   rclcpp::Publisher<fcat_msgs::msg::FunctionStates>::SharedPtr function_pub_;
   rclcpp::Publisher<fcat_msgs::msg::FtsStates>::SharedPtr fts_pub_;
-  rclcpp::Publisher<fcat_msgs::msg::ConditionalStates>::SharedPtr
-    conditional_pub_;
-  rclcpp::Publisher<fcat_msgs::msg::SchmittTriggerStates>::SharedPtr
-    schmitt_trigger_pub_;
-  rclcpp::Publisher<fcat_msgs::msg::LinearInterpolationStates>::SharedPtr
-    linear_interpolation_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::ConditionalStates>::SharedPtr conditional_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::SchmittTriggerStates>::SharedPtr schmitt_trigger_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::LinearInterpolationStates>::SharedPtr linear_interpolation_pub_;
   rclcpp::Publisher<fcat_msgs::msg::ThreeNodeThermalModelStates>::SharedPtr
-    three_node_thermal_model_pub_;
+      three_node_thermal_model_pub_;
 
   std::unordered_map<std::string, WrenchPublisher::SharedPtr> fts_raw_pub_map_;
-  std::unordered_map<std::string, WrenchPublisher::SharedPtr>
-    fts_tared_pub_map_;
+  std::unordered_map<std::string, WrenchPublisher::SharedPtr> fts_tared_pub_map_;
 
   rclcpp::TimerBase::SharedPtr process_timer_ = nullptr;
   ///////////////////////
   // Service Callbacks //
   ///////////////////////
 
-  void ResetSrvCb(
-    const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-    std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+  void ResetSrvCb(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                  std::shared_ptr<std_srvs::srv::Trigger::Response> response);
 
-  void FaultSrvCb(
-    const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-    std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+  void FaultSrvCb(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                  std::shared_ptr<std_srvs::srv::Trigger::Response> response);
 
   void ActuatorHaltSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::ActuatorHaltService::Request> request,
-    std::shared_ptr<fcat_msgs::srv::ActuatorHaltService::Response> response);
+      const std::shared_ptr<fcat_msgs::srv::ActuatorHaltService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::ActuatorHaltService::Response> response);
 
   void ActuatorSetGainSchedulingIndexSrvCb(
-    const std::shared_ptr<
-      fcat_msgs::srv::ActuatorSetGainSchedulingIndexService::Request>
-      request,
-    std::shared_ptr<
-      fcat_msgs::srv::ActuatorSetGainSchedulingIndexService::Response>
-      response);
+      const std::shared_ptr<fcat_msgs::srv::ActuatorSetGainSchedulingIndexService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::ActuatorSetGainSchedulingIndexService::Response> response);
 
   void ActuatorSetMaxCurrentSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::ActuatorSetMaxCurrentService::Request>
-      request,
-    std::shared_ptr<fcat_msgs::srv::ActuatorSetMaxCurrentService::Response>
-      response);
+      const std::shared_ptr<fcat_msgs::srv::ActuatorSetMaxCurrentService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::ActuatorSetMaxCurrentService::Response> response);
 
   void ActuatorSetOutputPositionSrvCb(
-    const std::shared_ptr<
-      fcat_msgs::srv::ActuatorSetOutputPositionService::Request>
-      request,
-    std::shared_ptr<fcat_msgs::srv::ActuatorSetOutputPositionService::Response>
-      response);
+      const std::shared_ptr<fcat_msgs::srv::ActuatorSetOutputPositionService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::ActuatorSetOutputPositionService::Response> response);
 
   void ActuatorSetDigitalOutputSrvCb(
-    const std::shared_ptr<
-      fcat_msgs::srv::ActuatorSetDigitalOutputService::Request>
-      request,
-    std::shared_ptr<fcat_msgs::srv::ActuatorSetDigitalOutputService::Response>
-      response);
+      const std::shared_ptr<fcat_msgs::srv::ActuatorSetDigitalOutputService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::ActuatorSetDigitalOutputService::Response> response);
 
   void ActuatorSetProfDisengagingTimeoutSrvCb(
-    const std::shared_ptr<
-      fcat_msgs::srv::ActuatorSetProfDisengagingTimeoutService::Request>
-      request,
-    std::shared_ptr<
-      fcat_msgs::srv::ActuatorSetProfDisengagingTimeoutService::Response>
-      response);
+      const std::shared_ptr<fcat_msgs::srv::ActuatorSetProfDisengagingTimeoutService::Request>
+          request,
+      std::shared_ptr<fcat_msgs::srv::ActuatorSetProfDisengagingTimeoutService::Response> response);
 
   void ActuatorCalibrateSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateService::Request>
-      request,
-    std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateService::Response>
-      response);
+      const std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateService::Response> response);
 
   void ActuatorProfPosSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::ActuatorProfPosService::Request>
-      request,
-    std::shared_ptr<fcat_msgs::srv::ActuatorProfPosService::Response> response);
+      const std::shared_ptr<fcat_msgs::srv::ActuatorProfPosService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::ActuatorProfPosService::Response> response);
 
   void ActuatorProfVelSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::ActuatorProfVelService::Request>
-      request,
-    std::shared_ptr<fcat_msgs::srv::ActuatorProfVelService::Response> response);
+      const std::shared_ptr<fcat_msgs::srv::ActuatorProfVelService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::ActuatorProfVelService::Response> response);
 
   void ActuatorProfTorqueSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueService::Request>
-      request,
-    std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueService::Response>
-      response);
+      const std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueService::Response> response);
 
   void CommanderEnableSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::CommanderEnableService::Request>
-      request,
-    std::shared_ptr<fcat_msgs::srv::CommanderEnableService::Response> response);
+      const std::shared_ptr<fcat_msgs::srv::CommanderEnableService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::CommanderEnableService::Response> response);
 
   void CommanderDisableSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::CommanderDisableService::Request>
-      request,
-    std::shared_ptr<fcat_msgs::srv::CommanderDisableService::Response>
-      response);
+      const std::shared_ptr<fcat_msgs::srv::CommanderDisableService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::CommanderDisableService::Response> response);
 
   void El2124WriteAllChannelsSrvCb(
-    const std::shared_ptr<
-      fcat_msgs::srv::El2124WriteAllChannelsService::Request>
-      request,
-    std::shared_ptr<fcat_msgs::srv::El2124WriteAllChannelsService::Response>
-      response);
+      const std::shared_ptr<fcat_msgs::srv::El2124WriteAllChannelsService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::El2124WriteAllChannelsService::Response> response);
 
   void El2124WriteChannelSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::El2124WriteChannelService::Request>
-      request,
-    std::shared_ptr<fcat_msgs::srv::El2124WriteChannelService::Response>
-      response);
+      const std::shared_ptr<fcat_msgs::srv::El2124WriteChannelService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::El2124WriteChannelService::Response> response);
 
   void El2809WriteAllChannelsSrvCb(
-    const std::shared_ptr<
-      fcat_msgs::srv::El2809WriteAllChannelsService::Request>
-      request,
-    std::shared_ptr<fcat_msgs::srv::El2809WriteAllChannelsService::Response>
-      response);
+      const std::shared_ptr<fcat_msgs::srv::El2809WriteAllChannelsService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::El2809WriteAllChannelsService::Response> response);
 
   void El2809WriteChannelSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::El2809WriteChannelService::Request>
-      request,
-    std::shared_ptr<fcat_msgs::srv::El2809WriteChannelService::Response>
-      response);
+      const std::shared_ptr<fcat_msgs::srv::El2809WriteChannelService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::El2809WriteChannelService::Response> response);
 
   void El2798WriteAllChannelsSrvCb(
-      const std::shared_ptr<
-          fcat_msgs::srv::El2798WriteAllChannelsService::Request>
-          request,
-      std::shared_ptr<fcat_msgs::srv::El2798WriteAllChannelsService::Response>
-          response);
+      const std::shared_ptr<fcat_msgs::srv::El2798WriteAllChannelsService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::El2798WriteAllChannelsService::Response> response);
 
   void El2798WriteChannelSrvCb(
-      const std::shared_ptr<fcat_msgs::srv::El2798WriteChannelService::Request>
-          request,
-      std::shared_ptr<fcat_msgs::srv::El2798WriteChannelService::Response>
-          response);
+      const std::shared_ptr<fcat_msgs::srv::El2798WriteChannelService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::El2798WriteChannelService::Response> response);
 
   void El2828WriteAllChannelsSrvCb(
-      const std::shared_ptr<
-          fcat_msgs::srv::El2828WriteAllChannelsService::Request>
-          request,
-      std::shared_ptr<fcat_msgs::srv::El2828WriteAllChannelsService::Response>
-          response);
+      const std::shared_ptr<fcat_msgs::srv::El2828WriteAllChannelsService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::El2828WriteAllChannelsService::Response> response);
 
   void El2828WriteChannelSrvCb(
-      const std::shared_ptr<fcat_msgs::srv::El2828WriteChannelService::Request>
-          request,
-      std::shared_ptr<fcat_msgs::srv::El2828WriteChannelService::Response>
-          response);
+      const std::shared_ptr<fcat_msgs::srv::El2828WriteChannelService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::El2828WriteChannelService::Response> response);
 
   void El4102WriteAllChannelsSrvCb(
-    const std::shared_ptr<
-      fcat_msgs::srv::El4102WriteAllChannelsService::Request>
-      request,
-    std::shared_ptr<fcat_msgs::srv::El4102WriteAllChannelsService::Response>
-      response);
+      const std::shared_ptr<fcat_msgs::srv::El4102WriteAllChannelsService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::El4102WriteAllChannelsService::Response> response);
 
   void El4102WriteChannelSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::El4102WriteChannelService::Request>
-      request,
-    std::shared_ptr<fcat_msgs::srv::El4102WriteChannelService::Response>
-      response);
+      const std::shared_ptr<fcat_msgs::srv::El4102WriteChannelService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::El4102WriteChannelService::Response> response);
 
   void FaulterEnableSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::FaulterEnableService::Request>
-      request,
-    std::shared_ptr<fcat_msgs::srv::FaulterEnableService::Response> response);
+      const std::shared_ptr<fcat_msgs::srv::FaulterEnableService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::FaulterEnableService::Response> response);
 
-  void FtsTareSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::DeviceTriggerService::Request>
-      request,
-    std::shared_ptr<fcat_msgs::srv::DeviceTriggerService::Response> response);
+  void FtsTareSrvCb(const std::shared_ptr<fcat_msgs::srv::DeviceTriggerService::Request> request,
+                    std::shared_ptr<fcat_msgs::srv::DeviceTriggerService::Response> response);
 
-  void PidActivateSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::PidActivateService::Request> request,
-    std::shared_ptr<fcat_msgs::srv::PidActivateService::Response> response);
+  void PidActivateSrvCb(const std::shared_ptr<fcat_msgs::srv::PidActivateService::Request> request,
+                        std::shared_ptr<fcat_msgs::srv::PidActivateService::Response> response);
 
   rclcpp::CallbackGroup::SharedPtr process_loop_callback_group_;
   rclcpp::CallbackGroup::SharedPtr topic_callback_group_;
@@ -502,17 +401,17 @@ class Fcat : public FcatNode
 
   bool fault_on_cycle_slip_ = true;
   double cycle_slip_fault_magnitude_ = 3.0;
-  
+
   ////////////
   // fields //
   ////////////
 
   std::vector<std::shared_ptr<const fastcat::DeviceState>> device_state_ptrs_;
   std::unordered_map<std::string, std::shared_ptr<const fastcat::DeviceState>>
-    device_name_state_map_;
+      device_name_state_map_;
   std::unordered_map<fastcat::DeviceStateType,
                      std::vector<std::shared_ptr<const fastcat::DeviceState>>>
-    device_type_vec_map_;
+      device_type_vec_map_;
   std::vector<std::any> services_;
   std::vector<std::any> subscriptions_;
 
@@ -562,12 +461,10 @@ class Fcat : public FcatNode
   fcat_msgs::msg::SchmittTriggerStates schmitt_trigger_states_msg_;
   fcat_msgs::msg::SignalGeneratorStates signal_generator_states_msg_;
   fcat_msgs::msg::LinearInterpolationStates linear_interpolation_states_msg_;
-  fcat_msgs::msg::ThreeNodeThermalModelStates
-    three_node_thermal_model_states_msg_;
+  fcat_msgs::msg::ThreeNodeThermalModelStates three_node_thermal_model_states_msg_;
 
   size_t command_queue_size_ = 0;
   bool reset_in_progress_ = false;
-  std::vector<rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr>
-    param_cb_handles_;
+  std::vector<rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr> param_cb_handles_;
 };
 #endif

--- a/src/fcat.hpp
+++ b/src/fcat.hpp
@@ -1,8 +1,6 @@
 #ifndef FCAT__FCAT_HPP_
 #define FCAT__FCAT_HPP_
 
-#include "casah_node/fault_interface.hpp"
-
 #include "rclcpp/rclcpp.hpp"
 
 #include <sys/time.h>
@@ -95,7 +93,7 @@
 
 using WrenchPublisher = rclcpp::Publisher<geometry_msgs::msg::WrenchStamped>;
 
-class Fcat : public casah_node::FaultInterface
+class Fcat : public FcatNode
 {
  public:
   ~Fcat();
@@ -111,7 +109,6 @@ class Fcat : public casah_node::FaultInterface
 
  private:
   void Process() override;
-  void StartProcessTimer();
   void SetRealtimePreempt(int scheduler_priority);
   void PopulateDeviceStateFields();
   void SetCpuAffinity();

--- a/src/fcat.hpp
+++ b/src/fcat.hpp
@@ -1,148 +1,166 @@
-#ifndef FCAT_HPP_
-#define FCAT_HPP_
+#ifndef FCAT__FCAT_HPP_
+#define FCAT__FCAT_HPP_
+
+#include "casah_node/evr_interface.hpp"
+#include "casah_node/fault_interface.hpp"
 
 #include "rclcpp/rclcpp.hpp"
-#include "fcat/fcat_node.hpp"
 
+#include <sys/time.h>
 #include <functional>
 #include <memory>
 #include <string>
 #include <unordered_map>
-#include <sys/time.h>
 
 #include "fastcat/fastcat.h"
 #include "jsd/jsd_print.h"
 
 // Standard Messages
-#include "std_msgs/msg/empty.hpp"
+#include "geometry_msgs/msg/wrench_stamped.hpp"
 #include "sensor_msgs/msg/joint_state.hpp"
-#include "geometry_msgs/msg/wrench.hpp"
+#include "std_msgs/msg/empty.hpp"
+#include "std_srvs/srv/trigger.hpp"
+
+// Instant Response services
+#include "fcat_msgs/srv/actuator_calibrate_service.hpp"
+#include "fcat_msgs/srv/actuator_halt_service.hpp"
+#include "fcat_msgs/srv/actuator_prof_pos_service.hpp"
+#include "fcat_msgs/srv/actuator_prof_torque_service.hpp"
+#include "fcat_msgs/srv/actuator_prof_vel_service.hpp"
+#include "fcat_msgs/srv/actuator_set_digital_output_service.hpp"
+#include "fcat_msgs/srv/actuator_set_gain_scheduling_index_service.hpp"
+#include "fcat_msgs/srv/actuator_set_max_current_service.hpp"
+#include "fcat_msgs/srv/actuator_set_output_position_service.hpp"
+#include "fcat_msgs/srv/actuator_set_prof_disengaging_timeout_service.hpp"
+#include "fcat_msgs/srv/commander_disable_service.hpp"
+#include "fcat_msgs/srv/commander_enable_service.hpp"
+#include "fcat_msgs/srv/device_trigger_service.hpp"
+#include "fcat_msgs/srv/el2124_write_all_channels_service.hpp"
+#include "fcat_msgs/srv/el2124_write_channel_service.hpp"
+#include "fcat_msgs/srv/el2809_write_all_channels_service.hpp"
+#include "fcat_msgs/srv/el2809_write_channel_service.hpp"
+#include "fcat_msgs/srv/el2798_write_all_channels_service.hpp"
+#include "fcat_msgs/srv/el2798_write_channel_service.hpp"
+#include "fcat_msgs/srv/el2828_write_all_channels_service.hpp"
+#include "fcat_msgs/srv/el2828_write_channel_service.hpp"
+#include "fcat_msgs/srv/el4102_write_all_channels_service.hpp"
+#include "fcat_msgs/srv/el4102_write_channel_service.hpp"
+#include "fcat_msgs/srv/faulter_enable_service.hpp"
+#include "fcat_msgs/srv/pid_activate_service.hpp"
 
 // Cmd Messages
+#include "fcat_msgs/msg/async_sdo_read_cmd.hpp"
+#include "fcat_msgs/msg/async_sdo_write_cmd.hpp"
+
 #include "fcat_msgs/msg/actuator_calibrate_cmd.hpp"
 #include "fcat_msgs/msg/actuator_csp_cmd.hpp"
+#include "fcat_msgs/msg/actuator_csp_cmds.hpp"
 #include "fcat_msgs/msg/actuator_cst_cmd.hpp"
+#include "fcat_msgs/msg/actuator_cst_cmds.hpp"
 #include "fcat_msgs/msg/actuator_csv_cmd.hpp"
+#include "fcat_msgs/msg/actuator_csv_cmds.hpp"
+#include "fcat_msgs/msg/actuator_halt_cmd.hpp"
+#include "fcat_msgs/msg/actuator_halt_cmds.hpp"
 #include "fcat_msgs/msg/actuator_prof_pos_cmd.hpp"
+#include "fcat_msgs/msg/actuator_prof_pos_cmds.hpp"
 #include "fcat_msgs/msg/actuator_prof_torque_cmd.hpp"
 #include "fcat_msgs/msg/actuator_prof_vel_cmd.hpp"
+#include "fcat_msgs/msg/actuator_set_digital_output_cmd.hpp"
+#include "fcat_msgs/msg/actuator_set_max_current_cmd.hpp"
 #include "fcat_msgs/msg/actuator_set_output_position_cmd.hpp"
+#include "fcat_msgs/msg/actuator_set_prof_disengaging_timeout_cmd.hpp"
+#include "fcat_msgs/msg/actuator_set_unit_mode_cmd.hpp"
 
-#include "fcat_msgs/msg/commander_enable_cmd.hpp"
 #include "fcat_msgs/msg/commander_disable_cmd.hpp"
+#include "fcat_msgs/msg/commander_enable_cmd.hpp"
 
 #include "fcat_msgs/msg/el2124_write_all_channels_cmd.hpp"
 #include "fcat_msgs/msg/el2124_write_channel_cmd.hpp"
+#include "fcat_msgs/msg/el2809_write_all_channels_cmd.hpp"
+#include "fcat_msgs/msg/el2809_write_channel_cmd.hpp"
+#include "fcat_msgs/msg/el2798_write_all_channels_cmd.hpp"
+#include "fcat_msgs/msg/el2798_write_channel_cmd.hpp"
+#include "fcat_msgs/msg/el2828_write_all_channels_cmd.hpp"
+#include "fcat_msgs/msg/el2828_write_channel_cmd.hpp"
+#include "fcat_msgs/msg/el4102_write_all_channels_cmd.hpp"
+#include "fcat_msgs/msg/el4102_write_channel_cmd.hpp"
 #include "fcat_msgs/msg/faulter_enable_cmd.hpp"
 #include "fcat_msgs/msg/fts_tare_cmd.hpp"
-#include "fcat_msgs/msg/jed_set_cmd_value_cmd.hpp"
 #include "fcat_msgs/msg/pid_activate_cmd.hpp"
 
-
 // State Messages
+#include "fcat_msgs/msg/async_sdo_response.hpp"
 #include "fcat_msgs/msg/module_state.hpp"
 
-#include "fcat_msgs/msg/actuator_states.hpp"
-#include "fcat_msgs/msg/egd_states.hpp"
-#include "fcat_msgs/msg/el2124_states.hpp"
-#include "fcat_msgs/msg/el3208_states.hpp"
-#include "fcat_msgs/msg/el3602_states.hpp"
-#include "fcat_msgs/msg/jed_states.hpp"
+#include "fcat/fcat_utils.hpp"
 
-#include "fcat_msgs/msg/commander_states.hpp"
-#include "fcat_msgs/msg/conditional_states.hpp"
-#include "fcat_msgs/msg/faulter_states.hpp"
-#include "fcat_msgs/msg/filter_states.hpp"
-#include "fcat_msgs/msg/function_states.hpp"
-#include "fcat_msgs/msg/pid_states.hpp"
-#include "fcat_msgs/msg/saturation_states.hpp"
-#include "fcat_msgs/msg/schmitt_trigger_states.hpp"
-#include "fcat_msgs/msg/signal_generator_states.hpp"
+using WrenchPublisher = rclcpp::Publisher<geometry_msgs::msg::WrenchStamped>;
 
-const unsigned int FCAT_PUB_QUEUE_SIZE = 32;
-const unsigned int FCAT_SUB_QUEUE_SIZE = 32;
-
-using WrenchPublisher = rclcpp::Publisher<geometry_msgs::msg::Wrench>;
-
-inline double fcat_get_time_sec()
+class Fcat : public casah_node::FaultInterface, public casah_node::EvrInterface
 {
-  struct timeval tv;
-  gettimeofday(&tv, NULL);
-  return (double)tv.tv_sec + (double)tv.tv_usec / 1000000;
-}
-
-fcat_msgs::msg::ActuatorState ActuatorStateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state);
-
-fcat_msgs::msg::EgdState EgdStateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state);
-
-fcat_msgs::msg::El2124State El2124StateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state);
-
-fcat_msgs::msg::El3208State El3208StateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state);
-
-fcat_msgs::msg::El3602State El3602StateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state);
-
-fcat_msgs::msg::JedState JedStateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state);
-
-fcat_msgs::msg::CommanderState CommanderStateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state);
-
-fcat_msgs::msg::ConditionalState ConditionalStateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state);
-
-fcat_msgs::msg::FaulterState FaulterStateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state);
-
-fcat_msgs::msg::FilterState FilterStateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state);
-
-fcat_msgs::msg::FunctionState FunctionStateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state);
-
-fcat_msgs::msg::PidState PidStateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state);
-
-fcat_msgs::msg::SaturationState SaturationStateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state);
-
-fcat_msgs::msg::SchmittTriggerState SchmittTriggerStateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state);
-
-fcat_msgs::msg::SignalGeneratorState SignalGeneratorStateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state);
-
-
-class Fcat: public FcatNode {
-public:
+ public:
   ~Fcat();
-  Fcat();
+  Fcat(const rclcpp::NodeOptions& options = rclcpp::NodeOptions());
+  rclcpp::CallbackGroup::SharedPtr get_process_loop_callback_group()
+  {
+    return process_loop_callback_group_;
+  }
+  rclcpp::CallbackGroup::SharedPtr get_topic_callback_group()
+  {
+    return topic_callback_group_;
+  }
 
-private:
-
+ private:
   void Process() override;
-
+  void StartProcessTimer();
+  void SetRealtimePreempt(int scheduler_priority);
   void PopulateDeviceStateFields();
-  bool DeviceExistsOnBus(std::string name, fastcat::DeviceStateType type);
+  void SetCpuAffinity();
+  void InitializeActuatorParams(const std::vector<std::string>& actuator_names,
+                                int& i);
+
+  void QueueCommand(fastcat::DeviceCmd& cmd)
+  {
+    command_queue_size_++;
+    fcat_manager_.QueueCommand(cmd);
+  }
+
+  bool ActuatorExistsOnBus(const std::string& name);
+  bool ActuatorExistsOnBus(const std::string& name, std::string& error_message);
+  bool DeviceExistsOnBus(const std::string& name,
+                         fastcat::DeviceStateType type);
+  bool DeviceExistsOnBus(const std::string& name, fastcat::DeviceStateType type,
+                         std::string& error_message);
+
   bool TypeExistsOnBus(fastcat::DeviceStateType type);
   void InitializePublishersAndMessages();
   void InitializeSubscribers();
+  void InitializeServices();
 
   void UpdateStateMap();
 
-  void PublishModuleState();
+  void PublishFcatModuleState();
+  void PublishAsyncSdoResponse();
+
   void PublishFtsStates();
 
   void PublishActuatorStates();
   void PublishEgdStates();
+  void PublishEl1008States();
   void PublishEl2124States();
+  void PublishEl2809States();
+  void PublishEl2798States();
+  void PublishEl2828States();
+  void PublishEl3104States();
+  void PublishEl3162States();
+  void PublishEl3202States();
   void PublishEl3208States();
+  void PublishEl3314States();
+  void PublishEl3318States();
   void PublishEl3602States();
-  void PublishJedStates();
+  void PublishEl4102States();
+  void PublishEl5042States();
+  void PublishIld1900States();
 
   void PublishCommanderStates();
   void PublishConditionalStates();
@@ -153,171 +171,401 @@ private:
   void PublishSaturationStates();
   void PublishSchmittTriggerStates();
   void PublishSignalGeneratorStates();
+  void PublishLinearInterpolationStates();
+  void PublishThreeNodeThermalModelStates();
+
+  void CallActuatorCSP(const fcat_msgs::msg::ActuatorCspCmd& csp_cmd, double t);
+  void CallActuatorCSV(const fcat_msgs::msg::ActuatorCsvCmd& csv_cmd);
+  void CallActuatorCST(const fcat_msgs::msg::ActuatorCstCmd& cst_cmd);
+  void CallActuatorProfPos(const fcat_msgs::msg::ActuatorProfPosCmd& prof_pos_cmd);
 
   /////////////////////////////////////
-  /////// Commands Callbacks //////////
+  /////// Topic Callbacks //////////
   /////////////////////////////////////
+
+  void ResetCmdCb(const std::shared_ptr<std_msgs::msg::Empty> msg) override;
+  void FaultCmdCb(const std::shared_ptr<std_msgs::msg::Empty> msg) override;
+
+  void AsyncSdoReadCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::AsyncSdoReadCmd> msg);
+  void AsyncSdoWriteCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::AsyncSdoWriteCmd> msg);
+
+  void ActuatorCSPCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::ActuatorCspCmd> msg);
+  void ActuatorCSVCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::ActuatorCsvCmd> msg);
+  void ActuatorCSTCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::ActuatorCstCmd> msg);
+  void ActuatorCSPCmdsCb(
+    const std::shared_ptr<fcat_msgs::msg::ActuatorCspCmds> msg);
+  void ActuatorCSVCmdsCb(
+    const std::shared_ptr<fcat_msgs::msg::ActuatorCsvCmds> msg);
+  void ActuatorCSTCmdsCb(
+    const std::shared_ptr<fcat_msgs::msg::ActuatorCstCmds> msg);
+  void ActuatorCalibrateCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::ActuatorCalibrateCmd> msg);
+  void ActuatorProfPosCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::ActuatorProfPosCmd> msg);
+  void ActuatorProfTorqueCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::ActuatorProfTorqueCmd> msg);
+  void ActuatorProfVelCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::ActuatorProfVelCmd> msg);
+  void ActuatorProfPosCmdsCb(
+    const std::shared_ptr<fcat_msgs::msg::ActuatorProfPosCmds> msg);
+  void ActuatorSetOutputPositionCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::ActuatorSetOutputPositionCmd> msg);
+  void ActuatorSetDigitalOutputCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::ActuatorSetDigitalOutputCmd> msg);
+  void ActuatorSetMaxCurrentCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::ActuatorSetMaxCurrentCmd> msg);
+  void ActuatorSetUnitModeCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::ActuatorSetUnitModeCmd> msg);
+  void ActuatorSetProfDisengagingTimeoutCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::ActuatorSetProfDisengagingTimeoutCmd>
+      msg);
+  void ActuatorHaltCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::ActuatorHaltCmd> msg);
+  void ActuatorHaltCmdsCb(
+    const std::shared_ptr<fcat_msgs::msg::ActuatorHaltCmds> msg);
+
+  void CommanderEnableCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::CommanderEnableCmd> msg);
+  void CommanderDisableCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::CommanderDisableCmd> msg);
+
+  void El2124WriteAllChannelsCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::El2124WriteAllChannelsCmd> msg);
+  void El2124WriteChannelCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::El2124WriteChannelCmd> msg);
+
+  void El2809WriteAllChannelsCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::El2809WriteAllChannelsCmd> msg);
+  void El2809WriteChannelCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::El2809WriteChannelCmd> msg);
   
-  // bus reset/fault
-  void ResetCb( const std::shared_ptr<std_msgs::msg::Empty> msg);
-  void FaultCb( const std::shared_ptr<std_msgs::msg::Empty> msg);
+  void El2828WriteAllChannelsCmdCb(
+      const std::shared_ptr<fcat_msgs::msg::El2828WriteAllChannelsCmd> msg);
+  void El2828WriteChannelCmdCb(
+      const std::shared_ptr<fcat_msgs::msg::El2828WriteChannelCmd> msg);
 
-  // Actuator
-  void ActuatorCSPCmdCb( const std::shared_ptr<fcat_msgs::msg::ActuatorCspCmd> msg);
-  void ActuatorCSVCmdCb( const std::shared_ptr<fcat_msgs::msg::ActuatorCsvCmd> msg);
-  void ActuatorCSTCmdCb( const std::shared_ptr<fcat_msgs::msg::ActuatorCstCmd> msg);
+  void El2798WriteAllChannelsCmdCb(
+      const std::shared_ptr<fcat_msgs::msg::El2798WriteAllChannelsCmd> msg);
+  void El2798WriteChannelCmdCb(
+      const std::shared_ptr<fcat_msgs::msg::El2798WriteChannelCmd> msg);
 
-  void ActuatorCalibrateCmdCb( 
-      const std::shared_ptr<fcat_msgs::msg::ActuatorCalibrateCmd> msg);
+  void El4102WriteAllChannelsCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::El4102WriteAllChannelsCmd> msg);
+  void El4102WriteChannelCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::El4102WriteChannelCmd> msg);
 
-  void ActuatorProfPosCmdCb( 
-      const std::shared_ptr<fcat_msgs::msg::ActuatorProfPosCmd> msg);
-  void ActuatorProfTorqueCmdCb( 
-      const std::shared_ptr<fcat_msgs::msg::ActuatorProfTorqueCmd> msg);
-  void ActuatorProfVelCmdCb( 
-      const std::shared_ptr<fcat_msgs::msg::ActuatorProfVelCmd> msg);
+  void FaulterEnableCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::FaulterEnableCmd> msg);
 
-  void ActuatorSetOutputPositionCmdCb( 
-      const std::shared_ptr<fcat_msgs::msg::ActuatorSetOutputPositionCmd> msg);
+  void FtsTareCmdCb(const std::shared_ptr<fcat_msgs::msg::FtsTareCmd> msg);
 
-  // Commander
-  void CommanderEnableCmdCb( 
-      const std::shared_ptr<fcat_msgs::msg::CommanderEnableCmd> msg);
-  void CommanderDisableCmdCb( 
-      const std::shared_ptr<fcat_msgs::msg::CommanderDisableCmd> msg);
+  void PidActivateCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::PidActivateCmd> msg);
 
-  // El2124
-  void El2124WriteAllChannelsCmdCb( 
-      const std::shared_ptr<fcat_msgs::msg::El2124WriteAllChannelsCmd> msg);
-  void El2124WriteChannelCmdCb( 
-      const std::shared_ptr<fcat_msgs::msg::El2124WriteChannelCmd> msg);
+  rcl_interfaces::msg::SetParametersResult SetParametersCb(
+    const std::vector<rclcpp::Parameter>&);
 
-  // Faulter
-  void FaulterEnableCmdCb( const std::shared_ptr<fcat_msgs::msg::FaulterEnableCmd> msg);
-
-  // Fts
-  void FtsTareCmdCb( const std::shared_ptr<fcat_msgs::msg::FtsTareCmd> msg);
-
-  // Jed
-  void JedSetCmdValueCmdCb( const std::shared_ptr<fcat_msgs::msg::JedSetCmdValueCmd> msg);
-
-  // Pid
-  void PidActivateCmdCb( const std::shared_ptr<fcat_msgs::msg::PidActivateCmd> msg);
-
-  //////////////////////////
-  // Topic Subscriptions //
-  //////////////////////////
-  
-  // bus reset/fault
-  rclcpp::Subscription<std_msgs::msg::Empty>::SharedPtr reset_sub_;
-  rclcpp::Subscription<std_msgs::msg::Empty>::SharedPtr fault_sub_;
- 
-  // Actuator
-  rclcpp::Subscription<fcat_msgs::msg::ActuatorCspCmd>::SharedPtr actuator_csp_sub_;
-  rclcpp::Subscription<fcat_msgs::msg::ActuatorCsvCmd>::SharedPtr actuator_csv_sub_;
-  rclcpp::Subscription<fcat_msgs::msg::ActuatorCstCmd>::SharedPtr actuator_cst_sub_;
-
-  rclcpp::Subscription<fcat_msgs::msg::ActuatorCalibrateCmd>::SharedPtr 
-    actuator_calibrate_sub_;
-
-  rclcpp::Subscription<fcat_msgs::msg::ActuatorProfPosCmd>::SharedPtr 
-    actuator_prof_pos_sub_;
-  rclcpp::Subscription<fcat_msgs::msg::ActuatorProfTorqueCmd>::SharedPtr 
-    actuator_prof_torque_sub_;
-  rclcpp::Subscription<fcat_msgs::msg::ActuatorProfVelCmd>::SharedPtr 
-    actuator_prof_vel_sub_;
-
-  rclcpp::Subscription<fcat_msgs::msg::ActuatorSetOutputPositionCmd>::SharedPtr 
-    actuator_set_output_position_sub_;
-
-  // Commander
-  rclcpp::Subscription<fcat_msgs::msg::CommanderEnableCmd>::SharedPtr  commander_enable_sub_;
-  rclcpp::Subscription<fcat_msgs::msg::CommanderDisableCmd>::SharedPtr commander_disable_sub_;
-
-  // El2124
-  rclcpp::Subscription<fcat_msgs::msg::El2124WriteAllChannelsCmd>::SharedPtr 
-    el2124_write_all_channels_sub_;
-  rclcpp::Subscription<fcat_msgs::msg::El2124WriteChannelCmd>::SharedPtr 
-    el2124_write_channel_sub_;
-  
-  // Faulter
-  rclcpp::Subscription<fcat_msgs::msg::FaulterEnableCmd>::SharedPtr 
-    faulter_enable_sub_;
-
-  // Fts
-  rclcpp::Subscription<fcat_msgs::msg::FtsTareCmd>::SharedPtr 
-    fts_tare_sub_;
-
-  // Jed
-  rclcpp::Subscription<fcat_msgs::msg::JedSetCmdValueCmd>::SharedPtr 
-    jed_set_cmd_value_sub_;
-
-  // Pid
-  rclcpp::Subscription<fcat_msgs::msg::PidActivateCmd>::SharedPtr pid_activate_sub_;
-  
   ////////////////
   // Publishers //
   ////////////////
-  
-  rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr joint_state_pub_; 
-  rclcpp::Publisher<fcat_msgs::msg::ModuleState>::SharedPtr  module_state_pub_;
+  static const unsigned int publisher_queue_size_ = 32;
+  static const unsigned int subscription_queue_size_ = 32;
+  const rclcpp::QoS subscription_qos_ = rclcpp::QoS(subscription_queue_size_);
+  const rclcpp::QoS service_qos_;
+
+  rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr joint_state_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::ModuleState>::SharedPtr module_state_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::AsyncSdoResponse>::SharedPtr
+    async_sdo_response_pub_;
 
   rclcpp::Publisher<fcat_msgs::msg::ActuatorStates>::SharedPtr actuator_pub_;
-  rclcpp::Publisher<fcat_msgs::msg::EgdStates>::SharedPtr      egd_pub_;
-  rclcpp::Publisher<fcat_msgs::msg::El3602States>::SharedPtr   el3602_pub_;
-  rclcpp::Publisher<fcat_msgs::msg::El2124States>::SharedPtr   el2124_pub_;
-  rclcpp::Publisher<fcat_msgs::msg::El3208States>::SharedPtr   el3208_pub_;
-  rclcpp::Publisher<fcat_msgs::msg::JedStates>::SharedPtr      jed_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::EgdStates>::SharedPtr egd_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::El1008States>::SharedPtr el1008_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::El2124States>::SharedPtr el2124_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::El2809States>::SharedPtr el2809_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::El2798States>::SharedPtr el2798_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::El2828States>::SharedPtr el2828_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::El3104States>::SharedPtr el3104_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::El3162States>::SharedPtr el3162_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::El3202States>::SharedPtr el3202_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::El3208States>::SharedPtr el3208_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::El3314States>::SharedPtr el3314_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::El3318States>::SharedPtr el3318_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::El3602States>::SharedPtr el3602_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::El4102States>::SharedPtr el4102_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::El5042States>::SharedPtr el5042_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::Ild1900States>::SharedPtr ild1900_pub_;
 
-  rclcpp::Publisher<fcat_msgs::msg::SaturationStates>::SharedPtr saturation_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::SaturationStates>::SharedPtr
+    saturation_pub_;
   rclcpp::Publisher<fcat_msgs::msg::FilterStates>::SharedPtr filter_pub_;
   rclcpp::Publisher<fcat_msgs::msg::PidStates>::SharedPtr pid_pub_;
   rclcpp::Publisher<fcat_msgs::msg::CommanderStates>::SharedPtr commander_pub_;
-  rclcpp::Publisher<fcat_msgs::msg::SignalGeneratorStates>::SharedPtr signal_generator_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::SignalGeneratorStates>::SharedPtr
+    signal_generator_pub_;
   rclcpp::Publisher<fcat_msgs::msg::FaulterStates>::SharedPtr faulter_pub_;
   rclcpp::Publisher<fcat_msgs::msg::FunctionStates>::SharedPtr function_pub_;
-  rclcpp::Publisher<fcat_msgs::msg::ConditionalStates>::SharedPtr conditional_pub_;
-  rclcpp::Publisher<fcat_msgs::msg::SchmittTriggerStates>::SharedPtr schmitt_trigger_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::FtsStates>::SharedPtr fts_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::ConditionalStates>::SharedPtr
+    conditional_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::SchmittTriggerStates>::SharedPtr
+    schmitt_trigger_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::LinearInterpolationStates>::SharedPtr
+    linear_interpolation_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::ThreeNodeThermalModelStates>::SharedPtr
+    three_node_thermal_model_pub_;
 
-  std::unordered_map<std::string, WrenchPublisher::SharedPtr>  fts_raw_pub_map_;
-  std::unordered_map<std::string, WrenchPublisher::SharedPtr>  fts_tared_pub_map_;
+  std::unordered_map<std::string, WrenchPublisher::SharedPtr> fts_raw_pub_map_;
+  std::unordered_map<std::string, WrenchPublisher::SharedPtr>
+    fts_tared_pub_map_;
 
+  rclcpp::TimerBase::SharedPtr process_timer_ = nullptr;
+  ///////////////////////
+  // Service Callbacks //
+  ///////////////////////
+
+  void ResetSrvCb(
+    const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+    std::shared_ptr<std_srvs::srv::Trigger::Response> response) override;
+
+  void FaultSrvCb(
+    const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+    std::shared_ptr<std_srvs::srv::Trigger::Response> response) override;
+
+  void ActuatorHaltSrvCb(
+    const std::shared_ptr<fcat_msgs::srv::ActuatorHaltService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorHaltService::Response> response);
+
+  void ActuatorSetGainSchedulingIndexSrvCb(
+    const std::shared_ptr<
+      fcat_msgs::srv::ActuatorSetGainSchedulingIndexService::Request>
+      request,
+    std::shared_ptr<
+      fcat_msgs::srv::ActuatorSetGainSchedulingIndexService::Response>
+      response);
+
+  void ActuatorSetMaxCurrentSrvCb(
+    const std::shared_ptr<fcat_msgs::srv::ActuatorSetMaxCurrentService::Request>
+      request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorSetMaxCurrentService::Response>
+      response);
+
+  void ActuatorSetOutputPositionSrvCb(
+    const std::shared_ptr<
+      fcat_msgs::srv::ActuatorSetOutputPositionService::Request>
+      request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorSetOutputPositionService::Response>
+      response);
+
+  void ActuatorSetDigitalOutputSrvCb(
+    const std::shared_ptr<
+      fcat_msgs::srv::ActuatorSetDigitalOutputService::Request>
+      request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorSetDigitalOutputService::Response>
+      response);
+
+  void ActuatorSetProfDisengagingTimeoutSrvCb(
+    const std::shared_ptr<
+      fcat_msgs::srv::ActuatorSetProfDisengagingTimeoutService::Request>
+      request,
+    std::shared_ptr<
+      fcat_msgs::srv::ActuatorSetProfDisengagingTimeoutService::Response>
+      response);
+
+  void ActuatorCalibrateSrvCb(
+    const std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateService::Request>
+      request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateService::Response>
+      response);
+
+  void ActuatorProfPosSrvCb(
+    const std::shared_ptr<fcat_msgs::srv::ActuatorProfPosService::Request>
+      request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorProfPosService::Response> response);
+
+  void ActuatorProfVelSrvCb(
+    const std::shared_ptr<fcat_msgs::srv::ActuatorProfVelService::Request>
+      request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorProfVelService::Response> response);
+
+  void ActuatorProfTorqueSrvCb(
+    const std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueService::Request>
+      request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueService::Response>
+      response);
+
+  void CommanderEnableSrvCb(
+    const std::shared_ptr<fcat_msgs::srv::CommanderEnableService::Request>
+      request,
+    std::shared_ptr<fcat_msgs::srv::CommanderEnableService::Response> response);
+
+  void CommanderDisableSrvCb(
+    const std::shared_ptr<fcat_msgs::srv::CommanderDisableService::Request>
+      request,
+    std::shared_ptr<fcat_msgs::srv::CommanderDisableService::Response>
+      response);
+
+  void El2124WriteAllChannelsSrvCb(
+    const std::shared_ptr<
+      fcat_msgs::srv::El2124WriteAllChannelsService::Request>
+      request,
+    std::shared_ptr<fcat_msgs::srv::El2124WriteAllChannelsService::Response>
+      response);
+
+  void El2124WriteChannelSrvCb(
+    const std::shared_ptr<fcat_msgs::srv::El2124WriteChannelService::Request>
+      request,
+    std::shared_ptr<fcat_msgs::srv::El2124WriteChannelService::Response>
+      response);
+
+  void El2809WriteAllChannelsSrvCb(
+    const std::shared_ptr<
+      fcat_msgs::srv::El2809WriteAllChannelsService::Request>
+      request,
+    std::shared_ptr<fcat_msgs::srv::El2809WriteAllChannelsService::Response>
+      response);
+
+  void El2809WriteChannelSrvCb(
+    const std::shared_ptr<fcat_msgs::srv::El2809WriteChannelService::Request>
+      request,
+    std::shared_ptr<fcat_msgs::srv::El2809WriteChannelService::Response>
+      response);
+
+  void El2798WriteAllChannelsSrvCb(
+      const std::shared_ptr<
+          fcat_msgs::srv::El2798WriteAllChannelsService::Request>
+          request,
+      std::shared_ptr<fcat_msgs::srv::El2798WriteAllChannelsService::Response>
+          response);
+
+  void El2798WriteChannelSrvCb(
+      const std::shared_ptr<fcat_msgs::srv::El2798WriteChannelService::Request>
+          request,
+      std::shared_ptr<fcat_msgs::srv::El2798WriteChannelService::Response>
+          response);
+
+  void El2828WriteAllChannelsSrvCb(
+      const std::shared_ptr<
+          fcat_msgs::srv::El2828WriteAllChannelsService::Request>
+          request,
+      std::shared_ptr<fcat_msgs::srv::El2828WriteAllChannelsService::Response>
+          response);
+
+  void El2828WriteChannelSrvCb(
+      const std::shared_ptr<fcat_msgs::srv::El2828WriteChannelService::Request>
+          request,
+      std::shared_ptr<fcat_msgs::srv::El2828WriteChannelService::Response>
+          response);
+
+  void El4102WriteAllChannelsSrvCb(
+    const std::shared_ptr<
+      fcat_msgs::srv::El4102WriteAllChannelsService::Request>
+      request,
+    std::shared_ptr<fcat_msgs::srv::El4102WriteAllChannelsService::Response>
+      response);
+
+  void El4102WriteChannelSrvCb(
+    const std::shared_ptr<fcat_msgs::srv::El4102WriteChannelService::Request>
+      request,
+    std::shared_ptr<fcat_msgs::srv::El4102WriteChannelService::Response>
+      response);
+
+  void FaulterEnableSrvCb(
+    const std::shared_ptr<fcat_msgs::srv::FaulterEnableService::Request>
+      request,
+    std::shared_ptr<fcat_msgs::srv::FaulterEnableService::Response> response);
+
+  void FtsTareSrvCb(
+    const std::shared_ptr<fcat_msgs::srv::DeviceTriggerService::Request>
+      request,
+    std::shared_ptr<fcat_msgs::srv::DeviceTriggerService::Response> response);
+
+  void PidActivateSrvCb(
+    const std::shared_ptr<fcat_msgs::srv::PidActivateService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::PidActivateService::Response> response);
+
+  rclcpp::CallbackGroup::SharedPtr process_loop_callback_group_;
+  rclcpp::CallbackGroup::SharedPtr topic_callback_group_;
 
   ////////////////////
   // ROS Parameters //
   ////////////////////
 
+  bool use_sim_time_;
   bool enable_js_pub_;
+  bool enable_ros_wrench_pub_;
+  bool enable_realtime_preempt_ = false;
+  int scheduler_priority_ = 49;
 
+  bool fault_on_cycle_slip_ = true;
+  double cycle_slip_fault_magnitude_ = 3.0;
+  
   ////////////
   // fields //
   ////////////
 
   std::vector<std::shared_ptr<const fastcat::DeviceState>> device_state_ptrs_;
-  std::unordered_map<std::string,std::shared_ptr<const fastcat::DeviceState>> device_name_state_map_;
-  std::unordered_map<fastcat::DeviceStateType, std::vector<std::shared_ptr<const fastcat::DeviceState>>> device_type_vec_map_;
+  std::unordered_map<std::string, std::shared_ptr<const fastcat::DeviceState>>
+    device_name_state_map_;
+  std::unordered_map<fastcat::DeviceStateType,
+                     std::vector<std::shared_ptr<const fastcat::DeviceState>>>
+    device_type_vec_map_;
+  std::vector<std::any> subscriptions_;
 
-  double loop_period_sec_;
-  double last_time_;
+  double loop_period_sec_ = 0.0;
+  double last_time_ = 0.0;
+
+  bool time_stamp_initialized_ = false;
+
+  int process_loop_cpu_id_ = 0;
+  int process_loop_thread_id_ = -1;
+  bool cpu_affinity_initialized_ = false;
+  bool subscription_cpu_affinity_initialized_ = false;
+  bool process_loop_realtime_preempt_initialized_ = false;
+  bool cs_subscription_cb_realtime_preempt_initialized_ = false;
+
+  rclcpp::Time publish_time_stamp_;
 
   fastcat::Manager fcat_manager_;
 
+  fcat_msgs::msg::ModuleState module_state_msg_;
   fcat_msgs::msg::ActuatorStates actuator_states_msg_;
-  fcat_msgs::msg::EgdStates      egd_states_msg_;
-  fcat_msgs::msg::El2124States   el2124_states_msg_;
-  fcat_msgs::msg::El3208States   el3208_states_msg_;
-  fcat_msgs::msg::El3602States   el3602_states_msg_;
-  fcat_msgs::msg::JedStates      jed_states_msg_;
+  fcat_msgs::msg::EgdStates egd_states_msg_;
+  fcat_msgs::msg::El1008States el1008_states_msg_;
+  fcat_msgs::msg::El2124States el2124_states_msg_;
+  fcat_msgs::msg::El2809States el2809_states_msg_;
+  fcat_msgs::msg::El2798States el2798_states_msg_;
+  fcat_msgs::msg::El2828States el2828_states_msg_;
+  fcat_msgs::msg::El3104States el3104_states_msg_;
+  fcat_msgs::msg::El3162States el3162_states_msg_;
+  fcat_msgs::msg::El3202States el3202_states_msg_;
+  fcat_msgs::msg::El3208States el3208_states_msg_;
+  fcat_msgs::msg::El3314States el3314_states_msg_;
+  fcat_msgs::msg::El3318States el3318_states_msg_;
+  fcat_msgs::msg::El3602States el3602_states_msg_;
+  fcat_msgs::msg::El4102States el4102_states_msg_;
+  fcat_msgs::msg::El5042States el5042_states_msg_;
+  fcat_msgs::msg::Ild1900States ild1900_states_msg_;
 
-  fcat_msgs::msg::CommanderStates       commander_states_msg_;
-  fcat_msgs::msg::ConditionalStates     conditional_states_msg_;
-  fcat_msgs::msg::FaulterStates         faulter_states_msg_;
-  fcat_msgs::msg::FilterStates          filter_states_msg_;
-  fcat_msgs::msg::FunctionStates        function_states_msg_;
-  fcat_msgs::msg::PidStates             pid_states_msg_;
-  fcat_msgs::msg::SaturationStates      saturation_states_msg_;
-  fcat_msgs::msg::SchmittTriggerStates  schmitt_trigger_states_msg_;
+  fcat_msgs::msg::CommanderStates commander_states_msg_;
+  fcat_msgs::msg::ConditionalStates conditional_states_msg_;
+  fcat_msgs::msg::FaulterStates faulter_states_msg_;
+  fcat_msgs::msg::FilterStates filter_states_msg_;
+  fcat_msgs::msg::FunctionStates function_states_msg_;
+  fcat_msgs::msg::FtsStates fts_states_msg_;
+  fcat_msgs::msg::PidStates pid_states_msg_;
+  fcat_msgs::msg::SaturationStates saturation_states_msg_;
+  fcat_msgs::msg::SchmittTriggerStates schmitt_trigger_states_msg_;
   fcat_msgs::msg::SignalGeneratorStates signal_generator_states_msg_;
+  fcat_msgs::msg::LinearInterpolationStates linear_interpolation_states_msg_;
+  fcat_msgs::msg::ThreeNodeThermalModelStates
+    three_node_thermal_model_states_msg_;
 
+  size_t command_queue_size_ = 0;
 };
 #endif

--- a/src/fcat.hpp
+++ b/src/fcat.hpp
@@ -1,5 +1,7 @@
-#ifndef FCAT__FCAT_HPP_
-#define FCAT__FCAT_HPP_
+// Copyright 2021 California Institute of Technology
+
+#ifndef FCAT_HPP_
+#define FCAT_HPP_
 
 #include <sys/time.h>
 
@@ -8,6 +10,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "fastcat/fastcat.h"
 #include "jsd/jsd_print.h"
@@ -94,7 +97,8 @@ using WrenchPublisher = rclcpp::Publisher<geometry_msgs::msg::WrenchStamped>;
 class Fcat : public FcatNode {
  public:
   ~Fcat();
-  Fcat(const rclcpp::NodeOptions& options = rclcpp::NodeOptions());
+  // NOLINTNEXTLINE(runtime/explicit)
+  Fcat(const rclcpp::NodeOptions &options = rclcpp::NodeOptions());
   rclcpp::CallbackGroup::SharedPtr get_process_loop_callback_group() {
     return process_loop_callback_group_;
   }
@@ -105,18 +109,18 @@ class Fcat : public FcatNode {
   void SetRealtimePreempt(int scheduler_priority);
   void PopulateDeviceStateFields();
   void SetCpuAffinity();
-  void InitializeActuatorParams(const std::vector<std::string>& actuator_names, int& i);
+  void InitializeActuatorParams(const std::vector<std::string> &actuator_names, int &i);
 
-  void QueueCommand(fastcat::DeviceCmd& cmd) {
+  void QueueCommand(fastcat::DeviceCmd &cmd) {
     command_queue_size_++;
     fcat_manager_.QueueCommand(cmd);
   }
 
-  bool ActuatorExistsOnBus(const std::string& name);
-  bool ActuatorExistsOnBus(const std::string& name, std::string& error_message);
-  bool DeviceExistsOnBus(const std::string& name, fastcat::DeviceStateType type);
-  bool DeviceExistsOnBus(const std::string& name, fastcat::DeviceStateType type,
-                         std::string& error_message);
+  bool ActuatorExistsOnBus(const std::string &name);
+  bool ActuatorExistsOnBus(const std::string &name, std::string &error_message);
+  bool DeviceExistsOnBus(const std::string &name, fastcat::DeviceStateType type);
+  bool DeviceExistsOnBus(const std::string &name, fastcat::DeviceStateType type,
+                         std::string &error_message);
 
   bool TypeExistsOnBus(fastcat::DeviceStateType type);
   void InitializePublishersAndMessages();
@@ -160,10 +164,10 @@ class Fcat : public FcatNode {
   void PublishLinearInterpolationStates();
   void PublishThreeNodeThermalModelStates();
 
-  void CallActuatorCSP(const fcat_msgs::msg::ActuatorCspCmd& csp_cmd, double t);
-  void CallActuatorCSV(const fcat_msgs::msg::ActuatorCsvCmd& csv_cmd);
-  void CallActuatorCST(const fcat_msgs::msg::ActuatorCstCmd& cst_cmd);
-  void CallActuatorProfPos(const fcat_msgs::msg::ActuatorProfPosCmd& prof_pos_cmd);
+  void CallActuatorCSP(const fcat_msgs::msg::ActuatorCspCmd &csp_cmd, double t);
+  void CallActuatorCSV(const fcat_msgs::msg::ActuatorCsvCmd &csv_cmd);
+  void CallActuatorCST(const fcat_msgs::msg::ActuatorCstCmd &cst_cmd);
+  void CallActuatorProfPos(const fcat_msgs::msg::ActuatorProfPosCmd &prof_pos_cmd);
 
   /////////////////////////////////////
   /////// Topic Callbacks //////////
@@ -227,7 +231,7 @@ class Fcat : public FcatNode {
 
   void PidActivateCmdCb(const std::shared_ptr<fcat_msgs::msg::PidActivateCmd> msg);
 
-  rcl_interfaces::msg::SetParametersResult SetParametersCb(const std::vector<rclcpp::Parameter>&);
+  rcl_interfaces::msg::SetParametersResult SetParametersCb(const std::vector<rclcpp::Parameter> &);
 
   ////////////////
   // Publishers //
@@ -467,4 +471,4 @@ class Fcat : public FcatNode {
   bool reset_in_progress_ = false;
   std::vector<rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr> param_cb_handles_;
 };
-#endif
+#endif  // FCAT_HPP_

--- a/src/fcat.hpp
+++ b/src/fcat.hpp
@@ -94,6 +94,9 @@
 
 using WrenchPublisher = rclcpp::Publisher<geometry_msgs::msg::WrenchStamped>;
 
+// enum for state machine states
+enum class FcatState { UNCONFIGURED, INACTIVE, ACTIVE, FINALIZED };
+
 class Fcat : public FcatNode {
  public:
   ~Fcat();
@@ -174,7 +177,9 @@ class Fcat : public FcatNode {
   /////////////////////////////////////
 
   void ResetCmdCb(const std::shared_ptr<std_msgs::msg::Empty> msg);
+  void Reset();
   void FaultCmdCb(const std::shared_ptr<std_msgs::msg::Empty> msg);
+  void Fault();
 
   void AsyncSdoReadCmdCb(const std::shared_ptr<fcat_msgs::msg::AsyncSdoReadCmd> msg);
   void AsyncSdoWriteCmdCb(const std::shared_ptr<fcat_msgs::msg::AsyncSdoWriteCmd> msg);
@@ -469,6 +474,7 @@ class Fcat : public FcatNode {
 
   size_t command_queue_size_ = 0;
   bool reset_in_progress_ = false;
+  FcatState fcat_state_ = FcatState::UNCONFIGURED;
   std::vector<rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr> param_cb_handles_;
 };
 #endif  // FCAT_HPP_

--- a/src/fcat_callbacks.cpp
+++ b/src/fcat_callbacks.cpp
@@ -61,7 +61,7 @@ void Fcat::CallActuatorCSP(const fcat_msgs::msg::ActuatorCspCmd& msg, double t)
 {
   if(!cs_subscription_cb_realtime_preempt_initialized_) {
     if(enable_realtime_preempt_) {
-      EVR_ACTIVITY_HI(
+      RCLCPP_INFO(this->get_logger(),
         "Setting realtime priority for subscription callback thread to %d", 
         scheduler_priority_ - 1);
       SetRealtimePreempt(scheduler_priority_ - 1); 
@@ -97,7 +97,7 @@ void Fcat::CallActuatorCSP(const fcat_msgs::msg::ActuatorCspCmd& msg, double t)
       std::isnan(msg.position_offset) ||
       std::isnan(msg.velocity_offset) ||
       std::isnan(msg.torque_offset_amps)) {
-    EVR_WARNING_HI(
+    RCLCPP_WARN(this->get_logger(),
         "A NaN value was found in a CSP setpoint; "
         "The CSP setpoint was ignored"
     );
@@ -130,7 +130,7 @@ void Fcat::CallActuatorCSV(
 {
   if(!cs_subscription_cb_realtime_preempt_initialized_) {
     if(enable_realtime_preempt_) {
-       EVR_ACTIVITY_HI(
+       RCLCPP_INFO(this->get_logger(),
         "Setting realtime priority for subscription callback thread to %d", 
         scheduler_priority_ - 1);
       SetRealtimePreempt(scheduler_priority_ - 1); 
@@ -175,7 +175,7 @@ void Fcat::CallActuatorCST(
 {
   if(!cs_subscription_cb_realtime_preempt_initialized_) {
     if(enable_realtime_preempt_) {
-      EVR_ACTIVITY_HI(
+      RCLCPP_INFO(this->get_logger(),
         "Setting realtime priority for subscription callback thread to %d", 
         scheduler_priority_ - 1);
       SetRealtimePreempt(scheduler_priority_ - 1); 
@@ -605,7 +605,7 @@ void Fcat::ResetSrvCb(
   const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
   std::shared_ptr<std_srvs::srv::Trigger::Response> response)
 {
-  EVR_ACTIVITY_LO("Handling Reset Command");
+  RCLCPP_INFO(this->get_logger(), "Handling Reset Command");
   fcat_manager_.ExecuteAllDeviceResets();
   FaultInterface::ResetSrvCb(request, response);
 }
@@ -614,7 +614,7 @@ void Fcat::FaultSrvCb(
   const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
   std::shared_ptr<std_srvs::srv::Trigger::Response> response)
 {
-  EVR_ACTIVITY_LO("Handling Fault Command");
+  RCLCPP_INFO(this->get_logger(), "Handling Fault Command");
   fcat_manager_.ExecuteAllDeviceFaults();
   FaultInterface::FaultSrvCb(request, response);
 }
@@ -623,7 +623,7 @@ void Fcat::ActuatorHaltSrvCb(
   const std::shared_ptr<fcat_msgs::srv::ActuatorHaltService::Request> request,
   std::shared_ptr<fcat_msgs::srv::ActuatorHaltService::Response> response)
 {
-  EVR_ACTIVITY_LO("Handling Actuator Halt Command");
+  RCLCPP_INFO(this->get_logger(), "Handling Actuator Halt Command");
   fastcat::DeviceCmd cmd;
   cmd.name = request->name;
   cmd.type = fastcat::ACTUATOR_HALT_CMD;
@@ -642,7 +642,7 @@ void Fcat::ActuatorSetGainSchedulingIndexSrvCb(
     fcat_msgs::srv::ActuatorSetGainSchedulingIndexService::Response>
     response)
 {
-  EVR_ACTIVITY_LO("Handling Actuator Set Gain Scheduling Index Command");
+  RCLCPP_INFO(this->get_logger(), "Handling Actuator Set Gain Scheduling Index Command");
   fastcat::DeviceCmd cmd;
   cmd.name = request->name;
   cmd.type = fastcat::ACTUATOR_SET_GAIN_SCHEDULING_INDEX_CMD;
@@ -661,7 +661,7 @@ void Fcat::ActuatorSetMaxCurrentSrvCb(
   std::shared_ptr<fcat_msgs::srv::ActuatorSetMaxCurrentService::Response>
     response)
 {
-  EVR_ACTIVITY_LO("Handling Actuator Set Max Current Command");
+  RCLCPP_INFO(this->get_logger(), "Handling Actuator Set Max Current Command");
   fastcat::DeviceCmd cmd;
   cmd.name = request->name;
   cmd.type = fastcat::ACTUATOR_SET_MAX_CURRENT_CMD;
@@ -680,7 +680,7 @@ void Fcat::ActuatorSetDigitalOutputSrvCb(
   std::shared_ptr<fcat_msgs::srv::ActuatorSetDigitalOutputService::Response>
     response)
 {
-  EVR_ACTIVITY_LO("Handling Actuator Set Digital Output Command");
+  RCLCPP_INFO(this->get_logger(), "Handling Actuator Set Digital Output Command");
   fastcat::DeviceCmd cmd;
   cmd.name = request->name;
   cmd.type = fastcat::ACTUATOR_SET_DIGITAL_OUTPUT_CMD;
@@ -701,7 +701,7 @@ void Fcat::ActuatorSetProfDisengagingTimeoutSrvCb(
     fcat_msgs::srv::ActuatorSetProfDisengagingTimeoutService::Response>
     response)
 {
-  EVR_ACTIVITY_LO("Handling Actuator Set Profile Disengaging Timeout Command");
+  RCLCPP_INFO(this->get_logger(), "Handling Actuator Set Profile Disengaging Timeout Command");
   fastcat::DeviceCmd cmd;
   cmd.name = request->name;
   cmd.type = fastcat::ACTUATOR_SET_PROF_DISENGAGING_TIMEOUT_CMD;
@@ -720,7 +720,7 @@ void Fcat::ActuatorSetOutputPositionSrvCb(
   std::shared_ptr<fcat_msgs::srv::ActuatorSetOutputPositionService::Response>
     response)
 {
-  EVR_ACTIVITY_LO("Handling Actuator Set Output Position Command");
+  RCLCPP_INFO(this->get_logger(), "Handling Actuator Set Output Position Command");
   fastcat::DeviceCmd cmd;
   cmd.name = request->name;
   cmd.type = fastcat::ACTUATOR_SET_OUTPUT_POSITION_CMD;
@@ -736,7 +736,7 @@ void Fcat::ActuatorCalibrateSrvCb(
     request,
   std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateService::Response> response)
 {
-  EVR_ACTIVITY_LO("Handling Actuator Calibrate Command");
+  RCLCPP_INFO(this->get_logger(), "Handling Actuator Calibrate Command");
   fastcat::DeviceCmd cmd;
   cmd.name = request->name;
   cmd.type = fastcat::ACTUATOR_CALIBRATE_CMD;
@@ -754,7 +754,7 @@ void Fcat::ActuatorProfPosSrvCb(
     request,
   std::shared_ptr<fcat_msgs::srv::ActuatorProfPosService::Response> response)
 {
-  EVR_ACTIVITY_LO("Handling Actuator Set Prof Pos Command");
+  RCLCPP_INFO(this->get_logger(), "Handling Actuator Set Prof Pos Command");
   fastcat::DeviceCmd cmd;
   cmd.name = request->name;
   cmd.type = fastcat::ACTUATOR_PROF_POS_CMD;
@@ -773,7 +773,7 @@ void Fcat::ActuatorProfVelSrvCb(
     request,
   std::shared_ptr<fcat_msgs::srv::ActuatorProfVelService::Response> response)
 {
-  EVR_ACTIVITY_LO("Handling Actuator Set Prof Vel Command");
+  RCLCPP_INFO(this->get_logger(), "Handling Actuator Set Prof Vel Command");
   fastcat::DeviceCmd cmd;
   cmd.name = request->name;
   cmd.type = fastcat::ACTUATOR_PROF_VEL_CMD;
@@ -791,7 +791,7 @@ void Fcat::ActuatorProfTorqueSrvCb(
     request,
   std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueService::Response> response)
 {
-  EVR_ACTIVITY_LO("Handling Actuator Set Prof Torque Command");
+  RCLCPP_INFO(this->get_logger(), "Handling Actuator Set Prof Torque Command");
   fastcat::DeviceCmd cmd;
   cmd.name = request->name;
   cmd.type = fastcat::ACTUATOR_PROF_TORQUE_CMD;
@@ -808,7 +808,7 @@ void Fcat::CommanderEnableSrvCb(
     request,
   std::shared_ptr<fcat_msgs::srv::CommanderEnableService::Response> response)
 {
-  EVR_ACTIVITY_LO("Handling Commander Enable Command");
+  RCLCPP_INFO(this->get_logger(), "Handling Commander Enable Command");
   fastcat::DeviceCmd cmd;
   cmd.name = request->name;
   cmd.type = fastcat::COMMANDER_ENABLE_CMD;
@@ -826,7 +826,7 @@ void Fcat::CommanderDisableSrvCb(
     request,
   std::shared_ptr<fcat_msgs::srv::CommanderDisableService::Response> response)
 {
-  EVR_ACTIVITY_LO("Handling Commander Disable Command");
+  RCLCPP_INFO(this->get_logger(), "Handling Commander Disable Command");
   fastcat::DeviceCmd cmd;
   cmd.name = request->name;
   cmd.type = fastcat::COMMANDER_DISABLE_CMD;
@@ -844,7 +844,7 @@ void Fcat::El2124WriteAllChannelsSrvCb(
   std::shared_ptr<fcat_msgs::srv::El2124WriteAllChannelsService::Response>
     response)
 {
-  EVR_ACTIVITY_LO("Handling EL2124 Write All Channels Command");
+  RCLCPP_INFO(this->get_logger(), "Handling EL2124 Write All Channels Command");
   fastcat::DeviceCmd cmd;
 
   cmd.name = request->name;
@@ -866,7 +866,7 @@ void Fcat::El2124WriteChannelSrvCb(
     request,
   std::shared_ptr<fcat_msgs::srv::El2124WriteChannelService::Response> response)
 {
-  EVR_ACTIVITY_LO("Handling EL2124 Write Channel Command");
+  RCLCPP_INFO(this->get_logger(), "Handling EL2124 Write Channel Command");
   fastcat::DeviceCmd cmd;
 
   cmd.name = request->name;
@@ -887,7 +887,7 @@ void Fcat::El2809WriteAllChannelsSrvCb(
   std::shared_ptr<fcat_msgs::srv::El2809WriteAllChannelsService::Response>
     response)
 {
-  EVR_ACTIVITY_LO("Handling EL2809 Write All Channels Command");
+  RCLCPP_INFO(this->get_logger(), "Handling EL2809 Write All Channels Command");
   fastcat::DeviceCmd cmd;
 
   cmd.name = request->name;
@@ -921,7 +921,7 @@ void Fcat::El2809WriteChannelSrvCb(
     request,
   std::shared_ptr<fcat_msgs::srv::El2809WriteChannelService::Response> response)
 {
-  EVR_ACTIVITY_LO("Handling EL2809 Write Channel Command");
+  RCLCPP_INFO(this->get_logger(), "Handling EL2809 Write Channel Command");
   fastcat::DeviceCmd cmd;
 
   cmd.name = request->name;
@@ -943,7 +943,7 @@ void Fcat::El2798WriteAllChannelsSrvCb(
     std::shared_ptr<fcat_msgs::srv::El2798WriteAllChannelsService::Response>
         response)
 {
-  EVR_ACTIVITY_LO("Handling EL2798 Write All Channels Command");
+  RCLCPP_INFO(this->get_logger(), "Handling EL2798 Write All Channels Command");
   fastcat::DeviceCmd cmd;
 
   cmd.name = request->name;
@@ -971,7 +971,7 @@ void Fcat::El2828WriteAllChannelsSrvCb(
     std::shared_ptr<fcat_msgs::srv::El2828WriteAllChannelsService::Response>
         response)
 {
-  EVR_ACTIVITY_LO("Handling EL2828 Write All Channels Command");
+  RCLCPP_INFO(this->get_logger(), "Handling EL2828 Write All Channels Command");
   fastcat::DeviceCmd cmd;
 
   cmd.name = request->name;
@@ -998,7 +998,7 @@ void Fcat::El2798WriteChannelSrvCb(
     std::shared_ptr<fcat_msgs::srv::El2798WriteChannelService::Response>
         response)
 {
-  EVR_ACTIVITY_LO("Handling EL2798 Write Channel Command");
+  RCLCPP_INFO(this->get_logger(), "Handling EL2798 Write Channel Command");
   fastcat::DeviceCmd cmd;
 
   cmd.name                             = request->name;
@@ -1019,7 +1019,7 @@ void Fcat::El2828WriteChannelSrvCb(
     std::shared_ptr<fcat_msgs::srv::El2828WriteChannelService::Response>
         response)
 {
-  EVR_ACTIVITY_LO("Handling EL2828 Write Channel Command");
+  RCLCPP_INFO(this->get_logger(), "Handling EL2828 Write Channel Command");
   fastcat::DeviceCmd cmd;
 
   cmd.name                             = request->name;
@@ -1040,7 +1040,7 @@ void Fcat::El4102WriteAllChannelsSrvCb(
   std::shared_ptr<fcat_msgs::srv::El4102WriteAllChannelsService::Response>
     response)
 {
-  EVR_ACTIVITY_LO("Handling EL4102 Write All Channels Command");
+  RCLCPP_INFO(this->get_logger(), "Handling EL4102 Write All Channels Command");
   fastcat::DeviceCmd cmd;
 
   cmd.name = request->name;
@@ -1062,7 +1062,7 @@ void Fcat::El4102WriteChannelSrvCb(
     request,
   std::shared_ptr<fcat_msgs::srv::El4102WriteChannelService::Response> response)
 {
-  EVR_ACTIVITY_LO("Handling EL4102 Write Channel Command");
+  RCLCPP_INFO(this->get_logger(), "Handling EL4102 Write Channel Command");
   fastcat::DeviceCmd cmd;
 
   cmd.name = request->name;
@@ -1081,7 +1081,7 @@ void Fcat::FaulterEnableSrvCb(
   const std::shared_ptr<fcat_msgs::srv::FaulterEnableService::Request> request,
   std::shared_ptr<fcat_msgs::srv::FaulterEnableService::Response> response)
 {
-  EVR_ACTIVITY_LO("Handling Faulter Enable Command");
+  RCLCPP_INFO(this->get_logger(), "Handling Faulter Enable Command");
   fastcat::DeviceCmd cmd;
 
   cmd.name = request->name;
@@ -1099,7 +1099,7 @@ void Fcat::FtsTareSrvCb(
   const std::shared_ptr<fcat_msgs::srv::DeviceTriggerService::Request> request,
   std::shared_ptr<fcat_msgs::srv::DeviceTriggerService::Response> response)
 {
-  EVR_ACTIVITY_LO("Handling FTS Tare Command");
+  RCLCPP_INFO(this->get_logger(), "Handling FTS Tare Command");
   fastcat::DeviceCmd cmd;
   cmd.name = request->name;
   cmd.type = fastcat::FTS_TARE_CMD;
@@ -1115,7 +1115,7 @@ void Fcat::PidActivateSrvCb(
   const std::shared_ptr<fcat_msgs::srv::PidActivateService::Request> request,
   std::shared_ptr<fcat_msgs::srv::PidActivateService::Response> response)
 {
-  EVR_ACTIVITY_LO("Handling PID Activate Command");
+  RCLCPP_INFO(this->get_logger(), "Handling PID Activate Command");
   fastcat::DeviceCmd cmd;
   cmd.type = fastcat::PID_ACTIVATE_CMD;
   cmd.pid_activate_cmd.setpoint = request->setpoint;

--- a/src/fcat_callbacks.cpp
+++ b/src/fcat_callbacks.cpp
@@ -9,18 +9,44 @@
 #include "rclcpp/rclcpp.hpp"
 
 void Fcat::ResetCmdCb(const std::shared_ptr<std_msgs::msg::Empty> msg) {
-  reset_in_progress_ = true;
   fcat_manager_.ExecuteAllDeviceResets();
-  // FaultInterface::ResetCmdCb(msg); // TODO: use lifecyle nodes
-  reset_in_progress_ = false;
+  Reset(); // TODO: use lifecyle nodes
+}
+
+void Fcat::Reset() {
+  RCLCPP_INFO(this->get_logger(), "Resetting all devices on the bus");
+  if (fcat_state_ == FcatState::ACTIVE) {
+    RCLCPP_INFO(this->get_logger(), "Fcat already in ACTIVE state; Reset command will not cause state transition");
+  } else if (fcat_state_ == FcatState::INACTIVE) {
+    RCLCPP_INFO(this->get_logger(), "Transitioning from INACTIVE to ACTIVE state");
+    fcat_state_ = FcatState::ACTIVE;
+  } else {
+    RCLCPP_WARN(this->get_logger(),
+                "Reset command received, but FCAT is in state %d; no state transition "
+                "performed",
+                static_cast<int>(fcat_state_));
+  }
 }
 
 void Fcat::FaultCmdCb(const std::shared_ptr<std_msgs::msg::Empty> msg) {
-  (void)msg;
-  if (!reset_in_progress_) {
     fcat_manager_.ExecuteAllDeviceFaults();
-    // FaultInterface::FaultCmdCb(msg); // TODO: use lifecyle nodes
+    Fault(); // TODO: use lifecyle nodes
+}
+
+void Fcat::Fault() {
+  RCLCPP_INFO(this->get_logger(), "Faulting all devices on the bus");
+  if (fcat_state_ == FcatState::INACTIVE) {
+    RCLCPP_INFO(this->get_logger(), "Fcat already in INACTIVE state; Fault command will not cause state transition");
+  } else if (fcat_state_ == FcatState::ACTIVE) {
+    RCLCPP_INFO(this->get_logger(), "Transitioning from ACTIVE to INACTIVE (faulted) state");
+    fcat_state_ = FcatState::INACTIVE;
+  } else {
+    RCLCPP_WARN(this->get_logger(),
+                "Fault command received, but FCAT is in state %d; no state transition "
+                "performed",
+                static_cast<int>(fcat_state_));
   }
+
 }
 
 void Fcat::AsyncSdoReadCmdCb(const std::shared_ptr<fcat_msgs::msg::AsyncSdoReadCmd> msg) {
@@ -538,14 +564,18 @@ void Fcat::ResetSrvCb(const std::shared_ptr<std_srvs::srv::Trigger::Request> req
                       std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling Reset Command");
   fcat_manager_.ExecuteAllDeviceResets();
-  // FaultInterface::ResetSrvCb(request, response); // TODO: use lifecyle nodes
+  Reset(); // TODO: use lifecyle nodes
+  response->success = true;
+  response->message = "All devices reset";
 }
 
 void Fcat::FaultSrvCb(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
                       std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling Fault Command");
   fcat_manager_.ExecuteAllDeviceFaults();
-  // FaultInterface::FaultSrvCb(request, response); // TODO: use lifecyle nodes
+  Fault(); // TODO: use lifecyle nodes
+  response->success = true;
+  response->message = "All devices faulted";
 }
 
 void Fcat::ActuatorHaltSrvCb(

--- a/src/fcat_callbacks.cpp
+++ b/src/fcat_callbacks.cpp
@@ -1,21 +1,18 @@
+#include <cstdio>
+
+#include "fastcat/jsd/actuator.h"
 #include "fcat/fcat.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "unistd.h"
 
-#include "fastcat/jsd/actuator.h"
-
-#include <cstdio>
-
-void Fcat::ResetCmdCb(const std::shared_ptr<std_msgs::msg::Empty> msg)
-{
+void Fcat::ResetCmdCb(const std::shared_ptr<std_msgs::msg::Empty> msg) {
   reset_in_progress_ = true;
   fcat_manager_.ExecuteAllDeviceResets();
   // FaultInterface::ResetCmdCb(msg); // TODO: use lifecyle nodes
   reset_in_progress_ = false;
 }
 
-void Fcat::FaultCmdCb(const std::shared_ptr<std_msgs::msg::Empty> msg)
-{
+void Fcat::FaultCmdCb(const std::shared_ptr<std_msgs::msg::Empty> msg) {
   (void)msg;
   if (!reset_in_progress_) {
     fcat_manager_.ExecuteAllDeviceFaults();
@@ -23,52 +20,45 @@ void Fcat::FaultCmdCb(const std::shared_ptr<std_msgs::msg::Empty> msg)
   }
 }
 
-void Fcat::AsyncSdoReadCmdCb(
-  const std::shared_ptr<fcat_msgs::msg::AsyncSdoReadCmd> msg)
-{
+void Fcat::AsyncSdoReadCmdCb(const std::shared_ptr<fcat_msgs::msg::AsyncSdoReadCmd> msg) {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::ASYNC_SDO_READ_CMD;
   cmd.async_sdo_read_cmd.sdo_index = msg->sdo_index;
   cmd.async_sdo_read_cmd.sdo_subindex = msg->sdo_subindex;
-  cmd.async_sdo_read_cmd.data_type =
-    jsd_sdo_data_type_from_string(msg->data_type);
+  cmd.async_sdo_read_cmd.data_type = jsd_sdo_data_type_from_string(msg->data_type);
   cmd.async_sdo_read_cmd.app_id = msg->app_id;
 
   if (device_name_state_map_.end() != device_name_state_map_.find(msg->name)) {
     QueueCommand(cmd);
   }
 }
-void Fcat::AsyncSdoWriteCmdCb(
-  const std::shared_ptr<fcat_msgs::msg::AsyncSdoWriteCmd> msg)
-{
+void Fcat::AsyncSdoWriteCmdCb(const std::shared_ptr<fcat_msgs::msg::AsyncSdoWriteCmd> msg) {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::ASYNC_SDO_WRITE_CMD;
   cmd.async_sdo_write_cmd.sdo_index = msg->sdo_index;
   cmd.async_sdo_write_cmd.sdo_subindex = msg->sdo_subindex;
-  cmd.async_sdo_write_cmd.data_type =
-    jsd_sdo_data_type_from_string(msg->data_type);
+  cmd.async_sdo_write_cmd.data_type = jsd_sdo_data_type_from_string(msg->data_type);
   cmd.async_sdo_write_cmd.app_id = msg->app_id;
 
   cmd.async_sdo_write_cmd.data =
-    jsd_sdo_data_from_string(cmd.async_sdo_write_cmd.data_type, msg->data);
+      jsd_sdo_data_from_string(cmd.async_sdo_write_cmd.data_type, msg->data);
 
   if (device_name_state_map_.end() != device_name_state_map_.find(msg->name)) {
     QueueCommand(cmd);
   }
 }
 
-void Fcat::CallActuatorCSP(const fcat_msgs::msg::ActuatorCspCmd& msg, double t)
-{
-  if(!cs_subscription_cb_realtime_preempt_initialized_) {
-    if(enable_realtime_preempt_) {
+void Fcat::CallActuatorCSP(const fcat_msgs::msg::ActuatorCspCmd& msg, double t) {
+  if (!cs_subscription_cb_realtime_preempt_initialized_) {
+    if (enable_realtime_preempt_) {
       RCLCPP_INFO(this->get_logger(),
-        "Setting realtime priority for subscription callback thread to %d", 
-        scheduler_priority_ - 1);
-      SetRealtimePreempt(scheduler_priority_ - 1); 
+                  "Setting realtime priority for subscription callback thread to %d",
+                  scheduler_priority_ - 1);
+      SetRealtimePreempt(scheduler_priority_ - 1);
     }
-    cs_subscription_cb_realtime_preempt_initialized_ = true; 
+    cs_subscription_cb_realtime_preempt_initialized_ = true;
   }
 
   if (!subscription_cpu_affinity_initialized_) {
@@ -94,15 +84,12 @@ void Fcat::CallActuatorCSP(const fcat_msgs::msg::ActuatorCspCmd& msg, double t)
   cmd.actuator_csp_cmd.interpolation_mode = msg.interpolation_mode;
   cmd.actuator_csp_cmd.receipt_stamp_time = t;
 
-  if (std::isnan(msg.request_time) ||
-      std::isnan(msg.target_position) ||
-      std::isnan(msg.position_offset) ||
-      std::isnan(msg.velocity_offset) ||
+  if (std::isnan(msg.request_time) || std::isnan(msg.target_position) ||
+      std::isnan(msg.position_offset) || std::isnan(msg.velocity_offset) ||
       std::isnan(msg.torque_offset_amps)) {
     RCLCPP_WARN(this->get_logger(),
-        "A NaN value was found in a CSP setpoint; "
-        "The CSP setpoint was ignored"
-    );
+                "A NaN value was found in a CSP setpoint; "
+                "The CSP setpoint was ignored");
     return;
   }
 
@@ -111,15 +98,11 @@ void Fcat::CallActuatorCSP(const fcat_msgs::msg::ActuatorCspCmd& msg, double t)
   }
 }
 
-void Fcat::ActuatorCSPCmdCb(
-  const std::shared_ptr<fcat_msgs::msg::ActuatorCspCmd> msg)
-{
+void Fcat::ActuatorCSPCmdCb(const std::shared_ptr<fcat_msgs::msg::ActuatorCspCmd> msg) {
   this->CallActuatorCSP(*msg, this->now().seconds());
 }
 
-void Fcat::ActuatorCSPCmdsCb(
-  const std::shared_ptr<fcat_msgs::msg::ActuatorCspCmds> msg)
-{
+void Fcat::ActuatorCSPCmdsCb(const std::shared_ptr<fcat_msgs::msg::ActuatorCspCmds> msg) {
   fprintf(stderr, "Processing ActuatorCSPCmdsCb\n");
   double t = this->now().seconds();
   for (auto csp_cmd : msg->commands) {
@@ -127,17 +110,15 @@ void Fcat::ActuatorCSPCmdsCb(
   }
 }
 
-void Fcat::CallActuatorCSV(
-  const fcat_msgs::msg::ActuatorCsvCmd& msg)
-{
-  if(!cs_subscription_cb_realtime_preempt_initialized_) {
-    if(enable_realtime_preempt_) {
-       RCLCPP_INFO(this->get_logger(),
-        "Setting realtime priority for subscription callback thread to %d", 
-        scheduler_priority_ - 1);
-      SetRealtimePreempt(scheduler_priority_ - 1); 
+void Fcat::CallActuatorCSV(const fcat_msgs::msg::ActuatorCsvCmd& msg) {
+  if (!cs_subscription_cb_realtime_preempt_initialized_) {
+    if (enable_realtime_preempt_) {
+      RCLCPP_INFO(this->get_logger(),
+                  "Setting realtime priority for subscription callback thread to %d",
+                  scheduler_priority_ - 1);
+      SetRealtimePreempt(scheduler_priority_ - 1);
     }
-    cs_subscription_cb_realtime_preempt_initialized_ = true; 
+    cs_subscription_cb_realtime_preempt_initialized_ = true;
   }
   if (!subscription_cpu_affinity_initialized_) {
     if (process_loop_cpu_id_ >= 0) {
@@ -157,32 +138,26 @@ void Fcat::CallActuatorCSV(
   }
 }
 
-void Fcat::ActuatorCSVCmdCb(
-  const std::shared_ptr<fcat_msgs::msg::ActuatorCsvCmd> msg)
-{
+void Fcat::ActuatorCSVCmdCb(const std::shared_ptr<fcat_msgs::msg::ActuatorCsvCmd> msg) {
   this->CallActuatorCSV(*msg);
 }
 
-void Fcat::ActuatorCSVCmdsCb(
-  const std::shared_ptr<fcat_msgs::msg::ActuatorCsvCmds> msg)
-{
+void Fcat::ActuatorCSVCmdsCb(const std::shared_ptr<fcat_msgs::msg::ActuatorCsvCmds> msg) {
   fprintf(stderr, "Processing ActuatorCSVCmdsCb\n");
   for (auto csv_cmd : msg->commands) {
     CallActuatorCSV(csv_cmd);
   }
 }
 
-void Fcat::CallActuatorCST(
-  const fcat_msgs::msg::ActuatorCstCmd& msg)
-{
-  if(!cs_subscription_cb_realtime_preempt_initialized_) {
-    if(enable_realtime_preempt_) {
+void Fcat::CallActuatorCST(const fcat_msgs::msg::ActuatorCstCmd& msg) {
+  if (!cs_subscription_cb_realtime_preempt_initialized_) {
+    if (enable_realtime_preempt_) {
       RCLCPP_INFO(this->get_logger(),
-        "Setting realtime priority for subscription callback thread to %d", 
-        scheduler_priority_ - 1);
-      SetRealtimePreempt(scheduler_priority_ - 1); 
+                  "Setting realtime priority for subscription callback thread to %d",
+                  scheduler_priority_ - 1);
+      SetRealtimePreempt(scheduler_priority_ - 1);
     }
-    cs_subscription_cb_realtime_preempt_initialized_ = true; 
+    cs_subscription_cb_realtime_preempt_initialized_ = true;
   }
   if (!subscription_cpu_affinity_initialized_) {
     if (process_loop_cpu_id_ >= 0) {
@@ -201,25 +176,18 @@ void Fcat::CallActuatorCST(
   }
 }
 
-void Fcat::ActuatorCSTCmdCb(
-  const std::shared_ptr<fcat_msgs::msg::ActuatorCstCmd> msg)
-{
+void Fcat::ActuatorCSTCmdCb(const std::shared_ptr<fcat_msgs::msg::ActuatorCstCmd> msg) {
   CallActuatorCST(*msg);
 }
 
-
-void Fcat::ActuatorCSTCmdsCb(
-  const std::shared_ptr<fcat_msgs::msg::ActuatorCstCmds> msg)
-{
+void Fcat::ActuatorCSTCmdsCb(const std::shared_ptr<fcat_msgs::msg::ActuatorCstCmds> msg) {
   fprintf(stderr, "Processing ActuatorCSTCmdsCb\n");
   for (auto cst_cmd : msg->commands) {
     CallActuatorCST(cst_cmd);
   }
 }
 
-void Fcat::ActuatorCalibrateCmdCb(
-  const std::shared_ptr<fcat_msgs::msg::ActuatorCalibrateCmd> msg)
-{
+void Fcat::ActuatorCalibrateCmdCb(const std::shared_ptr<fcat_msgs::msg::ActuatorCalibrateCmd> msg) {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::ACTUATOR_CALIBRATE_CMD;
@@ -231,8 +199,7 @@ void Fcat::ActuatorCalibrateCmdCb(
   }
 }
 
-void Fcat::CallActuatorProfPos(const fcat_msgs::msg::ActuatorProfPosCmd& msg)
-{
+void Fcat::CallActuatorProfPos(const fcat_msgs::msg::ActuatorProfPosCmd& msg) {
   fastcat::DeviceCmd cmd;
   cmd.name = msg.name;
   cmd.type = fastcat::ACTUATOR_PROF_POS_CMD;
@@ -245,14 +212,11 @@ void Fcat::CallActuatorProfPos(const fcat_msgs::msg::ActuatorProfPosCmd& msg)
   }
 }
 
-void Fcat::ActuatorProfPosCmdCb(
-  const std::shared_ptr<fcat_msgs::msg::ActuatorProfPosCmd> msg)
-{
+void Fcat::ActuatorProfPosCmdCb(const std::shared_ptr<fcat_msgs::msg::ActuatorProfPosCmd> msg) {
   CallActuatorProfPos(*msg);
 }
 void Fcat::ActuatorProfTorqueCmdCb(
-  const std::shared_ptr<fcat_msgs::msg::ActuatorProfTorqueCmd> msg)
-{
+    const std::shared_ptr<fcat_msgs::msg::ActuatorProfTorqueCmd> msg) {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::ACTUATOR_PROF_TORQUE_CMD;
@@ -262,9 +226,7 @@ void Fcat::ActuatorProfTorqueCmdCb(
     QueueCommand(cmd);
   }
 }
-void Fcat::ActuatorProfVelCmdCb(
-  const std::shared_ptr<fcat_msgs::msg::ActuatorProfVelCmd> msg)
-{
+void Fcat::ActuatorProfVelCmdCb(const std::shared_ptr<fcat_msgs::msg::ActuatorProfVelCmd> msg) {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::ACTUATOR_PROF_VEL_CMD;
@@ -276,17 +238,14 @@ void Fcat::ActuatorProfVelCmdCb(
   }
 }
 
-void Fcat::ActuatorProfPosCmdsCb(
-  const std::shared_ptr<fcat_msgs::msg::ActuatorProfPosCmds> msg)
-{
+void Fcat::ActuatorProfPosCmdsCb(const std::shared_ptr<fcat_msgs::msg::ActuatorProfPosCmds> msg) {
   for (auto prof_pos_cmd : msg->commands) {
     CallActuatorProfPos(prof_pos_cmd);
   }
 }
 
 void Fcat::ActuatorSetOutputPositionCmdCb(
-  const std::shared_ptr<fcat_msgs::msg::ActuatorSetOutputPositionCmd> msg)
-{
+    const std::shared_ptr<fcat_msgs::msg::ActuatorSetOutputPositionCmd> msg) {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::ACTUATOR_SET_OUTPUT_POSITION_CMD;
@@ -297,13 +256,11 @@ void Fcat::ActuatorSetOutputPositionCmdCb(
 }
 
 void Fcat::ActuatorSetDigitalOutputCmdCb(
-  const std::shared_ptr<fcat_msgs::msg::ActuatorSetDigitalOutputCmd> msg)
-{
+    const std::shared_ptr<fcat_msgs::msg::ActuatorSetDigitalOutputCmd> msg) {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::ACTUATOR_SET_DIGITAL_OUTPUT_CMD;
-  cmd.actuator_set_digital_output_cmd.digital_output_index =
-    msg->digital_output_index;
+  cmd.actuator_set_digital_output_cmd.digital_output_index = msg->digital_output_index;
   cmd.actuator_set_digital_output_cmd.output_level = msg->output_level;
   if (ActuatorExistsOnBus(cmd.name)) {
     QueueCommand(cmd);
@@ -311,8 +268,7 @@ void Fcat::ActuatorSetDigitalOutputCmdCb(
 }
 
 void Fcat::ActuatorSetMaxCurrentCmdCb(
-  const std::shared_ptr<fcat_msgs::msg::ActuatorSetMaxCurrentCmd> msg)
-{
+    const std::shared_ptr<fcat_msgs::msg::ActuatorSetMaxCurrentCmd> msg) {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::ACTUATOR_SET_MAX_CURRENT_CMD;
@@ -324,8 +280,7 @@ void Fcat::ActuatorSetMaxCurrentCmdCb(
 }
 
 void Fcat::ActuatorSetUnitModeCmdCb(
-  const std::shared_ptr<fcat_msgs::msg::ActuatorSetUnitModeCmd> msg)
-{
+    const std::shared_ptr<fcat_msgs::msg::ActuatorSetUnitModeCmd> msg) {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::ACTUATOR_SDO_SET_UNIT_MODE_CMD;
@@ -337,9 +292,7 @@ void Fcat::ActuatorSetUnitModeCmdCb(
 }
 
 void Fcat::ActuatorSetProfDisengagingTimeoutCmdCb(
-  const std::shared_ptr<fcat_msgs::msg::ActuatorSetProfDisengagingTimeoutCmd>
-    msg)
-{
+    const std::shared_ptr<fcat_msgs::msg::ActuatorSetProfDisengagingTimeoutCmd> msg) {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::ACTUATOR_SET_PROF_DISENGAGING_TIMEOUT_CMD;
@@ -349,9 +302,7 @@ void Fcat::ActuatorSetProfDisengagingTimeoutCmdCb(
   }
 }
 
-void Fcat::ActuatorHaltCmdCb(
-  const std::shared_ptr<fcat_msgs::msg::ActuatorHaltCmd> msg)
-{
+void Fcat::ActuatorHaltCmdCb(const std::shared_ptr<fcat_msgs::msg::ActuatorHaltCmd> msg) {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::ACTUATOR_HALT_CMD;
@@ -360,9 +311,7 @@ void Fcat::ActuatorHaltCmdCb(
   }
 }
 
-void Fcat::ActuatorHaltCmdsCb(
-  const std::shared_ptr<fcat_msgs::msg::ActuatorHaltCmds> msg)
-{
+void Fcat::ActuatorHaltCmdsCb(const std::shared_ptr<fcat_msgs::msg::ActuatorHaltCmds> msg) {
   for (auto& name : msg->names) {
     fastcat::DeviceCmd cmd;
     cmd.name = name;
@@ -373,9 +322,7 @@ void Fcat::ActuatorHaltCmdsCb(
   }
 }
 
-void Fcat::CommanderEnableCmdCb(
-  const std::shared_ptr<fcat_msgs::msg::CommanderEnableCmd> msg)
-{
+void Fcat::CommanderEnableCmdCb(const std::shared_ptr<fcat_msgs::msg::CommanderEnableCmd> msg) {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::COMMANDER_ENABLE_CMD;
@@ -386,9 +333,7 @@ void Fcat::CommanderEnableCmdCb(
   }
 }
 
-void Fcat::CommanderDisableCmdCb(
-  const std::shared_ptr<fcat_msgs::msg::CommanderDisableCmd> msg)
-{
+void Fcat::CommanderDisableCmdCb(const std::shared_ptr<fcat_msgs::msg::CommanderDisableCmd> msg) {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::COMMANDER_DISABLE_CMD;
@@ -399,8 +344,7 @@ void Fcat::CommanderDisableCmdCb(
 }
 
 void Fcat::El2124WriteAllChannelsCmdCb(
-  const std::shared_ptr<fcat_msgs::msg::El2124WriteAllChannelsCmd> msg)
-{
+    const std::shared_ptr<fcat_msgs::msg::El2124WriteAllChannelsCmd> msg) {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::EL2124_WRITE_ALL_CHANNELS_CMD;
@@ -414,8 +358,7 @@ void Fcat::El2124WriteAllChannelsCmdCb(
   }
 }
 void Fcat::El2124WriteChannelCmdCb(
-  const std::shared_ptr<fcat_msgs::msg::El2124WriteChannelCmd> msg)
-{
+    const std::shared_ptr<fcat_msgs::msg::El2124WriteChannelCmd> msg) {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::EL2124_WRITE_CHANNEL_CMD;
@@ -428,8 +371,7 @@ void Fcat::El2124WriteChannelCmdCb(
 }
 
 void Fcat::El2809WriteAllChannelsCmdCb(
-  const std::shared_ptr<fcat_msgs::msg::El2809WriteAllChannelsCmd> msg)
-{
+    const std::shared_ptr<fcat_msgs::msg::El2809WriteAllChannelsCmd> msg) {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::EL2809_WRITE_ALL_CHANNELS_CMD;
@@ -455,8 +397,7 @@ void Fcat::El2809WriteAllChannelsCmdCb(
   }
 }
 void Fcat::El2809WriteChannelCmdCb(
-  const std::shared_ptr<fcat_msgs::msg::El2809WriteChannelCmd> msg)
-{
+    const std::shared_ptr<fcat_msgs::msg::El2809WriteChannelCmd> msg) {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::EL2809_WRITE_CHANNEL_CMD;
@@ -469,32 +410,30 @@ void Fcat::El2809WriteChannelCmdCb(
 }
 
 void Fcat::El2798WriteAllChannelsCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::El2798WriteAllChannelsCmd> msg)
-{
+    const std::shared_ptr<fcat_msgs::msg::El2798WriteAllChannelsCmd> msg) {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::EL2798_WRITE_ALL_CHANNELS_CMD;
-  cmd.el2798_write_all_channels_cmd.channel_ch1  = msg->channel_ch1;
-  cmd.el2798_write_all_channels_cmd.channel_ch2  = msg->channel_ch2;
-  cmd.el2798_write_all_channels_cmd.channel_ch3  = msg->channel_ch3;
-  cmd.el2798_write_all_channels_cmd.channel_ch4  = msg->channel_ch4;
-  cmd.el2798_write_all_channels_cmd.channel_ch5  = msg->channel_ch5;
-  cmd.el2798_write_all_channels_cmd.channel_ch6  = msg->channel_ch6;
-  cmd.el2798_write_all_channels_cmd.channel_ch7  = msg->channel_ch7;
-  cmd.el2798_write_all_channels_cmd.channel_ch8  = msg->channel_ch8;
+  cmd.el2798_write_all_channels_cmd.channel_ch1 = msg->channel_ch1;
+  cmd.el2798_write_all_channels_cmd.channel_ch2 = msg->channel_ch2;
+  cmd.el2798_write_all_channels_cmd.channel_ch3 = msg->channel_ch3;
+  cmd.el2798_write_all_channels_cmd.channel_ch4 = msg->channel_ch4;
+  cmd.el2798_write_all_channels_cmd.channel_ch5 = msg->channel_ch5;
+  cmd.el2798_write_all_channels_cmd.channel_ch6 = msg->channel_ch6;
+  cmd.el2798_write_all_channels_cmd.channel_ch7 = msg->channel_ch7;
+  cmd.el2798_write_all_channels_cmd.channel_ch8 = msg->channel_ch8;
 
   if (DeviceExistsOnBus(cmd.name, fastcat::EL2798_STATE)) {
     QueueCommand(cmd);
   }
 }
 void Fcat::El2798WriteChannelCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::El2798WriteChannelCmd> msg)
-{
+    const std::shared_ptr<fcat_msgs::msg::El2798WriteChannelCmd> msg) {
   fastcat::DeviceCmd cmd;
-  cmd.name                             = msg->name;
-  cmd.type                             = fastcat::EL2798_WRITE_CHANNEL_CMD;
+  cmd.name = msg->name;
+  cmd.type = fastcat::EL2798_WRITE_CHANNEL_CMD;
   cmd.el2798_write_channel_cmd.channel = msg->channel;
-  cmd.el2798_write_channel_cmd.level   = msg->level;
+  cmd.el2798_write_channel_cmd.level = msg->level;
 
   if (DeviceExistsOnBus(cmd.name, fastcat::EL2798_STATE)) {
     QueueCommand(cmd);
@@ -502,32 +441,30 @@ void Fcat::El2798WriteChannelCmdCb(
 }
 
 void Fcat::El2828WriteAllChannelsCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::El2828WriteAllChannelsCmd> msg)
-{
+    const std::shared_ptr<fcat_msgs::msg::El2828WriteAllChannelsCmd> msg) {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::EL2828_WRITE_ALL_CHANNELS_CMD;
-  cmd.el2828_write_all_channels_cmd.channel_ch1  = msg->channel_ch1;
-  cmd.el2828_write_all_channels_cmd.channel_ch2  = msg->channel_ch2;
-  cmd.el2828_write_all_channels_cmd.channel_ch3  = msg->channel_ch3;
-  cmd.el2828_write_all_channels_cmd.channel_ch4  = msg->channel_ch4;
-  cmd.el2828_write_all_channels_cmd.channel_ch5  = msg->channel_ch5;
-  cmd.el2828_write_all_channels_cmd.channel_ch6  = msg->channel_ch6;
-  cmd.el2828_write_all_channels_cmd.channel_ch7  = msg->channel_ch7;
-  cmd.el2828_write_all_channels_cmd.channel_ch8  = msg->channel_ch8;
+  cmd.el2828_write_all_channels_cmd.channel_ch1 = msg->channel_ch1;
+  cmd.el2828_write_all_channels_cmd.channel_ch2 = msg->channel_ch2;
+  cmd.el2828_write_all_channels_cmd.channel_ch3 = msg->channel_ch3;
+  cmd.el2828_write_all_channels_cmd.channel_ch4 = msg->channel_ch4;
+  cmd.el2828_write_all_channels_cmd.channel_ch5 = msg->channel_ch5;
+  cmd.el2828_write_all_channels_cmd.channel_ch6 = msg->channel_ch6;
+  cmd.el2828_write_all_channels_cmd.channel_ch7 = msg->channel_ch7;
+  cmd.el2828_write_all_channels_cmd.channel_ch8 = msg->channel_ch8;
 
   if (DeviceExistsOnBus(cmd.name, fastcat::EL2828_STATE)) {
     QueueCommand(cmd);
   }
 }
 void Fcat::El2828WriteChannelCmdCb(
-    const std::shared_ptr<fcat_msgs::msg::El2828WriteChannelCmd> msg)
-{
+    const std::shared_ptr<fcat_msgs::msg::El2828WriteChannelCmd> msg) {
   fastcat::DeviceCmd cmd;
-  cmd.name                             = msg->name;
-  cmd.type                             = fastcat::EL2828_WRITE_CHANNEL_CMD;
+  cmd.name = msg->name;
+  cmd.type = fastcat::EL2828_WRITE_CHANNEL_CMD;
   cmd.el2828_write_channel_cmd.channel = msg->channel;
-  cmd.el2828_write_channel_cmd.level   = msg->level;
+  cmd.el2828_write_channel_cmd.level = msg->level;
 
   if (DeviceExistsOnBus(cmd.name, fastcat::EL2828_STATE)) {
     QueueCommand(cmd);
@@ -535,23 +472,19 @@ void Fcat::El2828WriteChannelCmdCb(
 }
 
 void Fcat::El4102WriteAllChannelsCmdCb(
-  const std::shared_ptr<fcat_msgs::msg::El4102WriteAllChannelsCmd> msg)
-{
+    const std::shared_ptr<fcat_msgs::msg::El4102WriteAllChannelsCmd> msg) {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::EL4102_WRITE_ALL_CHANNELS_CMD;
-  cmd.el4102_write_all_channels_cmd.voltage_output_ch1 =
-    msg->voltage_output_ch1;
-  cmd.el4102_write_all_channels_cmd.voltage_output_ch2 =
-    msg->voltage_output_ch2;
+  cmd.el4102_write_all_channels_cmd.voltage_output_ch1 = msg->voltage_output_ch1;
+  cmd.el4102_write_all_channels_cmd.voltage_output_ch2 = msg->voltage_output_ch2;
 
   if (DeviceExistsOnBus(cmd.name, fastcat::EL4102_STATE)) {
     QueueCommand(cmd);
   }
 }
 void Fcat::El4102WriteChannelCmdCb(
-  const std::shared_ptr<fcat_msgs::msg::El4102WriteChannelCmd> msg)
-{
+    const std::shared_ptr<fcat_msgs::msg::El4102WriteChannelCmd> msg) {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::EL4102_WRITE_CHANNEL_CMD;
@@ -563,9 +496,7 @@ void Fcat::El4102WriteChannelCmdCb(
   }
 }
 
-void Fcat::FaulterEnableCmdCb(
-  const std::shared_ptr<fcat_msgs::msg::FaulterEnableCmd> msg)
-{
+void Fcat::FaulterEnableCmdCb(const std::shared_ptr<fcat_msgs::msg::FaulterEnableCmd> msg) {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::FAULTER_ENABLE_CMD;
@@ -576,8 +507,7 @@ void Fcat::FaulterEnableCmdCb(
   }
 }
 
-void Fcat::FtsTareCmdCb(const std::shared_ptr<fcat_msgs::msg::FtsTareCmd> msg)
-{
+void Fcat::FtsTareCmdCb(const std::shared_ptr<fcat_msgs::msg::FtsTareCmd> msg) {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::FTS_TARE_CMD;
@@ -587,9 +517,7 @@ void Fcat::FtsTareCmdCb(const std::shared_ptr<fcat_msgs::msg::FtsTareCmd> msg)
   }
 }
 
-void Fcat::PidActivateCmdCb(
-  const std::shared_ptr<fcat_msgs::msg::PidActivateCmd> msg)
-{
+void Fcat::PidActivateCmdCb(const std::shared_ptr<fcat_msgs::msg::PidActivateCmd> msg) {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::PID_ACTIVATE_CMD;
@@ -603,28 +531,23 @@ void Fcat::PidActivateCmdCb(
   }
 }
 
-void Fcat::ResetSrvCb(
-  const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-  std::shared_ptr<std_srvs::srv::Trigger::Response> response)
-{
+void Fcat::ResetSrvCb(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                      std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling Reset Command");
   fcat_manager_.ExecuteAllDeviceResets();
   // FaultInterface::ResetSrvCb(request, response); // TODO: use lifecyle nodes
 }
 
-void Fcat::FaultSrvCb(
-  const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-  std::shared_ptr<std_srvs::srv::Trigger::Response> response)
-{
+void Fcat::FaultSrvCb(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                      std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling Fault Command");
   fcat_manager_.ExecuteAllDeviceFaults();
   // FaultInterface::FaultSrvCb(request, response); // TODO: use lifecyle nodes
 }
 
 void Fcat::ActuatorHaltSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::ActuatorHaltService::Request> request,
-  std::shared_ptr<fcat_msgs::srv::ActuatorHaltService::Response> response)
-{
+    const std::shared_ptr<fcat_msgs::srv::ActuatorHaltService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorHaltService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling Actuator Halt Command");
   fastcat::DeviceCmd cmd;
   cmd.name = request->name;
@@ -637,19 +560,13 @@ void Fcat::ActuatorHaltSrvCb(
 }
 
 void Fcat::ActuatorSetGainSchedulingIndexSrvCb(
-  const std::shared_ptr<
-    fcat_msgs::srv::ActuatorSetGainSchedulingIndexService::Request>
-    request,
-  std::shared_ptr<
-    fcat_msgs::srv::ActuatorSetGainSchedulingIndexService::Response>
-    response)
-{
+    const std::shared_ptr<fcat_msgs::srv::ActuatorSetGainSchedulingIndexService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorSetGainSchedulingIndexService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling Actuator Set Gain Scheduling Index Command");
   fastcat::DeviceCmd cmd;
   cmd.name = request->name;
   cmd.type = fastcat::ACTUATOR_SET_GAIN_SCHEDULING_INDEX_CMD;
-  cmd.actuator_set_gain_scheduling_index_cmd.gain_scheduling_index =
-    request->gain_scheduling_index;
+  cmd.actuator_set_gain_scheduling_index_cmd.gain_scheduling_index = request->gain_scheduling_index;
 
   response->success = ActuatorExistsOnBus(cmd.name, response->message);
   if (response->success) {
@@ -658,11 +575,8 @@ void Fcat::ActuatorSetGainSchedulingIndexSrvCb(
 }
 
 void Fcat::ActuatorSetMaxCurrentSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::ActuatorSetMaxCurrentService::Request>
-    request,
-  std::shared_ptr<fcat_msgs::srv::ActuatorSetMaxCurrentService::Response>
-    response)
-{
+    const std::shared_ptr<fcat_msgs::srv::ActuatorSetMaxCurrentService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorSetMaxCurrentService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling Actuator Set Max Current Command");
   fastcat::DeviceCmd cmd;
   cmd.name = request->name;
@@ -676,18 +590,13 @@ void Fcat::ActuatorSetMaxCurrentSrvCb(
 }
 
 void Fcat::ActuatorSetDigitalOutputSrvCb(
-  const std::shared_ptr<
-    fcat_msgs::srv::ActuatorSetDigitalOutputService::Request>
-    request,
-  std::shared_ptr<fcat_msgs::srv::ActuatorSetDigitalOutputService::Response>
-    response)
-{
+    const std::shared_ptr<fcat_msgs::srv::ActuatorSetDigitalOutputService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorSetDigitalOutputService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling Actuator Set Digital Output Command");
   fastcat::DeviceCmd cmd;
   cmd.name = request->name;
   cmd.type = fastcat::ACTUATOR_SET_DIGITAL_OUTPUT_CMD;
-  cmd.actuator_set_digital_output_cmd.digital_output_index =
-    request->digital_output_index;
+  cmd.actuator_set_digital_output_cmd.digital_output_index = request->digital_output_index;
   cmd.actuator_set_digital_output_cmd.output_level = request->output_level;
   response->success = ActuatorExistsOnBus(cmd.name, response->message);
   if (response->success) {
@@ -696,13 +605,9 @@ void Fcat::ActuatorSetDigitalOutputSrvCb(
 }
 
 void Fcat::ActuatorSetProfDisengagingTimeoutSrvCb(
-  const std::shared_ptr<
-    fcat_msgs::srv::ActuatorSetProfDisengagingTimeoutService::Request>
-    request,
-  std::shared_ptr<
-    fcat_msgs::srv::ActuatorSetProfDisengagingTimeoutService::Response>
-    response)
-{
+    const std::shared_ptr<fcat_msgs::srv::ActuatorSetProfDisengagingTimeoutService::Request>
+        request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorSetProfDisengagingTimeoutService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling Actuator Set Profile Disengaging Timeout Command");
   fastcat::DeviceCmd cmd;
   cmd.name = request->name;
@@ -716,12 +621,8 @@ void Fcat::ActuatorSetProfDisengagingTimeoutSrvCb(
 }
 
 void Fcat::ActuatorSetOutputPositionSrvCb(
-  const std::shared_ptr<
-    fcat_msgs::srv::ActuatorSetOutputPositionService::Request>
-    request,
-  std::shared_ptr<fcat_msgs::srv::ActuatorSetOutputPositionService::Response>
-    response)
-{
+    const std::shared_ptr<fcat_msgs::srv::ActuatorSetOutputPositionService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorSetOutputPositionService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling Actuator Set Output Position Command");
   fastcat::DeviceCmd cmd;
   cmd.name = request->name;
@@ -734,10 +635,8 @@ void Fcat::ActuatorSetOutputPositionSrvCb(
 }
 
 void Fcat::ActuatorCalibrateSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateService::Request>
-    request,
-  std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateService::Response> response)
-{
+    const std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling Actuator Calibrate Command");
   fastcat::DeviceCmd cmd;
   cmd.name = request->name;
@@ -752,10 +651,8 @@ void Fcat::ActuatorCalibrateSrvCb(
 }
 
 void Fcat::ActuatorProfPosSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::ActuatorProfPosService::Request>
-    request,
-  std::shared_ptr<fcat_msgs::srv::ActuatorProfPosService::Response> response)
-{
+    const std::shared_ptr<fcat_msgs::srv::ActuatorProfPosService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorProfPosService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling Actuator Set Prof Pos Command");
   fastcat::DeviceCmd cmd;
   cmd.name = request->name;
@@ -771,10 +668,8 @@ void Fcat::ActuatorProfPosSrvCb(
 }
 
 void Fcat::ActuatorProfVelSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::ActuatorProfVelService::Request>
-    request,
-  std::shared_ptr<fcat_msgs::srv::ActuatorProfVelService::Response> response)
-{
+    const std::shared_ptr<fcat_msgs::srv::ActuatorProfVelService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorProfVelService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling Actuator Set Prof Vel Command");
   fastcat::DeviceCmd cmd;
   cmd.name = request->name;
@@ -789,10 +684,8 @@ void Fcat::ActuatorProfVelSrvCb(
 }
 
 void Fcat::ActuatorProfTorqueSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueService::Request>
-    request,
-  std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueService::Response> response)
-{
+    const std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling Actuator Set Prof Torque Command");
   fastcat::DeviceCmd cmd;
   cmd.name = request->name;
@@ -806,46 +699,37 @@ void Fcat::ActuatorProfTorqueSrvCb(
 }
 
 void Fcat::CommanderEnableSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::CommanderEnableService::Request>
-    request,
-  std::shared_ptr<fcat_msgs::srv::CommanderEnableService::Response> response)
-{
+    const std::shared_ptr<fcat_msgs::srv::CommanderEnableService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::CommanderEnableService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling Commander Enable Command");
   fastcat::DeviceCmd cmd;
   cmd.name = request->name;
   cmd.type = fastcat::COMMANDER_ENABLE_CMD;
   cmd.commander_enable_cmd.duration = request->duration;
 
-  response->success =
-    DeviceExistsOnBus(cmd.name, fastcat::COMMANDER_STATE, response->message);
+  response->success = DeviceExistsOnBus(cmd.name, fastcat::COMMANDER_STATE, response->message);
   if (response->success) {
     QueueCommand(cmd);
   }
 }
 
 void Fcat::CommanderDisableSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::CommanderDisableService::Request>
-    request,
-  std::shared_ptr<fcat_msgs::srv::CommanderDisableService::Response> response)
-{
+    const std::shared_ptr<fcat_msgs::srv::CommanderDisableService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::CommanderDisableService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling Commander Disable Command");
   fastcat::DeviceCmd cmd;
   cmd.name = request->name;
   cmd.type = fastcat::COMMANDER_DISABLE_CMD;
 
-  response->success =
-    DeviceExistsOnBus(cmd.name, fastcat::COMMANDER_STATE, response->message);
+  response->success = DeviceExistsOnBus(cmd.name, fastcat::COMMANDER_STATE, response->message);
   if (response->success) {
     QueueCommand(cmd);
   }
 }
 
 void Fcat::El2124WriteAllChannelsSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::El2124WriteAllChannelsService::Request>
-    request,
-  std::shared_ptr<fcat_msgs::srv::El2124WriteAllChannelsService::Response>
-    response)
-{
+    const std::shared_ptr<fcat_msgs::srv::El2124WriteAllChannelsService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::El2124WriteAllChannelsService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling EL2124 Write All Channels Command");
   fastcat::DeviceCmd cmd;
 
@@ -856,18 +740,15 @@ void Fcat::El2124WriteAllChannelsSrvCb(
   cmd.el2124_write_all_channels_cmd.channel_ch3 = request->channel_ch3;
   cmd.el2124_write_all_channels_cmd.channel_ch4 = request->channel_ch4;
 
-  response->success =
-    DeviceExistsOnBus(cmd.name, fastcat::EL2124_STATE, response->message);
+  response->success = DeviceExistsOnBus(cmd.name, fastcat::EL2124_STATE, response->message);
   if (response->success) {
     QueueCommand(cmd);
   }
 }
 
 void Fcat::El2124WriteChannelSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::El2124WriteChannelService::Request>
-    request,
-  std::shared_ptr<fcat_msgs::srv::El2124WriteChannelService::Response> response)
-{
+    const std::shared_ptr<fcat_msgs::srv::El2124WriteChannelService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::El2124WriteChannelService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling EL2124 Write Channel Command");
   fastcat::DeviceCmd cmd;
 
@@ -876,19 +757,15 @@ void Fcat::El2124WriteChannelSrvCb(
   cmd.el2124_write_channel_cmd.channel = request->channel;
   cmd.el2124_write_channel_cmd.level = request->level;
 
-  response->success =
-    DeviceExistsOnBus(cmd.name, fastcat::EL2124_STATE, response->message);
+  response->success = DeviceExistsOnBus(cmd.name, fastcat::EL2124_STATE, response->message);
   if (response->success) {
     QueueCommand(cmd);
   }
 }
 
 void Fcat::El2809WriteAllChannelsSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::El2809WriteAllChannelsService::Request>
-    request,
-  std::shared_ptr<fcat_msgs::srv::El2809WriteAllChannelsService::Response>
-    response)
-{
+    const std::shared_ptr<fcat_msgs::srv::El2809WriteAllChannelsService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::El2809WriteAllChannelsService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling EL2809 Write All Channels Command");
   fastcat::DeviceCmd cmd;
 
@@ -911,18 +788,15 @@ void Fcat::El2809WriteAllChannelsSrvCb(
   cmd.el2809_write_all_channels_cmd.channel_ch15 = request->channel_ch15;
   cmd.el2809_write_all_channels_cmd.channel_ch16 = request->channel_ch16;
 
-  response->success =
-    DeviceExistsOnBus(cmd.name, fastcat::EL2809_STATE, response->message);
+  response->success = DeviceExistsOnBus(cmd.name, fastcat::EL2809_STATE, response->message);
   if (response->success) {
     QueueCommand(cmd);
   }
 }
 
 void Fcat::El2809WriteChannelSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::El2809WriteChannelService::Request>
-    request,
-  std::shared_ptr<fcat_msgs::srv::El2809WriteChannelService::Response> response)
-{
+    const std::shared_ptr<fcat_msgs::srv::El2809WriteChannelService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::El2809WriteChannelService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling EL2809 Write Channel Command");
   fastcat::DeviceCmd cmd;
 
@@ -931,139 +805,112 @@ void Fcat::El2809WriteChannelSrvCb(
   cmd.el2809_write_channel_cmd.channel = request->channel;
   cmd.el2809_write_channel_cmd.level = request->level;
 
-  response->success =
-    DeviceExistsOnBus(cmd.name, fastcat::EL2809_STATE, response->message);
+  response->success = DeviceExistsOnBus(cmd.name, fastcat::EL2809_STATE, response->message);
   if (response->success) {
     QueueCommand(cmd);
   }
 }
 
 void Fcat::El2798WriteAllChannelsSrvCb(
-    const std::shared_ptr<
-        fcat_msgs::srv::El2798WriteAllChannelsService::Request>
-        request,
-    std::shared_ptr<fcat_msgs::srv::El2798WriteAllChannelsService::Response>
-        response)
-{
+    const std::shared_ptr<fcat_msgs::srv::El2798WriteAllChannelsService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::El2798WriteAllChannelsService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling EL2798 Write All Channels Command");
   fastcat::DeviceCmd cmd;
 
   cmd.name = request->name;
   cmd.type = fastcat::EL2798_WRITE_ALL_CHANNELS_CMD;
-  cmd.el2798_write_all_channels_cmd.channel_ch1  = request->channel_ch1;
-  cmd.el2798_write_all_channels_cmd.channel_ch2  = request->channel_ch2;
-  cmd.el2798_write_all_channels_cmd.channel_ch3  = request->channel_ch3;
-  cmd.el2798_write_all_channels_cmd.channel_ch4  = request->channel_ch4;
-  cmd.el2798_write_all_channels_cmd.channel_ch5  = request->channel_ch5;
-  cmd.el2798_write_all_channels_cmd.channel_ch6  = request->channel_ch6;
-  cmd.el2798_write_all_channels_cmd.channel_ch7  = request->channel_ch7;
-  cmd.el2798_write_all_channels_cmd.channel_ch8  = request->channel_ch8;
+  cmd.el2798_write_all_channels_cmd.channel_ch1 = request->channel_ch1;
+  cmd.el2798_write_all_channels_cmd.channel_ch2 = request->channel_ch2;
+  cmd.el2798_write_all_channels_cmd.channel_ch3 = request->channel_ch3;
+  cmd.el2798_write_all_channels_cmd.channel_ch4 = request->channel_ch4;
+  cmd.el2798_write_all_channels_cmd.channel_ch5 = request->channel_ch5;
+  cmd.el2798_write_all_channels_cmd.channel_ch6 = request->channel_ch6;
+  cmd.el2798_write_all_channels_cmd.channel_ch7 = request->channel_ch7;
+  cmd.el2798_write_all_channels_cmd.channel_ch8 = request->channel_ch8;
 
-  response->success =
-      DeviceExistsOnBus(cmd.name, fastcat::EL2798_STATE, response->message);
+  response->success = DeviceExistsOnBus(cmd.name, fastcat::EL2798_STATE, response->message);
   if (response->success) {
     QueueCommand(cmd);
   }
 }
 
 void Fcat::El2828WriteAllChannelsSrvCb(
-    const std::shared_ptr<
-        fcat_msgs::srv::El2828WriteAllChannelsService::Request>
-        request,
-    std::shared_ptr<fcat_msgs::srv::El2828WriteAllChannelsService::Response>
-        response)
-{
+    const std::shared_ptr<fcat_msgs::srv::El2828WriteAllChannelsService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::El2828WriteAllChannelsService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling EL2828 Write All Channels Command");
   fastcat::DeviceCmd cmd;
 
   cmd.name = request->name;
   cmd.type = fastcat::EL2828_WRITE_ALL_CHANNELS_CMD;
-  cmd.el2828_write_all_channels_cmd.channel_ch1  = request->channel_ch1;
-  cmd.el2828_write_all_channels_cmd.channel_ch2  = request->channel_ch2;
-  cmd.el2828_write_all_channels_cmd.channel_ch3  = request->channel_ch3;
-  cmd.el2828_write_all_channels_cmd.channel_ch4  = request->channel_ch4;
-  cmd.el2828_write_all_channels_cmd.channel_ch5  = request->channel_ch5;
-  cmd.el2828_write_all_channels_cmd.channel_ch6  = request->channel_ch6;
-  cmd.el2828_write_all_channels_cmd.channel_ch7  = request->channel_ch7;
-  cmd.el2828_write_all_channels_cmd.channel_ch8  = request->channel_ch8;
+  cmd.el2828_write_all_channels_cmd.channel_ch1 = request->channel_ch1;
+  cmd.el2828_write_all_channels_cmd.channel_ch2 = request->channel_ch2;
+  cmd.el2828_write_all_channels_cmd.channel_ch3 = request->channel_ch3;
+  cmd.el2828_write_all_channels_cmd.channel_ch4 = request->channel_ch4;
+  cmd.el2828_write_all_channels_cmd.channel_ch5 = request->channel_ch5;
+  cmd.el2828_write_all_channels_cmd.channel_ch6 = request->channel_ch6;
+  cmd.el2828_write_all_channels_cmd.channel_ch7 = request->channel_ch7;
+  cmd.el2828_write_all_channels_cmd.channel_ch8 = request->channel_ch8;
 
-  response->success =
-      DeviceExistsOnBus(cmd.name, fastcat::EL2828_STATE, response->message);
+  response->success = DeviceExistsOnBus(cmd.name, fastcat::EL2828_STATE, response->message);
   if (response->success) {
     QueueCommand(cmd);
   }
 }
 
 void Fcat::El2798WriteChannelSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::El2798WriteChannelService::Request>
-        request,
-    std::shared_ptr<fcat_msgs::srv::El2798WriteChannelService::Response>
-        response)
-{
+    const std::shared_ptr<fcat_msgs::srv::El2798WriteChannelService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::El2798WriteChannelService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling EL2798 Write Channel Command");
   fastcat::DeviceCmd cmd;
 
-  cmd.name                             = request->name;
-  cmd.type                             = fastcat::EL2798_WRITE_CHANNEL_CMD;
+  cmd.name = request->name;
+  cmd.type = fastcat::EL2798_WRITE_CHANNEL_CMD;
   cmd.el2798_write_channel_cmd.channel = request->channel;
-  cmd.el2798_write_channel_cmd.level   = request->level;
+  cmd.el2798_write_channel_cmd.level = request->level;
 
-  response->success =
-      DeviceExistsOnBus(cmd.name, fastcat::EL2798_STATE, response->message);
+  response->success = DeviceExistsOnBus(cmd.name, fastcat::EL2798_STATE, response->message);
   if (response->success) {
     QueueCommand(cmd);
   }
 }
 
 void Fcat::El2828WriteChannelSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::El2828WriteChannelService::Request>
-        request,
-    std::shared_ptr<fcat_msgs::srv::El2828WriteChannelService::Response>
-        response)
-{
+    const std::shared_ptr<fcat_msgs::srv::El2828WriteChannelService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::El2828WriteChannelService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling EL2828 Write Channel Command");
   fastcat::DeviceCmd cmd;
 
-  cmd.name                             = request->name;
-  cmd.type                             = fastcat::EL2828_WRITE_CHANNEL_CMD;
+  cmd.name = request->name;
+  cmd.type = fastcat::EL2828_WRITE_CHANNEL_CMD;
   cmd.el2828_write_channel_cmd.channel = request->channel;
-  cmd.el2828_write_channel_cmd.level   = request->level;
+  cmd.el2828_write_channel_cmd.level = request->level;
 
-  response->success =
-      DeviceExistsOnBus(cmd.name, fastcat::EL2828_STATE, response->message);
+  response->success = DeviceExistsOnBus(cmd.name, fastcat::EL2828_STATE, response->message);
   if (response->success) {
     QueueCommand(cmd);
   }
 }
 
 void Fcat::El4102WriteAllChannelsSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::El4102WriteAllChannelsService::Request>
-    request,
-  std::shared_ptr<fcat_msgs::srv::El4102WriteAllChannelsService::Response>
-    response)
-{
+    const std::shared_ptr<fcat_msgs::srv::El4102WriteAllChannelsService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::El4102WriteAllChannelsService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling EL4102 Write All Channels Command");
   fastcat::DeviceCmd cmd;
 
   cmd.name = request->name;
   cmd.type = fastcat::EL4102_WRITE_ALL_CHANNELS_CMD;
-  cmd.el4102_write_all_channels_cmd.voltage_output_ch1 =
-    request->voltage_output_ch1;
-  cmd.el4102_write_all_channels_cmd.voltage_output_ch2 =
-    request->voltage_output_ch2;
+  cmd.el4102_write_all_channels_cmd.voltage_output_ch1 = request->voltage_output_ch1;
+  cmd.el4102_write_all_channels_cmd.voltage_output_ch2 = request->voltage_output_ch2;
 
-  response->success =
-    DeviceExistsOnBus(cmd.name, fastcat::EL4102_STATE, response->message);
+  response->success = DeviceExistsOnBus(cmd.name, fastcat::EL4102_STATE, response->message);
   if (response->success) {
     QueueCommand(cmd);
   }
 }
 
 void Fcat::El4102WriteChannelSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::El4102WriteChannelService::Request>
-    request,
-  std::shared_ptr<fcat_msgs::srv::El4102WriteChannelService::Response> response)
-{
+    const std::shared_ptr<fcat_msgs::srv::El4102WriteChannelService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::El4102WriteChannelService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling EL4102 Write Channel Command");
   fastcat::DeviceCmd cmd;
 
@@ -1072,17 +919,15 @@ void Fcat::El4102WriteChannelSrvCb(
   cmd.el4102_write_channel_cmd.channel = request->channel;
   cmd.el4102_write_channel_cmd.voltage_output = request->voltage_output;
 
-  response->success =
-    DeviceExistsOnBus(cmd.name, fastcat::EL4102_STATE, response->message);
+  response->success = DeviceExistsOnBus(cmd.name, fastcat::EL4102_STATE, response->message);
   if (response->success) {
     QueueCommand(cmd);
   }
 }
 
 void Fcat::FaulterEnableSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::FaulterEnableService::Request> request,
-  std::shared_ptr<fcat_msgs::srv::FaulterEnableService::Response> response)
-{
+    const std::shared_ptr<fcat_msgs::srv::FaulterEnableService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::FaulterEnableService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling Faulter Enable Command");
   fastcat::DeviceCmd cmd;
 
@@ -1090,33 +935,29 @@ void Fcat::FaulterEnableSrvCb(
   cmd.type = fastcat::FAULTER_ENABLE_CMD;
   cmd.faulter_enable_cmd.enable = request->enable;
 
-  response->success =
-    DeviceExistsOnBus(cmd.name, fastcat::FAULTER_STATE, response->message);
+  response->success = DeviceExistsOnBus(cmd.name, fastcat::FAULTER_STATE, response->message);
   if (response->success) {
     QueueCommand(cmd);
   }
 }
 
 void Fcat::FtsTareSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::DeviceTriggerService::Request> request,
-  std::shared_ptr<fcat_msgs::srv::DeviceTriggerService::Response> response)
-{
+    const std::shared_ptr<fcat_msgs::srv::DeviceTriggerService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::DeviceTriggerService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling FTS Tare Command");
   fastcat::DeviceCmd cmd;
   cmd.name = request->name;
   cmd.type = fastcat::FTS_TARE_CMD;
 
-  response->success =
-    DeviceExistsOnBus(cmd.name, fastcat::FTS_STATE, response->message);
+  response->success = DeviceExistsOnBus(cmd.name, fastcat::FTS_STATE, response->message);
   if (response->success) {
     QueueCommand(cmd);
   }
 }
 
 void Fcat::PidActivateSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::PidActivateService::Request> request,
-  std::shared_ptr<fcat_msgs::srv::PidActivateService::Response> response)
-{
+    const std::shared_ptr<fcat_msgs::srv::PidActivateService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::PidActivateService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling PID Activate Command");
   fastcat::DeviceCmd cmd;
   cmd.type = fastcat::PID_ACTIVATE_CMD;
@@ -1125,8 +966,7 @@ void Fcat::PidActivateSrvCb(
   cmd.pid_activate_cmd.persistence_duration = request->persistence_duration;
   cmd.pid_activate_cmd.max_duration = request->max_duration;
 
-  response->success =
-    DeviceExistsOnBus(cmd.name, fastcat::PID_STATE, response->message);
+  response->success = DeviceExistsOnBus(cmd.name, fastcat::PID_STATE, response->message);
   if (response->success) {
     QueueCommand(cmd);
   }

--- a/src/fcat_callbacks.cpp
+++ b/src/fcat_callbacks.cpp
@@ -4,6 +4,8 @@
 
 #include "fastcat/jsd/actuator.h"
 
+#include <cstdio>
+
 void Fcat::ResetCmdCb(const std::shared_ptr<std_msgs::msg::Empty> msg)
 {
   reset_in_progress_ = true;
@@ -118,7 +120,7 @@ void Fcat::ActuatorCSPCmdCb(
 void Fcat::ActuatorCSPCmdsCb(
   const std::shared_ptr<fcat_msgs::msg::ActuatorCspCmds> msg)
 {
-  CFW_TRACE("Processing ActuatorCSPCmdsCb");
+  fprintf(stderr, "Processing ActuatorCSPCmdsCb\n");
   double t = this->now().seconds();
   for (auto csp_cmd : msg->commands) {
     CallActuatorCSP(csp_cmd, t);
@@ -164,7 +166,7 @@ void Fcat::ActuatorCSVCmdCb(
 void Fcat::ActuatorCSVCmdsCb(
   const std::shared_ptr<fcat_msgs::msg::ActuatorCsvCmds> msg)
 {
-  CFW_TRACE("Processing ActuatorCSVCmdsCb");
+  fprintf(stderr, "Processing ActuatorCSVCmdsCb\n");
   for (auto csv_cmd : msg->commands) {
     CallActuatorCSV(csv_cmd);
   }
@@ -209,7 +211,7 @@ void Fcat::ActuatorCSTCmdCb(
 void Fcat::ActuatorCSTCmdsCb(
   const std::shared_ptr<fcat_msgs::msg::ActuatorCstCmds> msg)
 {
-  CFW_TRACE("Processing ActuatorCSTCmdsCb");
+  fprintf(stderr, "Processing ActuatorCSTCmdsCb\n");
   for (auto cst_cmd : msg->commands) {
     CallActuatorCST(cst_cmd);
   }

--- a/src/fcat_callbacks.cpp
+++ b/src/fcat_callbacks.cpp
@@ -10,7 +10,7 @@ void Fcat::ResetCmdCb(const std::shared_ptr<std_msgs::msg::Empty> msg)
 {
   reset_in_progress_ = true;
   fcat_manager_.ExecuteAllDeviceResets();
-  FaultInterface::ResetCmdCb(msg);
+  // FaultInterface::ResetCmdCb(msg); // TODO: use lifecyle nodes
   reset_in_progress_ = false;
 }
 
@@ -19,7 +19,7 @@ void Fcat::FaultCmdCb(const std::shared_ptr<std_msgs::msg::Empty> msg)
   (void)msg;
   if (!reset_in_progress_) {
     fcat_manager_.ExecuteAllDeviceFaults();
-    FaultInterface::FaultCmdCb(msg);
+    // FaultInterface::FaultCmdCb(msg); // TODO: use lifecyle nodes
   }
 }
 
@@ -609,7 +609,7 @@ void Fcat::ResetSrvCb(
 {
   RCLCPP_INFO(this->get_logger(), "Handling Reset Command");
   fcat_manager_.ExecuteAllDeviceResets();
-  FaultInterface::ResetSrvCb(request, response);
+  // FaultInterface::ResetSrvCb(request, response); // TODO: use lifecyle nodes
 }
 
 void Fcat::FaultSrvCb(
@@ -618,7 +618,7 @@ void Fcat::FaultSrvCb(
 {
   RCLCPP_INFO(this->get_logger(), "Handling Fault Command");
   fcat_manager_.ExecuteAllDeviceFaults();
-  FaultInterface::FaultSrvCb(request, response);
+  // FaultInterface::FaultSrvCb(request, response); // TODO: use lifecyle nodes
 }
 
 void Fcat::ActuatorHaltSrvCb(

--- a/src/fcat_callbacks.cpp
+++ b/src/fcat_callbacks.cpp
@@ -1,9 +1,12 @@
+// Copyright 2021 California Institute of Technology
+
+#include <unistd.h>
+
 #include <cstdio>
 
 #include "fastcat/jsd/actuator.h"
-#include "fcat/fcat.hpp"
+#include "fcat.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "unistd.h"
 
 void Fcat::ResetCmdCb(const std::shared_ptr<std_msgs::msg::Empty> msg) {
   reset_in_progress_ = true;

--- a/src/fcat_callbacks.cpp
+++ b/src/fcat_callbacks.cpp
@@ -4,364 +4,264 @@
 
 #include "fastcat/jsd/actuator.h"
 
-fcat_msgs::msg::ActuatorState 
-  ActuatorStateToMsg(std::shared_ptr<const fastcat::DeviceState> state)
+void Fcat::ResetCmdCb(const std::shared_ptr<std_msgs::msg::Empty> msg)
 {
-  auto msg = fcat_msgs::msg::ActuatorState();
-
-  msg.actual_position =              state->actuator_state.actual_position;
-  msg.actual_velocity =              state->actuator_state.actual_velocity;
-  msg.actual_current =               state->actuator_state.actual_current;
-  msg.faulted =                      state->actuator_state.faulted;
-  msg.cmd_position =                 state->actuator_state.cmd_position;
-  msg.cmd_velocity =                 state->actuator_state.cmd_velocity;
-  msg.cmd_current =                  state->actuator_state.cmd_current;
-  msg.cmd_max_current =              state->actuator_state.cmd_max_current;
-  msg.egd_state_machine_state =      state->actuator_state.egd_state_machine_state;
-  msg.egd_mode_of_operation =        state->actuator_state.egd_mode_of_operation;
-  msg.sto_engaged =                  state->actuator_state.sto_engaged;
-  msg.hall_state =                   state->actuator_state.hall_state;
-  msg.target_reached =               state->actuator_state.target_reached;
-  msg.motor_on =                     state->actuator_state.motor_on;
-  msg.fault_code =                   state->actuator_state.fault_code;
-  msg.bus_voltage =                  state->actuator_state.bus_voltage;
-  msg.drive_temperature =            state->actuator_state.drive_temperature;
-  msg.egd_actual_position =          state->actuator_state.egd_actual_position;
-  msg.egd_cmd_position =             state->actuator_state.egd_cmd_position;
-  msg.actuator_state_machine_state = state->actuator_state.actuator_state_machine_state;
-
-  return msg;
-}
-
-fcat_msgs::msg::EgdState EgdStateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state)
-{
-  auto msg = fcat_msgs::msg::EgdState();
-
-  msg.actual_position =            state->egd_state.actual_position;
-  msg.actual_velocity =            state->egd_state.actual_velocity;
-  msg.actual_current =             state->egd_state.actual_current;
-  msg.faulted =                    state->egd_state.faulted;
-  msg.cmd_position =               state->egd_state.cmd_position;
-  msg.cmd_velocity =               state->egd_state.cmd_velocity;
-  msg.cmd_current =                state->egd_state.cmd_current;
-  msg.cmd_max_current =            state->egd_state.cmd_max_current;
-  msg.cmd_ff_position =            state->egd_state.cmd_ff_position;
-  msg.cmd_ff_velocity =            state->egd_state.cmd_ff_velocity;
-  msg.cmd_ff_current =             state->egd_state.cmd_ff_current;
-  msg.actual_state_machine_state = state->egd_state.actual_state_machine_state;
-  msg.actual_mode_of_operation =   state->egd_state.actual_mode_of_operation;
-  msg.async_sdo_in_prog =          state->egd_state.async_sdo_in_prog;
-  msg.sto_engaged =                state->egd_state.sto_engaged;
-  msg.hall_state =                 state->egd_state.hall_state;
-  msg.in_motion =                  state->egd_state.in_motion;
-  msg.warning =                    state->egd_state.warning;
-  msg.target_reached =             state->egd_state.target_reached;
-  msg.motor_on =                   state->egd_state.motor_on;
-  msg.fault_code =                 state->egd_state.fault_code;
-  msg.bus_voltage =                state->egd_state.bus_voltage;
-  msg.analog_input_voltage =       state->egd_state.analog_input_voltage;
-  msg.digital_input_ch1 =          state->egd_state.digital_input_ch1;
-  msg.digital_input_ch2 =          state->egd_state.digital_input_ch2;
-  msg.digital_input_ch3 =          state->egd_state.digital_input_ch3;
-  msg.digital_input_ch4 =          state->egd_state.digital_input_ch4;
-  msg.digital_input_ch5 =          state->egd_state.digital_input_ch5;
-  msg.digital_input_ch6 =          state->egd_state.digital_input_ch6;
-  msg.digital_output_cmd_ch1 =     state->egd_state.digital_output_cmd_ch1;
-  msg.digital_output_cmd_ch2 =     state->egd_state.digital_output_cmd_ch2;
-  msg.digital_output_cmd_ch3 =     state->egd_state.digital_output_cmd_ch3;
-  msg.digital_output_cmd_ch4 =     state->egd_state.digital_output_cmd_ch4;
-  msg.digital_output_cmd_ch5 =     state->egd_state.digital_output_cmd_ch5;
-  msg.digital_output_cmd_ch6 =     state->egd_state.digital_output_cmd_ch6;
-  msg.drive_temperature =          state->egd_state.drive_temperature;
-
-  return msg;
-}
-
-fcat_msgs::msg::El2124State El2124StateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state)
-{
-  auto msg = fcat_msgs::msg::El2124State();
-
-  msg.level_ch1 = state->el2124_state.level_ch1;
-  msg.level_ch2 = state->el2124_state.level_ch2;
-  msg.level_ch3 = state->el2124_state.level_ch3;
-  msg.level_ch4 = state->el2124_state.level_ch4;
-
-  return msg;
-}
-
-fcat_msgs::msg::El3208State El3208StateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state)
-{
-  auto msg = fcat_msgs::msg::El3208State();
-
-  msg.output_ch1 =    state->el3208_state.output_ch1;
-  msg.adc_value_ch1 = state->el3208_state.adc_value_ch1;
-  msg.output_ch2 =    state->el3208_state.output_ch2;
-  msg.adc_value_ch2 = state->el3208_state.adc_value_ch2;
-  msg.output_ch3 =    state->el3208_state.output_ch3;
-  msg.adc_value_ch3 = state->el3208_state.adc_value_ch3;
-  msg.output_ch4 =    state->el3208_state.output_ch4;
-  msg.adc_value_ch4 = state->el3208_state.adc_value_ch4;
-  msg.output_ch5 =    state->el3208_state.output_ch5;
-  msg.adc_value_ch5 = state->el3208_state.adc_value_ch5;
-  msg.output_ch6 =    state->el3208_state.output_ch6;
-  msg.adc_value_ch6 = state->el3208_state.adc_value_ch6;
-  msg.output_ch7 =    state->el3208_state.output_ch7;
-  msg.adc_value_ch7 = state->el3208_state.adc_value_ch7;
-  msg.output_ch8 =    state->el3208_state.output_ch8;
-  msg.adc_value_ch8 = state->el3208_state.adc_value_ch8;
-
-  return msg;
-}
-
-fcat_msgs::msg::El3602State El3602StateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state)
-{
-  auto msg = fcat_msgs::msg::El3602State();
-
-
-  msg.voltage_ch1 =   state->el3602_state.voltage_ch1;
-  msg.adc_value_ch1 = state->el3602_state.adc_value_ch1;
-  msg.voltage_ch2 =   state->el3602_state.voltage_ch2;
-  msg.adc_value_ch2 = state->el3602_state.adc_value_ch2;
-
-  return msg;
-}
-
-fcat_msgs::msg::JedState JedStateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state)
-{
-  auto msg = fcat_msgs::msg::JedState();
-
-  msg.status = state->jed_state.status;
-  msg.cmd = state->jed_state.cmd;
-  msg.w_raw = state->jed_state.w_raw;
-  msg.x_raw = state->jed_state.x_raw;
-  msg.y_raw = state->jed_state.y_raw;
-  msg.z_raw = state->jed_state.z_raw;
-  msg.w = state->jed_state.w;
-  msg.x = state->jed_state.x;
-  msg.y = state->jed_state.y;
-  msg.z = state->jed_state.z;
-
-  return msg;
-}
-
-fcat_msgs::msg::CommanderState CommanderStateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state)
-{
-  auto msg = fcat_msgs::msg::CommanderState();
-
-  msg.enable = state->commander_state.enable;
-
-  return msg;
-}
-
-fcat_msgs::msg::ConditionalState ConditionalStateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state)
-{
-  auto msg = fcat_msgs::msg::ConditionalState();
-
-  msg.output = state->conditional_state.output;
-
-  return msg;
-}
-
-fcat_msgs::msg::FaulterState FaulterStateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state)
-{
-  auto msg = fcat_msgs::msg::FaulterState();
-
-  msg.enable = state->faulter_state.enable;
-  msg.fault_active = state->faulter_state.fault_active;
-
-  return msg;
-}
-
-fcat_msgs::msg::FilterState FilterStateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state)
-{
-  auto msg = fcat_msgs::msg::FilterState();
-
-  msg.output = state->filter_state.output;
-
-  return msg;
-}
-
-/* TODO
-auto msg = geometry_msgs::msg::Wrench();
-
-msg.force.x  = state->fts_state.raw_fx;
-msg.force.y  = state->fts_state.raw_fy;
-msg.force.z  = state->fts_state.raw_fz;
-msg.torque.x = state->fts_state.raw_tx;
-msg.torque.y = state->fts_state.raw_ty;
-msg.torque.z = state->fts_state.raw_tz;
-
-fts_raw_pub_[state->name]->publish(msg);
-
-msg.force.x  = state->fts_state.tared_fx;
-msg.force.y  = state->fts_state.tared_fy;
-msg.force.z  = state->fts_state.tared_fz;
-msg.torque.x = state->fts_state.tared_tx;
-msg.torque.y = state->fts_state.tared_ty;
-msg.torque.z = state->fts_state.tared_tz;
-
-fts_tared_pub_[state->name]->publish(msg);
-*/
-
-fcat_msgs::msg::FunctionState FunctionStateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state)
-{
-  auto msg = fcat_msgs::msg::FunctionState();
-
-  msg.output = state->function_state.output;
-
-  return msg;
-}
-
-fcat_msgs::msg::PidState PidStateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state)
-{
-  auto msg = fcat_msgs::msg::PidState();
-
-  msg.active = state->pid_state.active;
-  msg.output = state->pid_state.output;
-  msg.kp_term = state->pid_state.kp_term;
-  msg.ki_term = state->pid_state.ki_term;
-  msg.kd_term = state->pid_state.kd_term;
-
-  return msg;
-}
-
-fcat_msgs::msg::SaturationState SaturationStateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state)
-{
-  auto msg = fcat_msgs::msg::SaturationState();
-
-  msg.output = state->saturation_state.output;
-
-  return msg;
-}
-
-fcat_msgs::msg::SchmittTriggerState SchmittTriggerStateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state)
-{
-  auto msg = fcat_msgs::msg::SchmittTriggerState();
-
-  msg.output = state->schmitt_trigger_state.output;
-
-  return msg;
-}
-
-fcat_msgs::msg::SignalGeneratorState SignalGeneratorStateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state)
-{
-  auto msg = fcat_msgs::msg::SignalGeneratorState();
-
-  msg.output = state->signal_generator_state.output;
-
-  return msg;
-}
-
-void Fcat::ResetCb( const std::shared_ptr<std_msgs::msg::Empty> msg)
-{
-  (void)msg;
+  reset_in_progress_ = true;
   fcat_manager_.ExecuteAllDeviceResets();
+  FaultInterface::ResetCmdCb(msg);
+  reset_in_progress_ = false;
 }
 
-void Fcat::FaultCb( const std::shared_ptr<std_msgs::msg::Empty> msg)
+void Fcat::FaultCmdCb(const std::shared_ptr<std_msgs::msg::Empty> msg)
 {
   (void)msg;
-  fcat_manager_.ExecuteAllDeviceFaults();
+  if (!reset_in_progress_) {
+    fcat_manager_.ExecuteAllDeviceFaults();
+    FaultInterface::FaultCmdCb(msg);
+  }
 }
 
-void Fcat::ActuatorCSPCmdCb( const std::shared_ptr<fcat_msgs::msg::ActuatorCspCmd> msg){
+void Fcat::AsyncSdoReadCmdCb(
+  const std::shared_ptr<fcat_msgs::msg::AsyncSdoReadCmd> msg)
+{
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
+  cmd.type = fastcat::ASYNC_SDO_READ_CMD;
+  cmd.async_sdo_read_cmd.sdo_index = msg->sdo_index;
+  cmd.async_sdo_read_cmd.sdo_subindex = msg->sdo_subindex;
+  cmd.async_sdo_read_cmd.data_type =
+    jsd_sdo_data_type_from_string(msg->data_type);
+  cmd.async_sdo_read_cmd.app_id = msg->app_id;
+
+  if (device_name_state_map_.end() != device_name_state_map_.find(msg->name)) {
+    QueueCommand(cmd);
+  }
+}
+void Fcat::AsyncSdoWriteCmdCb(
+  const std::shared_ptr<fcat_msgs::msg::AsyncSdoWriteCmd> msg)
+{
+  fastcat::DeviceCmd cmd;
+  cmd.name = msg->name;
+  cmd.type = fastcat::ASYNC_SDO_WRITE_CMD;
+  cmd.async_sdo_write_cmd.sdo_index = msg->sdo_index;
+  cmd.async_sdo_write_cmd.sdo_subindex = msg->sdo_subindex;
+  cmd.async_sdo_write_cmd.data_type =
+    jsd_sdo_data_type_from_string(msg->data_type);
+  cmd.async_sdo_write_cmd.app_id = msg->app_id;
+
+  cmd.async_sdo_write_cmd.data =
+    jsd_sdo_data_from_string(cmd.async_sdo_write_cmd.data_type, msg->data);
+
+  if (device_name_state_map_.end() != device_name_state_map_.find(msg->name)) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::CallActuatorCSP(const fcat_msgs::msg::ActuatorCspCmd& msg, double t)
+{
+  if(!cs_subscription_cb_realtime_preempt_initialized_) {
+    if(enable_realtime_preempt_) {
+      EVR_ACTIVITY_HI(
+        "Setting realtime priority for subscription callback thread to %d", 
+        scheduler_priority_ - 1);
+      SetRealtimePreempt(scheduler_priority_ - 1); 
+    }
+    cs_subscription_cb_realtime_preempt_initialized_ = true; 
+  }
+
+  if (!subscription_cpu_affinity_initialized_) {
+    if (process_loop_cpu_id_ >= 0) {
+      SetCpuAffinity();
+    }
+    subscription_cpu_affinity_initialized_ = true;
+  }
+
+  fastcat::DeviceCmd cmd;
+  cmd.name = msg.name;
   cmd.type = fastcat::ACTUATOR_CSP_CMD;
-  cmd.actuator_csp_cmd.target_position = msg->target_position;
-  cmd.actuator_csp_cmd.position_offset = msg->position_offset;
-  cmd.actuator_csp_cmd.velocity_offset = msg->velocity_offset;
-  cmd.actuator_csp_cmd.torque_offset_amps = msg->torque_offset_amps;
+  cmd.actuator_csp_cmd.request_time = msg.request_time;
+  cmd.actuator_csp_cmd.target_position = msg.target_position;
+  cmd.actuator_csp_cmd.position_offset = msg.position_offset;
+  cmd.actuator_csp_cmd.velocity_offset = msg.velocity_offset;
+  cmd.actuator_csp_cmd.torque_offset_amps = msg.torque_offset_amps;
 
-  if(DeviceExistsOnBus(cmd.name, fastcat::ACTUATOR_STATE)){
-    fcat_manager_.QueueCommand(cmd);
+  // these arguments are not part of the CSP spec, but are used to
+  // inform how to update CSP setpoints if a new setpoint is not received
+  // from the calling module
+  cmd.actuator_csp_cmd.acceleration_offset = msg.acceleration_offset;
+  cmd.actuator_csp_cmd.interpolation_mode = msg.interpolation_mode;
+  cmd.actuator_csp_cmd.receipt_stamp_time = t;
+
+  if (std::isnan(msg.request_time) ||
+      std::isnan(msg.target_position) ||
+      std::isnan(msg.position_offset) ||
+      std::isnan(msg.velocity_offset) ||
+      std::isnan(msg.torque_offset_amps)) {
+    EVR_WARNING_HI(
+        "A NaN value was found in a CSP setpoint; "
+        "The CSP setpoint was ignored"
+    );
+    return;
+  }
+
+  if (ActuatorExistsOnBus(cmd.name)) {
+    QueueCommand(cmd);
   }
 }
 
-void Fcat::ActuatorCSVCmdCb( const std::shared_ptr<fcat_msgs::msg::ActuatorCsvCmd> msg){
+void Fcat::ActuatorCSPCmdCb(
+  const std::shared_ptr<fcat_msgs::msg::ActuatorCspCmd> msg)
+{
+  this->CallActuatorCSP(*msg, this->now().seconds());
+}
+
+void Fcat::ActuatorCSPCmdsCb(
+  const std::shared_ptr<fcat_msgs::msg::ActuatorCspCmds> msg)
+{
+  CFW_TRACE("Processing ActuatorCSPCmdsCb");
+  double t = this->now().seconds();
+  for (auto csp_cmd : msg->commands) {
+    CallActuatorCSP(csp_cmd, t);
+  }
+}
+
+void Fcat::CallActuatorCSV(
+  const fcat_msgs::msg::ActuatorCsvCmd& msg)
+{
+  if(!cs_subscription_cb_realtime_preempt_initialized_) {
+    if(enable_realtime_preempt_) {
+       EVR_ACTIVITY_HI(
+        "Setting realtime priority for subscription callback thread to %d", 
+        scheduler_priority_ - 1);
+      SetRealtimePreempt(scheduler_priority_ - 1); 
+    }
+    cs_subscription_cb_realtime_preempt_initialized_ = true; 
+  }
+  if (!subscription_cpu_affinity_initialized_) {
+    if (process_loop_cpu_id_ >= 0) {
+      SetCpuAffinity();
+    }
+    subscription_cpu_affinity_initialized_ = true;
+  }
+
   fastcat::DeviceCmd cmd;
-  cmd.name = msg->name;
+  cmd.name = msg.name;
   cmd.type = fastcat::ACTUATOR_CSV_CMD;
-  cmd.actuator_csv_cmd.target_velocity = msg->target_velocity;
-  cmd.actuator_csv_cmd.velocity_offset = msg->velocity_offset;
-  cmd.actuator_csv_cmd.torque_offset_amps = msg->torque_offset_amps;
-
-  if(DeviceExistsOnBus(cmd.name, fastcat::ACTUATOR_STATE)){
-    fcat_manager_.QueueCommand(cmd);
+  cmd.actuator_csv_cmd.target_velocity = msg.target_velocity;
+  cmd.actuator_csv_cmd.velocity_offset = msg.velocity_offset;
+  cmd.actuator_csv_cmd.torque_offset_amps = msg.torque_offset_amps;
+  if (ActuatorExistsOnBus(cmd.name)) {
+    QueueCommand(cmd);
   }
 }
 
-void Fcat::ActuatorCSTCmdCb( const std::shared_ptr<fcat_msgs::msg::ActuatorCstCmd> msg){
+void Fcat::ActuatorCSVCmdCb(
+  const std::shared_ptr<fcat_msgs::msg::ActuatorCsvCmd> msg)
+{
+  this->CallActuatorCSV(*msg);
+}
+
+void Fcat::ActuatorCSVCmdsCb(
+  const std::shared_ptr<fcat_msgs::msg::ActuatorCsvCmds> msg)
+{
+  CFW_TRACE("Processing ActuatorCSVCmdsCb");
+  for (auto csv_cmd : msg->commands) {
+    CallActuatorCSV(csv_cmd);
+  }
+}
+
+void Fcat::CallActuatorCST(
+  const fcat_msgs::msg::ActuatorCstCmd& msg)
+{
+  if(!cs_subscription_cb_realtime_preempt_initialized_) {
+    if(enable_realtime_preempt_) {
+      EVR_ACTIVITY_HI(
+        "Setting realtime priority for subscription callback thread to %d", 
+        scheduler_priority_ - 1);
+      SetRealtimePreempt(scheduler_priority_ - 1); 
+    }
+    cs_subscription_cb_realtime_preempt_initialized_ = true; 
+  }
+  if (!subscription_cpu_affinity_initialized_) {
+    if (process_loop_cpu_id_ >= 0) {
+      SetCpuAffinity();
+    }
+    subscription_cpu_affinity_initialized_ = true;
+  }
+
   fastcat::DeviceCmd cmd;
-  cmd.name = msg->name;
+  cmd.name = msg.name;
   cmd.type = fastcat::ACTUATOR_CST_CMD;
-  cmd.actuator_cst_cmd.target_torque_amps = msg->target_torque_amps;
-  cmd.actuator_cst_cmd.torque_offset_amps = msg->torque_offset_amps;
-
-  if(DeviceExistsOnBus(cmd.name, fastcat::ACTUATOR_STATE)){
-    fcat_manager_.QueueCommand(cmd);
+  cmd.actuator_cst_cmd.target_torque_amps = msg.target_torque_amps;
+  cmd.actuator_cst_cmd.torque_offset_amps = msg.torque_offset_amps;
+  if (ActuatorExistsOnBus(cmd.name)) {
+    QueueCommand(cmd);
   }
 }
 
-void Fcat::ActuatorCalibrateCmdCb( 
-    const std::shared_ptr<fcat_msgs::msg::ActuatorCalibrateCmd> msg)
+void Fcat::ActuatorCSTCmdCb(
+  const std::shared_ptr<fcat_msgs::msg::ActuatorCstCmd> msg)
+{
+  CallActuatorCST(*msg);
+}
+
+
+void Fcat::ActuatorCSTCmdsCb(
+  const std::shared_ptr<fcat_msgs::msg::ActuatorCstCmds> msg)
+{
+  CFW_TRACE("Processing ActuatorCSTCmdsCb");
+  for (auto cst_cmd : msg->commands) {
+    CallActuatorCST(cst_cmd);
+  }
+}
+
+void Fcat::ActuatorCalibrateCmdCb(
+  const std::shared_ptr<fcat_msgs::msg::ActuatorCalibrateCmd> msg)
 {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::ACTUATOR_CALIBRATE_CMD;
-  cmd.actuator_calibrate_cmd.velocity    = msg->velocity;
-  cmd.actuator_calibrate_cmd.accel       = msg->accel;
+  cmd.actuator_calibrate_cmd.velocity = msg->velocity;
+  cmd.actuator_calibrate_cmd.accel = msg->accel;
   cmd.actuator_calibrate_cmd.max_current = msg->max_current;
-
-  if(DeviceExistsOnBus(cmd.name, fastcat::ACTUATOR_STATE)){
-    fcat_manager_.QueueCommand(cmd);
+  if (ActuatorExistsOnBus(cmd.name)) {
+    QueueCommand(cmd);
   }
 }
 
-void Fcat::ActuatorProfPosCmdCb( 
-    const std::shared_ptr<fcat_msgs::msg::ActuatorProfPosCmd> msg)
+void Fcat::CallActuatorProfPos(const fcat_msgs::msg::ActuatorProfPosCmd& msg)
 {
   fastcat::DeviceCmd cmd;
-  cmd.name = msg->name;
+  cmd.name = msg.name;
   cmd.type = fastcat::ACTUATOR_PROF_POS_CMD;
-  cmd.actuator_prof_pos_cmd.target_position = msg->target_position;
-  cmd.actuator_prof_pos_cmd.profile_velocity = msg->profile_velocity;
-  cmd.actuator_prof_pos_cmd.profile_accel= msg->profile_accel;
-  cmd.actuator_prof_pos_cmd.relative = msg->relative;
-
-  if(DeviceExistsOnBus(cmd.name, fastcat::ACTUATOR_STATE)){
-    fcat_manager_.QueueCommand(cmd);
+  cmd.actuator_prof_pos_cmd.target_position = msg.target_position;
+  cmd.actuator_prof_pos_cmd.profile_velocity = msg.profile_velocity;
+  cmd.actuator_prof_pos_cmd.profile_accel = msg.profile_accel;
+  cmd.actuator_prof_pos_cmd.relative = msg.relative;
+  if (ActuatorExistsOnBus(cmd.name)) {
+    QueueCommand(cmd);
   }
 }
-void Fcat::ActuatorProfTorqueCmdCb( 
-    const std::shared_ptr<fcat_msgs::msg::ActuatorProfTorqueCmd> msg)
+
+void Fcat::ActuatorProfPosCmdCb(
+  const std::shared_ptr<fcat_msgs::msg::ActuatorProfPosCmd> msg)
+{
+  CallActuatorProfPos(*msg);
+}
+void Fcat::ActuatorProfTorqueCmdCb(
+  const std::shared_ptr<fcat_msgs::msg::ActuatorProfTorqueCmd> msg)
 {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::ACTUATOR_PROF_TORQUE_CMD;
   cmd.actuator_prof_torque_cmd.target_torque_amps = msg->target_torque_amps;
   cmd.actuator_prof_torque_cmd.max_duration = msg->max_duration;
-
-  if(DeviceExistsOnBus(cmd.name, fastcat::ACTUATOR_STATE)){
-    fcat_manager_.QueueCommand(cmd);
+  if (ActuatorExistsOnBus(cmd.name)) {
+    QueueCommand(cmd);
   }
 }
-void Fcat::ActuatorProfVelCmdCb( 
-    const std::shared_ptr<fcat_msgs::msg::ActuatorProfVelCmd> msg)
+void Fcat::ActuatorProfVelCmdCb(
+  const std::shared_ptr<fcat_msgs::msg::ActuatorProfVelCmd> msg)
 {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
@@ -369,53 +269,135 @@ void Fcat::ActuatorProfVelCmdCb(
   cmd.actuator_prof_vel_cmd.target_velocity = msg->target_velocity;
   cmd.actuator_prof_vel_cmd.profile_accel = msg->profile_accel;
   cmd.actuator_prof_vel_cmd.max_duration = msg->max_duration;
-
-  if(DeviceExistsOnBus(cmd.name, fastcat::ACTUATOR_STATE)){
-    fcat_manager_.QueueCommand(cmd);
+  if (ActuatorExistsOnBus(cmd.name)) {
+    QueueCommand(cmd);
   }
 }
 
-void Fcat::ActuatorSetOutputPositionCmdCb( 
-    const std::shared_ptr<fcat_msgs::msg::ActuatorSetOutputPositionCmd> msg)
+void Fcat::ActuatorProfPosCmdsCb(
+  const std::shared_ptr<fcat_msgs::msg::ActuatorProfPosCmds> msg)
 {
+  for (auto prof_pos_cmd : msg->commands) {
+    CallActuatorProfPos(prof_pos_cmd);
+  }
+}
 
+void Fcat::ActuatorSetOutputPositionCmdCb(
+  const std::shared_ptr<fcat_msgs::msg::ActuatorSetOutputPositionCmd> msg)
+{
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::ACTUATOR_SET_OUTPUT_POSITION_CMD;
   cmd.actuator_set_output_position_cmd.position = msg->position;
-
-  if(DeviceExistsOnBus(cmd.name, fastcat::ACTUATOR_STATE)){
-    fcat_manager_.QueueCommand(cmd);
+  if (ActuatorExistsOnBus(cmd.name)) {
+    QueueCommand(cmd);
   }
 }
 
-void Fcat::CommanderEnableCmdCb( 
-    const std::shared_ptr<fcat_msgs::msg::CommanderEnableCmd> msg)
+void Fcat::ActuatorSetDigitalOutputCmdCb(
+  const std::shared_ptr<fcat_msgs::msg::ActuatorSetDigitalOutputCmd> msg)
+{
+  fastcat::DeviceCmd cmd;
+  cmd.name = msg->name;
+  cmd.type = fastcat::ACTUATOR_SET_DIGITAL_OUTPUT_CMD;
+  cmd.actuator_set_digital_output_cmd.digital_output_index =
+    msg->digital_output_index;
+  cmd.actuator_set_digital_output_cmd.output_level = msg->output_level;
+  if (ActuatorExistsOnBus(cmd.name)) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::ActuatorSetMaxCurrentCmdCb(
+  const std::shared_ptr<fcat_msgs::msg::ActuatorSetMaxCurrentCmd> msg)
+{
+  fastcat::DeviceCmd cmd;
+  cmd.name = msg->name;
+  cmd.type = fastcat::ACTUATOR_SET_MAX_CURRENT_CMD;
+  cmd.actuator_set_max_current_cmd.current = msg->max_current;
+
+  if (ActuatorExistsOnBus(cmd.name)) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::ActuatorSetUnitModeCmdCb(
+  const std::shared_ptr<fcat_msgs::msg::ActuatorSetUnitModeCmd> msg)
+{
+  fastcat::DeviceCmd cmd;
+  cmd.name = msg->name;
+  cmd.type = fastcat::ACTUATOR_SDO_SET_UNIT_MODE_CMD;
+  cmd.actuator_sdo_set_unit_mode_cmd.mode = msg->mode;
+  cmd.actuator_sdo_set_unit_mode_cmd.app_id = msg->app_id;
+  if (ActuatorExistsOnBus(cmd.name)) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::ActuatorSetProfDisengagingTimeoutCmdCb(
+  const std::shared_ptr<fcat_msgs::msg::ActuatorSetProfDisengagingTimeoutCmd>
+    msg)
+{
+  fastcat::DeviceCmd cmd;
+  cmd.name = msg->name;
+  cmd.type = fastcat::ACTUATOR_SET_PROF_DISENGAGING_TIMEOUT_CMD;
+  cmd.actuator_set_prof_disengaging_timeout_cmd.timeout = msg->timeout;
+  if (ActuatorExistsOnBus(cmd.name)) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::ActuatorHaltCmdCb(
+  const std::shared_ptr<fcat_msgs::msg::ActuatorHaltCmd> msg)
+{
+  fastcat::DeviceCmd cmd;
+  cmd.name = msg->name;
+  cmd.type = fastcat::ACTUATOR_HALT_CMD;
+  if (ActuatorExistsOnBus(cmd.name)) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::ActuatorHaltCmdsCb(
+  const std::shared_ptr<fcat_msgs::msg::ActuatorHaltCmds> msg)
+{
+  for (auto& name : msg->names) {
+    fastcat::DeviceCmd cmd;
+    cmd.name = name;
+    cmd.type = fastcat::ACTUATOR_HALT_CMD;
+    if (ActuatorExistsOnBus(cmd.name)) {
+      QueueCommand(cmd);
+    }
+  }
+}
+
+void Fcat::CommanderEnableCmdCb(
+  const std::shared_ptr<fcat_msgs::msg::CommanderEnableCmd> msg)
 {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::COMMANDER_ENABLE_CMD;
   cmd.commander_enable_cmd.duration = msg->duration;
 
-  if(DeviceExistsOnBus(cmd.name, fastcat::COMMANDER_STATE)){
-    fcat_manager_.QueueCommand(cmd);
+  if (DeviceExistsOnBus(cmd.name, fastcat::COMMANDER_STATE)) {
+    QueueCommand(cmd);
   }
 }
 
-void Fcat::CommanderDisableCmdCb( 
-    const std::shared_ptr<fcat_msgs::msg::CommanderDisableCmd> msg)
+void Fcat::CommanderDisableCmdCb(
+  const std::shared_ptr<fcat_msgs::msg::CommanderDisableCmd> msg)
 {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::COMMANDER_DISABLE_CMD;
 
-  if(DeviceExistsOnBus(cmd.name, fastcat::COMMANDER_STATE)){
-    fcat_manager_.QueueCommand(cmd);
+  if (DeviceExistsOnBus(cmd.name, fastcat::COMMANDER_STATE)) {
+    QueueCommand(cmd);
   }
 }
 
-void Fcat::El2124WriteAllChannelsCmdCb( 
-    const std::shared_ptr<fcat_msgs::msg::El2124WriteAllChannelsCmd> msg)
+void Fcat::El2124WriteAllChannelsCmdCb(
+  const std::shared_ptr<fcat_msgs::msg::El2124WriteAllChannelsCmd> msg)
 {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
@@ -425,12 +407,12 @@ void Fcat::El2124WriteAllChannelsCmdCb(
   cmd.el2124_write_all_channels_cmd.channel_ch3 = msg->channel_ch3;
   cmd.el2124_write_all_channels_cmd.channel_ch4 = msg->channel_ch4;
 
-  if(DeviceExistsOnBus(cmd.name, fastcat::EL2124_STATE)){
-    fcat_manager_.QueueCommand(cmd);
+  if (DeviceExistsOnBus(cmd.name, fastcat::EL2124_STATE)) {
+    QueueCommand(cmd);
   }
 }
-void Fcat::El2124WriteChannelCmdCb( 
-    const std::shared_ptr<fcat_msgs::msg::El2124WriteChannelCmd> msg)
+void Fcat::El2124WriteChannelCmdCb(
+  const std::shared_ptr<fcat_msgs::msg::El2124WriteChannelCmd> msg)
 {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
@@ -438,47 +420,173 @@ void Fcat::El2124WriteChannelCmdCb(
   cmd.el2124_write_channel_cmd.channel = msg->channel;
   cmd.el2124_write_channel_cmd.level = msg->level;
 
-  if(DeviceExistsOnBus(cmd.name, fastcat::EL2124_STATE)){
-    fcat_manager_.QueueCommand(cmd);
+  if (DeviceExistsOnBus(cmd.name, fastcat::EL2124_STATE)) {
+    QueueCommand(cmd);
   }
 }
 
-void Fcat::FaulterEnableCmdCb( const std::shared_ptr<fcat_msgs::msg::FaulterEnableCmd> msg)
+void Fcat::El2809WriteAllChannelsCmdCb(
+  const std::shared_ptr<fcat_msgs::msg::El2809WriteAllChannelsCmd> msg)
+{
+  fastcat::DeviceCmd cmd;
+  cmd.name = msg->name;
+  cmd.type = fastcat::EL2809_WRITE_ALL_CHANNELS_CMD;
+  cmd.el2809_write_all_channels_cmd.channel_ch1 = msg->channel_ch1;
+  cmd.el2809_write_all_channels_cmd.channel_ch2 = msg->channel_ch2;
+  cmd.el2809_write_all_channels_cmd.channel_ch3 = msg->channel_ch3;
+  cmd.el2809_write_all_channels_cmd.channel_ch4 = msg->channel_ch4;
+  cmd.el2809_write_all_channels_cmd.channel_ch5 = msg->channel_ch5;
+  cmd.el2809_write_all_channels_cmd.channel_ch6 = msg->channel_ch6;
+  cmd.el2809_write_all_channels_cmd.channel_ch7 = msg->channel_ch7;
+  cmd.el2809_write_all_channels_cmd.channel_ch8 = msg->channel_ch8;
+  cmd.el2809_write_all_channels_cmd.channel_ch9 = msg->channel_ch9;
+  cmd.el2809_write_all_channels_cmd.channel_ch10 = msg->channel_ch10;
+  cmd.el2809_write_all_channels_cmd.channel_ch11 = msg->channel_ch11;
+  cmd.el2809_write_all_channels_cmd.channel_ch12 = msg->channel_ch12;
+  cmd.el2809_write_all_channels_cmd.channel_ch13 = msg->channel_ch13;
+  cmd.el2809_write_all_channels_cmd.channel_ch14 = msg->channel_ch14;
+  cmd.el2809_write_all_channels_cmd.channel_ch15 = msg->channel_ch15;
+  cmd.el2809_write_all_channels_cmd.channel_ch16 = msg->channel_ch16;
+
+  if (DeviceExistsOnBus(cmd.name, fastcat::EL2809_STATE)) {
+    QueueCommand(cmd);
+  }
+}
+void Fcat::El2809WriteChannelCmdCb(
+  const std::shared_ptr<fcat_msgs::msg::El2809WriteChannelCmd> msg)
+{
+  fastcat::DeviceCmd cmd;
+  cmd.name = msg->name;
+  cmd.type = fastcat::EL2809_WRITE_CHANNEL_CMD;
+  cmd.el2809_write_channel_cmd.channel = msg->channel;
+  cmd.el2809_write_channel_cmd.level = msg->level;
+
+  if (DeviceExistsOnBus(cmd.name, fastcat::EL2809_STATE)) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::El2798WriteAllChannelsCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::El2798WriteAllChannelsCmd> msg)
+{
+  fastcat::DeviceCmd cmd;
+  cmd.name = msg->name;
+  cmd.type = fastcat::EL2798_WRITE_ALL_CHANNELS_CMD;
+  cmd.el2798_write_all_channels_cmd.channel_ch1  = msg->channel_ch1;
+  cmd.el2798_write_all_channels_cmd.channel_ch2  = msg->channel_ch2;
+  cmd.el2798_write_all_channels_cmd.channel_ch3  = msg->channel_ch3;
+  cmd.el2798_write_all_channels_cmd.channel_ch4  = msg->channel_ch4;
+  cmd.el2798_write_all_channels_cmd.channel_ch5  = msg->channel_ch5;
+  cmd.el2798_write_all_channels_cmd.channel_ch6  = msg->channel_ch6;
+  cmd.el2798_write_all_channels_cmd.channel_ch7  = msg->channel_ch7;
+  cmd.el2798_write_all_channels_cmd.channel_ch8  = msg->channel_ch8;
+
+  if (DeviceExistsOnBus(cmd.name, fastcat::EL2798_STATE)) {
+    QueueCommand(cmd);
+  }
+}
+void Fcat::El2798WriteChannelCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::El2798WriteChannelCmd> msg)
+{
+  fastcat::DeviceCmd cmd;
+  cmd.name                             = msg->name;
+  cmd.type                             = fastcat::EL2798_WRITE_CHANNEL_CMD;
+  cmd.el2798_write_channel_cmd.channel = msg->channel;
+  cmd.el2798_write_channel_cmd.level   = msg->level;
+
+  if (DeviceExistsOnBus(cmd.name, fastcat::EL2798_STATE)) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::El2828WriteAllChannelsCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::El2828WriteAllChannelsCmd> msg)
+{
+  fastcat::DeviceCmd cmd;
+  cmd.name = msg->name;
+  cmd.type = fastcat::EL2828_WRITE_ALL_CHANNELS_CMD;
+  cmd.el2828_write_all_channels_cmd.channel_ch1  = msg->channel_ch1;
+  cmd.el2828_write_all_channels_cmd.channel_ch2  = msg->channel_ch2;
+  cmd.el2828_write_all_channels_cmd.channel_ch3  = msg->channel_ch3;
+  cmd.el2828_write_all_channels_cmd.channel_ch4  = msg->channel_ch4;
+  cmd.el2828_write_all_channels_cmd.channel_ch5  = msg->channel_ch5;
+  cmd.el2828_write_all_channels_cmd.channel_ch6  = msg->channel_ch6;
+  cmd.el2828_write_all_channels_cmd.channel_ch7  = msg->channel_ch7;
+  cmd.el2828_write_all_channels_cmd.channel_ch8  = msg->channel_ch8;
+
+  if (DeviceExistsOnBus(cmd.name, fastcat::EL2828_STATE)) {
+    QueueCommand(cmd);
+  }
+}
+void Fcat::El2828WriteChannelCmdCb(
+    const std::shared_ptr<fcat_msgs::msg::El2828WriteChannelCmd> msg)
+{
+  fastcat::DeviceCmd cmd;
+  cmd.name                             = msg->name;
+  cmd.type                             = fastcat::EL2828_WRITE_CHANNEL_CMD;
+  cmd.el2828_write_channel_cmd.channel = msg->channel;
+  cmd.el2828_write_channel_cmd.level   = msg->level;
+
+  if (DeviceExistsOnBus(cmd.name, fastcat::EL2828_STATE)) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::El4102WriteAllChannelsCmdCb(
+  const std::shared_ptr<fcat_msgs::msg::El4102WriteAllChannelsCmd> msg)
+{
+  fastcat::DeviceCmd cmd;
+  cmd.name = msg->name;
+  cmd.type = fastcat::EL4102_WRITE_ALL_CHANNELS_CMD;
+  cmd.el4102_write_all_channels_cmd.voltage_output_ch1 =
+    msg->voltage_output_ch1;
+  cmd.el4102_write_all_channels_cmd.voltage_output_ch2 =
+    msg->voltage_output_ch2;
+
+  if (DeviceExistsOnBus(cmd.name, fastcat::EL4102_STATE)) {
+    QueueCommand(cmd);
+  }
+}
+void Fcat::El4102WriteChannelCmdCb(
+  const std::shared_ptr<fcat_msgs::msg::El4102WriteChannelCmd> msg)
+{
+  fastcat::DeviceCmd cmd;
+  cmd.name = msg->name;
+  cmd.type = fastcat::EL4102_WRITE_CHANNEL_CMD;
+  cmd.el4102_write_channel_cmd.channel = msg->channel;
+  cmd.el4102_write_channel_cmd.voltage_output = msg->voltage_output;
+
+  if (DeviceExistsOnBus(cmd.name, fastcat::EL4102_STATE)) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::FaulterEnableCmdCb(
+  const std::shared_ptr<fcat_msgs::msg::FaulterEnableCmd> msg)
 {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::FAULTER_ENABLE_CMD;
   cmd.faulter_enable_cmd.enable = msg->enable;
 
-  if(DeviceExistsOnBus(cmd.name, fastcat::FAULTER_STATE)){
-    fcat_manager_.QueueCommand(cmd);
+  if (DeviceExistsOnBus(cmd.name, fastcat::FAULTER_STATE)) {
+    QueueCommand(cmd);
   }
 }
 
-void Fcat::FtsTareCmdCb( const std::shared_ptr<fcat_msgs::msg::FtsTareCmd> msg)
+void Fcat::FtsTareCmdCb(const std::shared_ptr<fcat_msgs::msg::FtsTareCmd> msg)
 {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
   cmd.type = fastcat::FTS_TARE_CMD;
 
-  if(DeviceExistsOnBus(cmd.name, fastcat::FTS_STATE)){
-    fcat_manager_.QueueCommand(cmd);
+  if (DeviceExistsOnBus(cmd.name, fastcat::FTS_STATE)) {
+    QueueCommand(cmd);
   }
 }
 
-void Fcat::JedSetCmdValueCmdCb( const std::shared_ptr<fcat_msgs::msg::JedSetCmdValueCmd> msg)
-{
-  fastcat::DeviceCmd cmd;
-  cmd.name = msg->name;
-  cmd.type = fastcat::JED_SET_CMD_VALUE_CMD;
-  cmd.jed_set_cmd_value_cmd.cmd = msg->cmd;
-
-  if(DeviceExistsOnBus(cmd.name, fastcat::JED_STATE)){
-    fcat_manager_.QueueCommand(cmd);
-  }
-}
-
-void Fcat::PidActivateCmdCb( const std::shared_ptr<fcat_msgs::msg::PidActivateCmd> msg)
+void Fcat::PidActivateCmdCb(
+  const std::shared_ptr<fcat_msgs::msg::PidActivateCmd> msg)
 {
   fastcat::DeviceCmd cmd;
   cmd.name = msg->name;
@@ -488,7 +596,536 @@ void Fcat::PidActivateCmdCb( const std::shared_ptr<fcat_msgs::msg::PidActivateCm
   cmd.pid_activate_cmd.persistence_duration = msg->persistence_duration;
   cmd.pid_activate_cmd.max_duration = msg->max_duration;
 
-  if(DeviceExistsOnBus(cmd.name, fastcat::PID_STATE)){
-    fcat_manager_.QueueCommand(cmd);
+  if (DeviceExistsOnBus(cmd.name, fastcat::PID_STATE)) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::ResetSrvCb(
+  const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+  std::shared_ptr<std_srvs::srv::Trigger::Response> response)
+{
+  EVR_ACTIVITY_LO("Handling Reset Command");
+  fcat_manager_.ExecuteAllDeviceResets();
+  FaultInterface::ResetSrvCb(request, response);
+}
+
+void Fcat::FaultSrvCb(
+  const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+  std::shared_ptr<std_srvs::srv::Trigger::Response> response)
+{
+  EVR_ACTIVITY_LO("Handling Fault Command");
+  fcat_manager_.ExecuteAllDeviceFaults();
+  FaultInterface::FaultSrvCb(request, response);
+}
+
+void Fcat::ActuatorHaltSrvCb(
+  const std::shared_ptr<fcat_msgs::srv::ActuatorHaltService::Request> request,
+  std::shared_ptr<fcat_msgs::srv::ActuatorHaltService::Response> response)
+{
+  EVR_ACTIVITY_LO("Handling Actuator Halt Command");
+  fastcat::DeviceCmd cmd;
+  cmd.name = request->name;
+  cmd.type = fastcat::ACTUATOR_HALT_CMD;
+
+  response->success = ActuatorExistsOnBus(cmd.name, response->message);
+  if (response->success) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::ActuatorSetGainSchedulingIndexSrvCb(
+  const std::shared_ptr<
+    fcat_msgs::srv::ActuatorSetGainSchedulingIndexService::Request>
+    request,
+  std::shared_ptr<
+    fcat_msgs::srv::ActuatorSetGainSchedulingIndexService::Response>
+    response)
+{
+  EVR_ACTIVITY_LO("Handling Actuator Set Gain Scheduling Index Command");
+  fastcat::DeviceCmd cmd;
+  cmd.name = request->name;
+  cmd.type = fastcat::ACTUATOR_SET_GAIN_SCHEDULING_INDEX_CMD;
+  cmd.actuator_set_gain_scheduling_index_cmd.gain_scheduling_index =
+    request->gain_scheduling_index;
+
+  response->success = ActuatorExistsOnBus(cmd.name, response->message);
+  if (response->success) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::ActuatorSetMaxCurrentSrvCb(
+  const std::shared_ptr<fcat_msgs::srv::ActuatorSetMaxCurrentService::Request>
+    request,
+  std::shared_ptr<fcat_msgs::srv::ActuatorSetMaxCurrentService::Response>
+    response)
+{
+  EVR_ACTIVITY_LO("Handling Actuator Set Max Current Command");
+  fastcat::DeviceCmd cmd;
+  cmd.name = request->name;
+  cmd.type = fastcat::ACTUATOR_SET_MAX_CURRENT_CMD;
+  cmd.actuator_set_max_current_cmd.current = request->max_current;
+
+  response->success = ActuatorExistsOnBus(cmd.name, response->message);
+  if (response->success) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::ActuatorSetDigitalOutputSrvCb(
+  const std::shared_ptr<
+    fcat_msgs::srv::ActuatorSetDigitalOutputService::Request>
+    request,
+  std::shared_ptr<fcat_msgs::srv::ActuatorSetDigitalOutputService::Response>
+    response)
+{
+  EVR_ACTIVITY_LO("Handling Actuator Set Digital Output Command");
+  fastcat::DeviceCmd cmd;
+  cmd.name = request->name;
+  cmd.type = fastcat::ACTUATOR_SET_DIGITAL_OUTPUT_CMD;
+  cmd.actuator_set_digital_output_cmd.digital_output_index =
+    request->digital_output_index;
+  cmd.actuator_set_digital_output_cmd.output_level = request->output_level;
+  response->success = ActuatorExistsOnBus(cmd.name, response->message);
+  if (response->success) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::ActuatorSetProfDisengagingTimeoutSrvCb(
+  const std::shared_ptr<
+    fcat_msgs::srv::ActuatorSetProfDisengagingTimeoutService::Request>
+    request,
+  std::shared_ptr<
+    fcat_msgs::srv::ActuatorSetProfDisengagingTimeoutService::Response>
+    response)
+{
+  EVR_ACTIVITY_LO("Handling Actuator Set Profile Disengaging Timeout Command");
+  fastcat::DeviceCmd cmd;
+  cmd.name = request->name;
+  cmd.type = fastcat::ACTUATOR_SET_PROF_DISENGAGING_TIMEOUT_CMD;
+  cmd.actuator_set_prof_disengaging_timeout_cmd.timeout = request->timeout;
+
+  response->success = ActuatorExistsOnBus(cmd.name, response->message);
+  if (response->success) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::ActuatorSetOutputPositionSrvCb(
+  const std::shared_ptr<
+    fcat_msgs::srv::ActuatorSetOutputPositionService::Request>
+    request,
+  std::shared_ptr<fcat_msgs::srv::ActuatorSetOutputPositionService::Response>
+    response)
+{
+  EVR_ACTIVITY_LO("Handling Actuator Set Output Position Command");
+  fastcat::DeviceCmd cmd;
+  cmd.name = request->name;
+  cmd.type = fastcat::ACTUATOR_SET_OUTPUT_POSITION_CMD;
+  cmd.actuator_set_output_position_cmd.position = request->position;
+  response->success = ActuatorExistsOnBus(cmd.name, response->message);
+  if (response->success) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::ActuatorCalibrateSrvCb(
+  const std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateService::Request>
+    request,
+  std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateService::Response> response)
+{
+  EVR_ACTIVITY_LO("Handling Actuator Calibrate Command");
+  fastcat::DeviceCmd cmd;
+  cmd.name = request->name;
+  cmd.type = fastcat::ACTUATOR_CALIBRATE_CMD;
+  cmd.actuator_calibrate_cmd.velocity = request->velocity;
+  cmd.actuator_calibrate_cmd.accel = request->accel;
+  cmd.actuator_calibrate_cmd.max_current = request->max_current;
+  response->success = ActuatorExistsOnBus(cmd.name, response->message);
+  if (response->success) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::ActuatorProfPosSrvCb(
+  const std::shared_ptr<fcat_msgs::srv::ActuatorProfPosService::Request>
+    request,
+  std::shared_ptr<fcat_msgs::srv::ActuatorProfPosService::Response> response)
+{
+  EVR_ACTIVITY_LO("Handling Actuator Set Prof Pos Command");
+  fastcat::DeviceCmd cmd;
+  cmd.name = request->name;
+  cmd.type = fastcat::ACTUATOR_PROF_POS_CMD;
+  cmd.actuator_prof_pos_cmd.target_position = request->target_position;
+  cmd.actuator_prof_pos_cmd.profile_velocity = request->profile_velocity;
+  cmd.actuator_prof_pos_cmd.profile_accel = request->profile_accel;
+  cmd.actuator_prof_pos_cmd.relative = request->relative;
+  response->success = ActuatorExistsOnBus(cmd.name, response->message);
+  if (response->success) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::ActuatorProfVelSrvCb(
+  const std::shared_ptr<fcat_msgs::srv::ActuatorProfVelService::Request>
+    request,
+  std::shared_ptr<fcat_msgs::srv::ActuatorProfVelService::Response> response)
+{
+  EVR_ACTIVITY_LO("Handling Actuator Set Prof Vel Command");
+  fastcat::DeviceCmd cmd;
+  cmd.name = request->name;
+  cmd.type = fastcat::ACTUATOR_PROF_VEL_CMD;
+  cmd.actuator_prof_vel_cmd.target_velocity = request->target_velocity;
+  cmd.actuator_prof_vel_cmd.profile_accel = request->profile_accel;
+  cmd.actuator_prof_vel_cmd.max_duration = request->max_duration;
+  response->success = ActuatorExistsOnBus(cmd.name, response->message);
+  if (response->success) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::ActuatorProfTorqueSrvCb(
+  const std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueService::Request>
+    request,
+  std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueService::Response> response)
+{
+  EVR_ACTIVITY_LO("Handling Actuator Set Prof Torque Command");
+  fastcat::DeviceCmd cmd;
+  cmd.name = request->name;
+  cmd.type = fastcat::ACTUATOR_PROF_TORQUE_CMD;
+  cmd.actuator_prof_torque_cmd.target_torque_amps = request->target_torque_amps;
+  cmd.actuator_prof_torque_cmd.max_duration = request->max_duration;
+  response->success = ActuatorExistsOnBus(cmd.name, response->message);
+  if (response->success) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::CommanderEnableSrvCb(
+  const std::shared_ptr<fcat_msgs::srv::CommanderEnableService::Request>
+    request,
+  std::shared_ptr<fcat_msgs::srv::CommanderEnableService::Response> response)
+{
+  EVR_ACTIVITY_LO("Handling Commander Enable Command");
+  fastcat::DeviceCmd cmd;
+  cmd.name = request->name;
+  cmd.type = fastcat::COMMANDER_ENABLE_CMD;
+  cmd.commander_enable_cmd.duration = request->duration;
+
+  response->success =
+    DeviceExistsOnBus(cmd.name, fastcat::COMMANDER_STATE, response->message);
+  if (response->success) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::CommanderDisableSrvCb(
+  const std::shared_ptr<fcat_msgs::srv::CommanderDisableService::Request>
+    request,
+  std::shared_ptr<fcat_msgs::srv::CommanderDisableService::Response> response)
+{
+  EVR_ACTIVITY_LO("Handling Commander Disable Command");
+  fastcat::DeviceCmd cmd;
+  cmd.name = request->name;
+  cmd.type = fastcat::COMMANDER_DISABLE_CMD;
+
+  response->success =
+    DeviceExistsOnBus(cmd.name, fastcat::COMMANDER_STATE, response->message);
+  if (response->success) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::El2124WriteAllChannelsSrvCb(
+  const std::shared_ptr<fcat_msgs::srv::El2124WriteAllChannelsService::Request>
+    request,
+  std::shared_ptr<fcat_msgs::srv::El2124WriteAllChannelsService::Response>
+    response)
+{
+  EVR_ACTIVITY_LO("Handling EL2124 Write All Channels Command");
+  fastcat::DeviceCmd cmd;
+
+  cmd.name = request->name;
+  cmd.type = fastcat::EL2124_WRITE_ALL_CHANNELS_CMD;
+  cmd.el2124_write_all_channels_cmd.channel_ch1 = request->channel_ch1;
+  cmd.el2124_write_all_channels_cmd.channel_ch2 = request->channel_ch2;
+  cmd.el2124_write_all_channels_cmd.channel_ch3 = request->channel_ch3;
+  cmd.el2124_write_all_channels_cmd.channel_ch4 = request->channel_ch4;
+
+  response->success =
+    DeviceExistsOnBus(cmd.name, fastcat::EL2124_STATE, response->message);
+  if (response->success) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::El2124WriteChannelSrvCb(
+  const std::shared_ptr<fcat_msgs::srv::El2124WriteChannelService::Request>
+    request,
+  std::shared_ptr<fcat_msgs::srv::El2124WriteChannelService::Response> response)
+{
+  EVR_ACTIVITY_LO("Handling EL2124 Write Channel Command");
+  fastcat::DeviceCmd cmd;
+
+  cmd.name = request->name;
+  cmd.type = fastcat::EL2124_WRITE_CHANNEL_CMD;
+  cmd.el2124_write_channel_cmd.channel = request->channel;
+  cmd.el2124_write_channel_cmd.level = request->level;
+
+  response->success =
+    DeviceExistsOnBus(cmd.name, fastcat::EL2124_STATE, response->message);
+  if (response->success) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::El2809WriteAllChannelsSrvCb(
+  const std::shared_ptr<fcat_msgs::srv::El2809WriteAllChannelsService::Request>
+    request,
+  std::shared_ptr<fcat_msgs::srv::El2809WriteAllChannelsService::Response>
+    response)
+{
+  EVR_ACTIVITY_LO("Handling EL2809 Write All Channels Command");
+  fastcat::DeviceCmd cmd;
+
+  cmd.name = request->name;
+  cmd.type = fastcat::EL2809_WRITE_ALL_CHANNELS_CMD;
+  cmd.el2809_write_all_channels_cmd.channel_ch1 = request->channel_ch1;
+  cmd.el2809_write_all_channels_cmd.channel_ch2 = request->channel_ch2;
+  cmd.el2809_write_all_channels_cmd.channel_ch3 = request->channel_ch3;
+  cmd.el2809_write_all_channels_cmd.channel_ch4 = request->channel_ch4;
+  cmd.el2809_write_all_channels_cmd.channel_ch5 = request->channel_ch5;
+  cmd.el2809_write_all_channels_cmd.channel_ch6 = request->channel_ch6;
+  cmd.el2809_write_all_channels_cmd.channel_ch7 = request->channel_ch7;
+  cmd.el2809_write_all_channels_cmd.channel_ch8 = request->channel_ch8;
+  cmd.el2809_write_all_channels_cmd.channel_ch9 = request->channel_ch9;
+  cmd.el2809_write_all_channels_cmd.channel_ch10 = request->channel_ch10;
+  cmd.el2809_write_all_channels_cmd.channel_ch11 = request->channel_ch11;
+  cmd.el2809_write_all_channels_cmd.channel_ch12 = request->channel_ch12;
+  cmd.el2809_write_all_channels_cmd.channel_ch13 = request->channel_ch13;
+  cmd.el2809_write_all_channels_cmd.channel_ch14 = request->channel_ch14;
+  cmd.el2809_write_all_channels_cmd.channel_ch15 = request->channel_ch15;
+  cmd.el2809_write_all_channels_cmd.channel_ch16 = request->channel_ch16;
+
+  response->success =
+    DeviceExistsOnBus(cmd.name, fastcat::EL2809_STATE, response->message);
+  if (response->success) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::El2809WriteChannelSrvCb(
+  const std::shared_ptr<fcat_msgs::srv::El2809WriteChannelService::Request>
+    request,
+  std::shared_ptr<fcat_msgs::srv::El2809WriteChannelService::Response> response)
+{
+  EVR_ACTIVITY_LO("Handling EL2809 Write Channel Command");
+  fastcat::DeviceCmd cmd;
+
+  cmd.name = request->name;
+  cmd.type = fastcat::EL2809_WRITE_CHANNEL_CMD;
+  cmd.el2809_write_channel_cmd.channel = request->channel;
+  cmd.el2809_write_channel_cmd.level = request->level;
+
+  response->success =
+    DeviceExistsOnBus(cmd.name, fastcat::EL2809_STATE, response->message);
+  if (response->success) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::El2798WriteAllChannelsSrvCb(
+    const std::shared_ptr<
+        fcat_msgs::srv::El2798WriteAllChannelsService::Request>
+        request,
+    std::shared_ptr<fcat_msgs::srv::El2798WriteAllChannelsService::Response>
+        response)
+{
+  EVR_ACTIVITY_LO("Handling EL2798 Write All Channels Command");
+  fastcat::DeviceCmd cmd;
+
+  cmd.name = request->name;
+  cmd.type = fastcat::EL2798_WRITE_ALL_CHANNELS_CMD;
+  cmd.el2798_write_all_channels_cmd.channel_ch1  = request->channel_ch1;
+  cmd.el2798_write_all_channels_cmd.channel_ch2  = request->channel_ch2;
+  cmd.el2798_write_all_channels_cmd.channel_ch3  = request->channel_ch3;
+  cmd.el2798_write_all_channels_cmd.channel_ch4  = request->channel_ch4;
+  cmd.el2798_write_all_channels_cmd.channel_ch5  = request->channel_ch5;
+  cmd.el2798_write_all_channels_cmd.channel_ch6  = request->channel_ch6;
+  cmd.el2798_write_all_channels_cmd.channel_ch7  = request->channel_ch7;
+  cmd.el2798_write_all_channels_cmd.channel_ch8  = request->channel_ch8;
+
+  response->success =
+      DeviceExistsOnBus(cmd.name, fastcat::EL2798_STATE, response->message);
+  if (response->success) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::El2828WriteAllChannelsSrvCb(
+    const std::shared_ptr<
+        fcat_msgs::srv::El2828WriteAllChannelsService::Request>
+        request,
+    std::shared_ptr<fcat_msgs::srv::El2828WriteAllChannelsService::Response>
+        response)
+{
+  EVR_ACTIVITY_LO("Handling EL2828 Write All Channels Command");
+  fastcat::DeviceCmd cmd;
+
+  cmd.name = request->name;
+  cmd.type = fastcat::EL2828_WRITE_ALL_CHANNELS_CMD;
+  cmd.el2828_write_all_channels_cmd.channel_ch1  = request->channel_ch1;
+  cmd.el2828_write_all_channels_cmd.channel_ch2  = request->channel_ch2;
+  cmd.el2828_write_all_channels_cmd.channel_ch3  = request->channel_ch3;
+  cmd.el2828_write_all_channels_cmd.channel_ch4  = request->channel_ch4;
+  cmd.el2828_write_all_channels_cmd.channel_ch5  = request->channel_ch5;
+  cmd.el2828_write_all_channels_cmd.channel_ch6  = request->channel_ch6;
+  cmd.el2828_write_all_channels_cmd.channel_ch7  = request->channel_ch7;
+  cmd.el2828_write_all_channels_cmd.channel_ch8  = request->channel_ch8;
+
+  response->success =
+      DeviceExistsOnBus(cmd.name, fastcat::EL2828_STATE, response->message);
+  if (response->success) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::El2798WriteChannelSrvCb(
+    const std::shared_ptr<fcat_msgs::srv::El2798WriteChannelService::Request>
+        request,
+    std::shared_ptr<fcat_msgs::srv::El2798WriteChannelService::Response>
+        response)
+{
+  EVR_ACTIVITY_LO("Handling EL2798 Write Channel Command");
+  fastcat::DeviceCmd cmd;
+
+  cmd.name                             = request->name;
+  cmd.type                             = fastcat::EL2798_WRITE_CHANNEL_CMD;
+  cmd.el2798_write_channel_cmd.channel = request->channel;
+  cmd.el2798_write_channel_cmd.level   = request->level;
+
+  response->success =
+      DeviceExistsOnBus(cmd.name, fastcat::EL2798_STATE, response->message);
+  if (response->success) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::El2828WriteChannelSrvCb(
+    const std::shared_ptr<fcat_msgs::srv::El2828WriteChannelService::Request>
+        request,
+    std::shared_ptr<fcat_msgs::srv::El2828WriteChannelService::Response>
+        response)
+{
+  EVR_ACTIVITY_LO("Handling EL2828 Write Channel Command");
+  fastcat::DeviceCmd cmd;
+
+  cmd.name                             = request->name;
+  cmd.type                             = fastcat::EL2828_WRITE_CHANNEL_CMD;
+  cmd.el2828_write_channel_cmd.channel = request->channel;
+  cmd.el2828_write_channel_cmd.level   = request->level;
+
+  response->success =
+      DeviceExistsOnBus(cmd.name, fastcat::EL2828_STATE, response->message);
+  if (response->success) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::El4102WriteAllChannelsSrvCb(
+  const std::shared_ptr<fcat_msgs::srv::El4102WriteAllChannelsService::Request>
+    request,
+  std::shared_ptr<fcat_msgs::srv::El4102WriteAllChannelsService::Response>
+    response)
+{
+  EVR_ACTIVITY_LO("Handling EL4102 Write All Channels Command");
+  fastcat::DeviceCmd cmd;
+
+  cmd.name = request->name;
+  cmd.type = fastcat::EL4102_WRITE_ALL_CHANNELS_CMD;
+  cmd.el4102_write_all_channels_cmd.voltage_output_ch1 =
+    request->voltage_output_ch1;
+  cmd.el4102_write_all_channels_cmd.voltage_output_ch2 =
+    request->voltage_output_ch2;
+
+  response->success =
+    DeviceExistsOnBus(cmd.name, fastcat::EL4102_STATE, response->message);
+  if (response->success) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::El4102WriteChannelSrvCb(
+  const std::shared_ptr<fcat_msgs::srv::El4102WriteChannelService::Request>
+    request,
+  std::shared_ptr<fcat_msgs::srv::El4102WriteChannelService::Response> response)
+{
+  EVR_ACTIVITY_LO("Handling EL4102 Write Channel Command");
+  fastcat::DeviceCmd cmd;
+
+  cmd.name = request->name;
+  cmd.type = fastcat::EL4102_WRITE_CHANNEL_CMD;
+  cmd.el4102_write_channel_cmd.channel = request->channel;
+  cmd.el4102_write_channel_cmd.voltage_output = request->voltage_output;
+
+  response->success =
+    DeviceExistsOnBus(cmd.name, fastcat::EL4102_STATE, response->message);
+  if (response->success) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::FaulterEnableSrvCb(
+  const std::shared_ptr<fcat_msgs::srv::FaulterEnableService::Request> request,
+  std::shared_ptr<fcat_msgs::srv::FaulterEnableService::Response> response)
+{
+  EVR_ACTIVITY_LO("Handling Faulter Enable Command");
+  fastcat::DeviceCmd cmd;
+
+  cmd.name = request->name;
+  cmd.type = fastcat::FAULTER_ENABLE_CMD;
+  cmd.faulter_enable_cmd.enable = request->enable;
+
+  response->success =
+    DeviceExistsOnBus(cmd.name, fastcat::FAULTER_STATE, response->message);
+  if (response->success) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::FtsTareSrvCb(
+  const std::shared_ptr<fcat_msgs::srv::DeviceTriggerService::Request> request,
+  std::shared_ptr<fcat_msgs::srv::DeviceTriggerService::Response> response)
+{
+  EVR_ACTIVITY_LO("Handling FTS Tare Command");
+  fastcat::DeviceCmd cmd;
+  cmd.name = request->name;
+  cmd.type = fastcat::FTS_TARE_CMD;
+
+  response->success =
+    DeviceExistsOnBus(cmd.name, fastcat::FTS_STATE, response->message);
+  if (response->success) {
+    QueueCommand(cmd);
+  }
+}
+
+void Fcat::PidActivateSrvCb(
+  const std::shared_ptr<fcat_msgs::srv::PidActivateService::Request> request,
+  std::shared_ptr<fcat_msgs::srv::PidActivateService::Response> response)
+{
+  EVR_ACTIVITY_LO("Handling PID Activate Command");
+  fastcat::DeviceCmd cmd;
+  cmd.type = fastcat::PID_ACTIVATE_CMD;
+  cmd.pid_activate_cmd.setpoint = request->setpoint;
+  cmd.pid_activate_cmd.deadband = request->deadband;
+  cmd.pid_activate_cmd.persistence_duration = request->persistence_duration;
+  cmd.pid_activate_cmd.max_duration = request->max_duration;
+
+  response->success =
+    DeviceExistsOnBus(cmd.name, fastcat::PID_STATE, response->message);
+  if (response->success) {
+    QueueCommand(cmd);
   }
 }

--- a/src/fcat_main.cpp
+++ b/src/fcat_main.cpp
@@ -39,7 +39,6 @@ int main(int argc, char* argv[])
   // spawning individual executors for different callback groups
   rclcpp::executors::StaticSingleThreadedExecutor process_loop_executor;
   rclcpp::executors::SingleThreadedExecutor topic_executor;
-  rclcpp::executors::SingleThreadedExecutor module_state_executor;
 
   auto fcat_node = std::make_shared<Fcat>();
 
@@ -53,17 +52,9 @@ int main(int argc, char* argv[])
   topic_executor.add_callback_group(fcat_node->get_topic_callback_group(),
                                     fcat_node->get_node_base_interface());
 
-  module_state_executor.add_callback_group(
-    fcat_node->get_fault_interface_callback_group(),
-    fcat_node->get_node_base_interface());
-  module_state_executor.add_callback_group(
-    fcat_node->get_state_interface_callback_group(),
-    fcat_node->get_node_base_interface());
-
   auto process_loop_thread =
     std::thread([&]() { process_loop_executor.spin(); });
   auto topic_thread = std::thread([&]() { topic_executor.spin(); });
-  auto module_state_thread = std::thread([&]() { module_state_executor.spin(); });
 
   while (rclcpp::ok()) {
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
@@ -71,7 +62,6 @@ int main(int argc, char* argv[])
   rclcpp::shutdown();
   process_loop_thread.join();
   topic_thread.join();
-  module_state_thread.join();
 #endif
 
   return 0;

--- a/src/fcat_main.cpp
+++ b/src/fcat_main.cpp
@@ -1,3 +1,5 @@
+// Copyright 2021 California Institute of Technology
+
 #include <sched.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -5,7 +7,7 @@
 #include <chrono>
 #include <thread>
 
-#include "fcat/fcat.hpp"
+#include "fcat.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 int main(int argc, char* argv[]) {

--- a/src/fcat_main.cpp
+++ b/src/fcat_main.cpp
@@ -6,11 +6,9 @@
 #include <thread>
 
 #include "fcat/fcat.hpp"
-
 #include "rclcpp/rclcpp.hpp"
 
-int main(int argc, char* argv[])
-{
+int main(int argc, char* argv[]) {
   rclcpp::init(argc, argv);
 
 #ifdef ROS2_FOXY
@@ -23,9 +21,8 @@ int main(int argc, char* argv[])
   // subscriptions periodically at run-time, which may intermittently delay the
   // main process loop; therefore it is recommended to use ROS2 humble or later
   // when running at higher loop rates
-  rclcpp::executors::MultiThreadedExecutor executor(
-    rclcpp::ExecutorOptions(),  // Default options
-    2                           // Number of threads
+  rclcpp::executors::MultiThreadedExecutor executor(rclcpp::ExecutorOptions(),  // Default options
+                                                    2                           // Number of threads
   );
   auto fcat_node = std::make_shared<Fcat>();
   executor.add_node(fcat_node);
@@ -42,18 +39,16 @@ int main(int argc, char* argv[])
 
   auto fcat_node = std::make_shared<Fcat>();
 
-  process_loop_executor.add_callback_group(
-    fcat_node->get_process_loop_callback_group(),
-    fcat_node->get_node_base_interface());
+  process_loop_executor.add_callback_group(fcat_node->get_process_loop_callback_group(),
+                                           fcat_node->get_node_base_interface());
 
   topic_executor.add_callback_group(
-    fcat_node->get_node_base_interface()->get_default_callback_group(),
-    fcat_node->get_node_base_interface());
+      fcat_node->get_node_base_interface()->get_default_callback_group(),
+      fcat_node->get_node_base_interface());
   topic_executor.add_callback_group(fcat_node->get_topic_callback_group(),
                                     fcat_node->get_node_base_interface());
 
-  auto process_loop_thread =
-    std::thread([&]() { process_loop_executor.spin(); });
+  auto process_loop_thread = std::thread([&]() { process_loop_executor.spin(); });
   auto topic_thread = std::thread([&]() { topic_executor.spin(); });
 
   while (rclcpp::ok()) {

--- a/src/fcat_main.cpp
+++ b/src/fcat_main.cpp
@@ -1,14 +1,78 @@
-#include "fcat/fcat.hpp"
-#include "rclcpp/rclcpp.hpp"
 #include <sched.h>
 #include <sys/types.h>
 #include <unistd.h>
 
-int main(int argc, char * argv[])
-{
+#include <chrono>
+#include <thread>
 
+#include "fcat/fcat.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+
+int main(int argc, char* argv[])
+{
   rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<Fcat>());
+
+#ifdef ROS2_FOXY
+  // support for adding specific callback groups to an executor was only added
+  // after ROS2 foxy, so just use a standard MultiThreadedExecutor for ROS2 foxy
+  // only
+  //
+  // A MultiThreadedExecutor consists of multiple SingleThreadedExecutors
+  // running in different threads. SingleThreadedExecutors will check for new
+  // subscriptions periodically at run-time, which may intermittently delay the
+  // main process loop; therefore it is recommended to use ROS2 humble or later
+  // when running at higher loop rates
+  rclcpp::executors::MultiThreadedExecutor executor(
+    rclcpp::ExecutorOptions(),  // Default options
+    2                           // Number of threads
+  );
+  auto fcat_node = std::make_shared<Fcat>();
+  executor.add_node(fcat_node);
+  executor.spin();
   rclcpp::shutdown();
+#else
+  // Use a StaticSingleThreadedExecutor for main Process loop to avoid overhead
+  // of checking for new subscriptions at run-time. ROS2 does not allow the
+  // option of using a StaticSingleThreadedExecutor within a
+  // MultiThreadedExecutor, so it is necessary to take more granular control of
+  // spawning individual executors for different callback groups
+  rclcpp::executors::StaticSingleThreadedExecutor process_loop_executor;
+  rclcpp::executors::SingleThreadedExecutor topic_executor;
+  rclcpp::executors::SingleThreadedExecutor module_state_executor;
+
+  auto fcat_node = std::make_shared<Fcat>();
+
+  process_loop_executor.add_callback_group(
+    fcat_node->get_process_loop_callback_group(),
+    fcat_node->get_node_base_interface());
+
+  topic_executor.add_callback_group(
+    fcat_node->get_node_base_interface()->get_default_callback_group(),
+    fcat_node->get_node_base_interface());
+  topic_executor.add_callback_group(fcat_node->get_topic_callback_group(),
+                                    fcat_node->get_node_base_interface());
+
+  module_state_executor.add_callback_group(
+    fcat_node->get_fault_interface_callback_group(),
+    fcat_node->get_node_base_interface());
+  module_state_executor.add_callback_group(
+    fcat_node->get_state_interface_callback_group(),
+    fcat_node->get_node_base_interface());
+
+  auto process_loop_thread =
+    std::thread([&]() { process_loop_executor.spin(); });
+  auto topic_thread = std::thread([&]() { topic_executor.spin(); });
+  auto module_state_thread = std::thread([&]() { module_state_executor.spin(); });
+
+  while (rclcpp::ok()) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  rclcpp::shutdown();
+  process_loop_thread.join();
+  topic_thread.join();
+  module_state_thread.join();
+#endif
+
   return 0;
 }

--- a/src/fcat_node.hpp
+++ b/src/fcat_node.hpp
@@ -1,3 +1,5 @@
+// Copyright 2021 California Institute of Technology
+
 #ifndef FCAT_NODE_HPP_
 #define FCAT_NODE_HPP_
 
@@ -37,4 +39,4 @@ class FcatNode : public rclcpp::Node {
   rclcpp::CallbackGroup::SharedPtr timer_callback_group_ = nullptr;
 };
 
-#endif
+#endif  // FCAT_NODE_HPP_

--- a/src/fcat_node.hpp
+++ b/src/fcat_node.hpp
@@ -1,48 +1,40 @@
 #ifndef FCAT_NODE_HPP_
 #define FCAT_NODE_HPP_
 
-#include "rclcpp/rclcpp.hpp"
-
 #include <chrono>
 #include <functional>
 #include <string>
 
-class FcatNode : public rclcpp::Node
-{
-  public:
-    FcatNode(const std::string& node_name, const std::string& namespace_,
-        const rclcpp::NodeOptions& options = rclcpp::NodeOptions())
-      : rclcpp::Node(node_name, namespace_, options)
-    {
-    }
+#include "rclcpp/rclcpp.hpp"
 
+class FcatNode : public rclcpp::Node {
+ public:
+  FcatNode(const std::string& node_name, const std::string& namespace_,
+           const rclcpp::NodeOptions& options = rclcpp::NodeOptions())
+      : rclcpp::Node(node_name, namespace_, options) {}
 
-    // Must be called before InitializeTimer() to take effect
-    void InitializeTimerRate(double hz) { target_loop_rate_hz_ = hz; }
-    double GetTimerRate() const { return target_loop_rate_hz_; }
-    void SetTimerCallbackGroup(rclcpp::CallbackGroup::SharedPtr callback_group)
-    {
-      timer_callback_group_ = callback_group;
-    }
+  // Must be called before InitializeTimer() to take effect
+  void InitializeTimerRate(double hz) { target_loop_rate_hz_ = hz; }
+  double GetTimerRate() const { return target_loop_rate_hz_; }
+  void SetTimerCallbackGroup(rclcpp::CallbackGroup::SharedPtr callback_group) {
+    timer_callback_group_ = callback_group;
+  }
 
-    void SetActive() {}
+  void SetActive() {}
 
-    virtual void StartProcessTimer()
-    {
-      double period_usec = 1.0e6 / target_loop_rate_hz_;
-      std::chrono::duration<double, std::micro> chrono_dur(period_usec);
-      timer_ = this->create_wall_timer(
-        chrono_dur, std::bind(&FcatNode::Process, this), timer_callback_group_);
-    }
+  virtual void StartProcessTimer() {
+    double period_usec = 1.0e6 / target_loop_rate_hz_;
+    std::chrono::duration<double, std::micro> chrono_dur(period_usec);
+    timer_ = this->create_wall_timer(chrono_dur, std::bind(&FcatNode::Process, this),
+                                     timer_callback_group_);
+  }
 
-    virtual void Process() = 0;
+  virtual void Process() = 0;
 
-  protected:
-
-    double target_loop_rate_hz_ = 250.0;
-    rclcpp::TimerBase::SharedPtr timer_ = nullptr;
-    rclcpp::CallbackGroup::SharedPtr timer_callback_group_ = nullptr;
-
+ protected:
+  double target_loop_rate_hz_ = 250.0;
+  rclcpp::TimerBase::SharedPtr timer_ = nullptr;
+  rclcpp::CallbackGroup::SharedPtr timer_callback_group_ = nullptr;
 };
 
 #endif

--- a/src/fcat_node.hpp
+++ b/src/fcat_node.hpp
@@ -3,6 +3,10 @@
 
 #include "rclcpp/rclcpp.hpp"
 
+#include <chrono>
+#include <functional>
+#include <string>
+
 class FcatNode : public rclcpp::Node
 {
   public:
@@ -10,24 +14,25 @@ class FcatNode : public rclcpp::Node
         const rclcpp::NodeOptions& options = rclcpp::NodeOptions())
       : rclcpp::Node(node_name, namespace_, options)
     {
-      InitializeDefaultParameters();
     }
 
-    void InitializeDefaultParameters()
-    {
-      // set up default parameters
-
-    }
 
     // Must be called before InitializeTimer() to take effect
-    void SetTimerRate(double hz){ target_loop_rate_hz_ = hz; }
+    void InitializeTimerRate(double hz) { target_loop_rate_hz_ = hz; }
+    double GetTimerRate() const { return target_loop_rate_hz_; }
+    void SetTimerCallbackGroup(rclcpp::CallbackGroup::SharedPtr callback_group)
+    {
+      timer_callback_group_ = callback_group;
+    }
 
-    virtual void InitializeTimer()
+    void SetActive() {}
+
+    virtual void StartProcessTimer()
     {
       double period_usec = 1.0e6 / target_loop_rate_hz_;
       std::chrono::duration<double, std::micro> chrono_dur(period_usec);
-      timer_ = this->create_wall_timer(chrono_dur, 
-          std::bind(&FcatNode::Process, this));
+      timer_ = this->create_wall_timer(
+        chrono_dur, std::bind(&FcatNode::Process, this), timer_callback_group_);
     }
 
     virtual void Process() = 0;
@@ -36,6 +41,7 @@ class FcatNode : public rclcpp::Node
 
     double target_loop_rate_hz_ = 250.0;
     rclcpp::TimerBase::SharedPtr timer_ = nullptr;
+    rclcpp::CallbackGroup::SharedPtr timer_callback_group_ = nullptr;
 
 };
 

--- a/src/fcat_srvs.cpp
+++ b/src/fcat_srvs.cpp
@@ -1,4 +1,5 @@
 #include "fcat/fcat_services.hpp"
+#include "rclcpp/rclcpp.hpp"
 #include "fastcat/jsd/actuator.h"
 #include "fcat/fcat_utils.hpp"
 #include "jsd/jsd_print.h"
@@ -12,7 +13,6 @@ using std::placeholders::_2;
 
 FcatSrvs::FcatSrvs(const rclcpp::NodeOptions& options)
     : casah_node::BaseInterface("fcat_services", "fcat", options),
-      casah_node::EvrInterface("fcat_services", "fcat", options),
       services_qos_(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_services_default), rmw_qos_profile_services_default),
       module_state_last_recv_time_(0),
       act_states_last_recv_time_(0),
@@ -479,14 +479,14 @@ bool FcatSrvs::ActuatorCmdPrechecks(std::string name, std::string& message)
   if ((this->now().seconds() - module_state_last_recv_time_) >
       liveliness_duration_sec_) {
     message = "stale fcat module state topic, fcat is not running";
-    EVR_WARNING_LO("bad command: %s", message.c_str());
+    RCLCPP_WARN(this->get_logger(), "bad command: %s", message.c_str());
     return false;
   }
 
   // 2) Check fcat module is not faulted
   if (fcat_module_state_msg_.faulted) {
     message = "fcat is faulted, reset fcat first";
-    EVR_WARNING_LO("bad command: %s", message.c_str());
+    RCLCPP_WARN(this->get_logger(), "bad command: %s", message.c_str());
     return false;
   }
 
@@ -496,14 +496,14 @@ bool FcatSrvs::ActuatorCmdPrechecks(std::string name, std::string& message)
     message =
       "stale fcat actuator states topic, check fastcat YAML has any "
       "actuators";
-    EVR_WARNING_LO("bad command: %s", message.c_str());
+    RCLCPP_WARN(this->get_logger(), "bad command: %s", message.c_str());
     return false;
   }
 
   // 4) Check Actuator name is on the bus
   if (act_state_map_.find(name) == act_state_map_.end()) {
     message = "actuator name not found, check device name";
-    EVR_WARNING_LO("bad command: %s", message.c_str());
+    RCLCPP_WARN(this->get_logger(), "bad command: %s", message.c_str());
     return false;
   }
   return true;
@@ -515,14 +515,14 @@ bool FcatSrvs::PidCmdPrechecks(std::string name, std::string& message)
   if ((this->now().seconds() - module_state_last_recv_time_) >
       liveliness_duration_sec_) {
     message = "stale fcat module state topic, fcat is not running";
-    EVR_WARNING_LO("bad command: %s", message.c_str());
+    RCLCPP_WARN(this->get_logger(), "bad command: %s", message.c_str());
     return false;
   }
 
   // 2) Check fcat module is not faulted
   if (fcat_module_state_msg_.faulted) {
     message = "fcat is faulted, reset fcat first";
-    EVR_WARNING_LO("bad command: %s", message.c_str());
+    RCLCPP_WARN(this->get_logger(), "bad command: %s", message.c_str());
     return false;
   }
 
@@ -531,14 +531,14 @@ bool FcatSrvs::PidCmdPrechecks(std::string name, std::string& message)
       liveliness_duration_sec_) {
     message =
       "stale fcat pid states topic, check fastcat YAML has any pid devices";
-    EVR_WARNING_LO("bad command: %s", message.c_str());
+    RCLCPP_WARN(this->get_logger(), "bad command: %s", message.c_str());
     return false;
   }
 
   // 4) Check Pid name is on the bus
   if (pid_state_map_.find(name) == pid_state_map_.end()) {
     message = "pid name not found, check device name";
-    EVR_WARNING_LO("bad command: %s", message.c_str());
+    RCLCPP_WARN(this->get_logger(), "bad command: %s", message.c_str());
     return false;
   }
   return true;
@@ -548,20 +548,20 @@ bool FcatSrvs::CheckCommonFaultActive(std::string& error_message)
 {
   if (!rclcpp::ok()) {
     error_message = "fcat_srvs node shutdown";
-    EVR_FATAL("Failure: %s", error_message.c_str());
+    RCLCPP_FATAL(this->get_logger(), "Failure: %s", error_message.c_str());
     return true;
   }
 
   if ((this->now().seconds() - module_state_last_recv_time_) >
       liveliness_duration_sec_) {
     error_message = "stale fcat module state topic, fcat has stopped ";
-    EVR_WARNING_HI("Failure: %s", error_message.c_str());
+    RCLCPP_WARN(this->get_logger(), "Failure: %s", error_message.c_str());
     return true;
   }
 
   if (fcat_module_state_msg_.faulted) {
     error_message = "fcat is encountered a fault";
-    EVR_WARNING_LO("%s", error_message.c_str());
+    RCLCPP_WARN(this->get_logger(), "%s", error_message.c_str());
     return false;
   }
 
@@ -594,7 +594,7 @@ bool FcatSrvs::RunActuatorMonitorLoop(std::string& error_message,
 
     if (sms == fastcat::ACTUATOR_SMS_FAULTED) {
       error_message = std::string("Actuator unexpectedly faulted");
-      EVR_WARNING_LO("Failure: %s", error_message.c_str());
+      RCLCPP_WARN(this->get_logger(), "Failure: %s", error_message.c_str());
       return false;
     }
 
@@ -608,7 +608,7 @@ bool FcatSrvs::RunActuatorMonitorLoop(std::string& error_message,
         if (sms == fastcat::ACTUATOR_SMS_HALTED ||
             sms == fastcat::ACTUATOR_SMS_HOLDING) {
           if (idle_rti_count >= idle_persist_rti) {
-            EVR_ACTIVITY_LO(
+            RCLCPP_INFO(this->get_logger(),
               "Max number of RTIs (%ld) elapsed with no Actuator SMS change, "
               "interpreting this result as a success",
               idle_persist_rti);
@@ -630,7 +630,7 @@ bool FcatSrvs::RunActuatorMonitorLoop(std::string& error_message,
         break;
 
       default:
-        EVR_WARNING_HI("bad srv state, aborting command");
+        RCLCPP_WARN(this->get_logger(), "bad srv state, aborting command");
         return false;
     }
   }
@@ -676,7 +676,7 @@ bool FcatSrvs::WaitForSdoResponse(std::string& message, uint16_t app_id)
                 async_sdo_response_msg_.data_type.c_str(),
                 async_sdo_response_msg_.app_id);
         message = print_str;
-        EVR_WARNING_LO("%s", print_str);
+        RCLCPP_WARN(this->get_logger(), "%s", print_str);
       } else {
         sprintf(print_str,
                 "SDO Response Success {Name:(%s) Index:(0x%x)"
@@ -688,7 +688,7 @@ bool FcatSrvs::WaitForSdoResponse(std::string& message, uint16_t app_id)
                 async_sdo_response_msg_.data_type.c_str(),
                 async_sdo_response_msg_.app_id);
         message = print_str;
-        EVR_ACTIVITY_HI("%s", print_str);
+        RCLCPP_INFO(this->get_logger(), "%s", print_str);
       }
       return success;
     }
@@ -702,7 +702,7 @@ bool FcatSrvs::WaitForSdoResponse(std::string& message, uint16_t app_id)
           "Parameter 'sdo_wait_duration_sec' is set to (%lf)",
           app_id, sdo_wait_duration_sec);
   message = print_str;
-  EVR_WARNING_LO("%s", print_str);
+  RCLCPP_WARN(this->get_logger(), "%s", print_str);
   return false;
 }
 
@@ -715,7 +715,7 @@ void FcatSrvs::ActuatorProfPosSrvCb(
     request,
   std::shared_ptr<fcat_msgs::srv::ActuatorProfPosService::Response> response)
 {
-  EVR_ACTIVITY_LO("Handling Actuator Prof Pos Command");
+  RCLCPP_INFO(this->get_logger(), "Handling Actuator Prof Pos Command");
   response->success = false;
 
   if (!ActuatorCmdPrechecks(request->name, response->message)) {
@@ -738,13 +738,13 @@ void FcatSrvs::ActuatorProfPosSrvCb(
     goal_pos += act_state_map_[request->name].actual_position;
   }
 
-  EVR_ACTIVITY_LO("actuator:%s Profile Position command from: %lf to goal: %lf",
+  RCLCPP_INFO(this->get_logger(), "actuator:%s Profile Position command from: %lf to goal: %lf",
                   request->name.c_str(),
                   act_state_map_[request->name].actual_position, goal_pos);
 
   response->success = RunActuatorMonitorLoop(response->message, request->name);
   if (response->success) {
-    EVR_ACTIVITY_HI("Completed ACTUATOR_PROF_POS for: %s",
+    RCLCPP_INFO(this->get_logger(), "Completed ACTUATOR_PROF_POS for: %s",
                     request->name.c_str());
     response->message = "";  // not strictly needed
   }
@@ -755,7 +755,7 @@ void FcatSrvs::ActuatorProfVelSrvCb(
     request,
   std::shared_ptr<fcat_msgs::srv::ActuatorProfVelService::Response> response)
 {
-  EVR_ACTIVITY_LO("Handling Actuator Prof Vel Command");
+  RCLCPP_INFO(this->get_logger(), "Handling Actuator Prof Vel Command");
   response->success = false;
 
   if (!ActuatorCmdPrechecks(request->name, response->message)) {
@@ -764,7 +764,7 @@ void FcatSrvs::ActuatorProfVelSrvCb(
 
   double tol = this->get_parameter("tolerance").as_double();
   if (fabs(request->max_duration) < tol) {
-    EVR_WARNING_HI(
+    RCLCPP_WARN(this->get_logger(),
       "Max Duration (%E) < tolerance (%E) indicating this runs forever. "
       "In this case, use the topic (non-blocking) interface instead of the "
       "service (blocking) interface",
@@ -782,12 +782,12 @@ void FcatSrvs::ActuatorProfVelSrvCb(
 
   act_prof_vel_pub_->publish(cmd_msg);
 
-  EVR_ACTIVITY_LO("actuator:%s to goal velocity value: %lf",
+  RCLCPP_INFO(this->get_logger(), "actuator:%s to goal velocity value: %lf",
                   request->name.c_str(), request->target_velocity);
 
   response->success = RunActuatorMonitorLoop(response->message, request->name);
   if (response->success) {
-    EVR_ACTIVITY_HI("Completed ACTUATOR_PROF_VEL for: %s",
+    RCLCPP_INFO(this->get_logger(), "Completed ACTUATOR_PROF_VEL for: %s",
                     request->name.c_str());
     response->message = "";
   }
@@ -798,14 +798,14 @@ void FcatSrvs::ActuatorProfTorqueSrvCb(
     request,
   std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueService::Response> response)
 {
-  EVR_ACTIVITY_HI("Handling Actuator Prof Torque Command");
+  RCLCPP_INFO(this->get_logger(), "Handling Actuator Prof Torque Command");
   response->success = false;
 
   if (!ActuatorCmdPrechecks(request->name, response->message)) {
     return;
   }
 
-  EVR_DIAGNOSTIC(
+  RCLCPP_DEBUG(this->get_logger(),
     "actuator_prof_torque: issuing topic cmd and watching for completion");
 
   // Publish topic to start the service
@@ -817,12 +817,12 @@ void FcatSrvs::ActuatorProfTorqueSrvCb(
 
   act_prof_torque_pub_->publish(cmd_msg);
 
-  EVR_ACTIVITY_LO("fcat_srv actuator:%s to goal current value: %lf",
+  RCLCPP_INFO(this->get_logger(), "fcat_srv actuator:%s to goal current value: %lf",
                   request->name.c_str(), request->target_torque_amps);
 
   response->success = RunActuatorMonitorLoop(response->message, request->name);
   if (response->success) {
-    EVR_ACTIVITY_HI("Completed ACTUATOR_PROF_TORQUE for: %s",
+    RCLCPP_INFO(this->get_logger(), "Completed ACTUATOR_PROF_TORQUE for: %s",
                     request->name.c_str());
     response->message = "";
   }
@@ -833,7 +833,7 @@ void FcatSrvs::ActuatorCalibrateSrvCb(
     request,
   std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateService::Response> response)
 {
-  EVR_ACTIVITY_HI("Handling Actuator Calibrate Command");
+  RCLCPP_INFO(this->get_logger(), "Handling Actuator Calibrate Command");
   response->success = false;
 
   if (!ActuatorCmdPrechecks(request->name, response->message)) {
@@ -852,7 +852,7 @@ void FcatSrvs::ActuatorCalibrateSrvCb(
 
   response->success = RunActuatorMonitorLoop(response->message, request->name);
   if (response->success) {
-    EVR_ACTIVITY_HI("Completed ACTUATOR_CALIBRATE for: %s",
+    RCLCPP_INFO(this->get_logger(), "Completed ACTUATOR_CALIBRATE for: %s",
                     request->name.c_str());
     response->message = "";
   }
@@ -866,7 +866,7 @@ void FcatSrvs::ActuatorSetGainSchedulingModeSrvCb(
     fcat_msgs::srv::ActuatorSetGainSchedulingModeService::Response>
     response)
 {
-  EVR_ACTIVITY_HI("Handling Actuator Set Gain Scheduling Mode Command");
+  RCLCPP_INFO(this->get_logger(), "Handling Actuator Set Gain Scheduling Mode Command");
   response->success = false;
 
   auto tlc_req = std::make_shared<fcat_msgs::srv::TlcWriteService::Request>();
@@ -890,7 +890,7 @@ void FcatSrvs::ActuatorSetUnitModeSrvCb(
   std::shared_ptr<fcat_msgs::srv::ActuatorSetUnitModeService::Response>
     response)
 {
-  EVR_ACTIVITY_HI("Handling Actuator Set Unit Mode Command");
+  RCLCPP_INFO(this->get_logger(), "Handling Actuator Set Unit Mode Command");
   response->success = false;
 
   auto tlc_req = std::make_shared<fcat_msgs::srv::TlcWriteService::Request>();
@@ -912,14 +912,14 @@ void FcatSrvs::PidActivateSrvCb(
   const std::shared_ptr<fcat_msgs::srv::PidActivateService::Request> request,
   std::shared_ptr<fcat_msgs::srv::PidActivateService::Response> response)
 {
-  EVR_ACTIVITY_HI("Handling Pid Activate Command");
+  RCLCPP_INFO(this->get_logger(), "Handling Pid Activate Command");
   response->success = false;
 
   if (!PidCmdPrechecks(request->name, response->message)) {
     return;
   }
 
-  EVR_DIAGNOSTIC("pid_activate: issuing topic cmd and watching for completion");
+  RCLCPP_DEBUG(this->get_logger(), "pid_activate: issuing topic cmd and watching for completion");
 
   // Publish topic to start the service
   auto cmd_msg = fcat_msgs::msg::PidActivateCmd();
@@ -957,7 +957,7 @@ void FcatSrvs::PidActivateSrvCb(
     rate_->sleep();
   }
 
-  EVR_ACTIVITY_HI("Completed PID_ACTIVATE for: %s", request->name.c_str());
+  RCLCPP_INFO(this->get_logger(), "Completed PID_ACTIVATE for: %s", request->name.c_str());
   response->message = "";
   response->success = true;
 }
@@ -966,7 +966,7 @@ void FcatSrvs::AsyncSdoWriteSrvCb(
   const std::shared_ptr<fcat_msgs::srv::AsyncSdoWriteService::Request> request,
   std::shared_ptr<fcat_msgs::srv::AsyncSdoWriteService::Response> response)
 {
-  EVR_ACTIVITY_HI("Handling SDO Write command");
+  RCLCPP_INFO(this->get_logger(), "Handling SDO Write command");
   char print_str[512];
   response->message = "";
 
@@ -977,7 +977,7 @@ void FcatSrvs::AsyncSdoWriteSrvCb(
             request->sdo_index.c_str());
 
     response->message = print_str;
-    EVR_WARNING_LO("%s", print_str);
+    RCLCPP_WARN(this->get_logger(), "%s", print_str);
 
     return;
   }
@@ -989,7 +989,7 @@ void FcatSrvs::AsyncSdoWriteSrvCb(
             "{'I8', 'I16', 'I32', 'I64', 'F32', 'U8', 'U16', 'U32', 'U64'}",
             request->data_type.c_str());
     response->message = print_str;
-    EVR_WARNING_LO("%s", print_str);
+    RCLCPP_WARN(this->get_logger(), "%s", print_str);
     return;
   }
 
@@ -1005,7 +1005,7 @@ void FcatSrvs::AsyncSdoWriteSrvCb(
 
   async_sdo_write_pub_->publish(msg);
 
-  EVR_ACTIVITY_LO(
+  RCLCPP_INFO(this->get_logger(),
     "Async SDO Write issued {Name:(%s) Index:(0x%x)"
     " Subindex:(%u) Data:(%s) DataType:(%s) AppId:(%u)}",
     msg.name.c_str(), msg.sdo_index, msg.sdo_subindex, msg.data.c_str(),
@@ -1019,7 +1019,7 @@ void FcatSrvs::AsyncSdoReadSrvCb(
   const std::shared_ptr<fcat_msgs::srv::AsyncSdoReadService::Request> request,
   std::shared_ptr<fcat_msgs::srv::AsyncSdoReadService::Response> response)
 {
-  EVR_ACTIVITY_HI("Handling SDO Read command");
+  RCLCPP_INFO(this->get_logger(), "Handling SDO Read command");
   char print_str[512];
   response->message = "";
 
@@ -1030,7 +1030,7 @@ void FcatSrvs::AsyncSdoReadSrvCb(
             request->sdo_index.c_str());
 
     response->message = print_str;
-    EVR_WARNING_LO("%s", print_str);
+    RCLCPP_WARN(this->get_logger(), "%s", print_str);
     return;
   }
 
@@ -1042,7 +1042,7 @@ void FcatSrvs::AsyncSdoReadSrvCb(
             request->data_type.c_str());
 
     response->message = print_str;
-    EVR_WARNING_LO("%s", print_str);
+    RCLCPP_WARN(this->get_logger(), "%s", print_str);
     return;
   }
 
@@ -1057,7 +1057,7 @@ void FcatSrvs::AsyncSdoReadSrvCb(
 
   async_sdo_read_pub_->publish(msg);
 
-  EVR_ACTIVITY_LO(
+  RCLCPP_INFO(this->get_logger(),
     "Async SDO Read issued {Name:(%s) Index:(0x%x)"
     " Subindex:(%u) DataType:(%s) AppId:(%u)}",
     msg.name.c_str(), msg.sdo_index, msg.sdo_subindex, msg.data_type.c_str(),
@@ -1071,7 +1071,7 @@ void FcatSrvs::TlcWriteSrvCb(
   const std::shared_ptr<fcat_msgs::srv::TlcWriteService::Request> request,
   std::shared_ptr<fcat_msgs::srv::TlcWriteService::Response> response)
 {
-  EVR_ACTIVITY_HI("Handling Two-Letter Command (TLC) Write command");
+  RCLCPP_INFO(this->get_logger(), "Handling Two-Letter Command (TLC) Write command");
   char print_str[512];
   response->message = "";
 
@@ -1082,7 +1082,7 @@ void FcatSrvs::TlcWriteSrvCb(
             request->tlc.c_str());
 
     response->message = print_str;
-    EVR_WARNING_LO("%s", print_str);
+    RCLCPP_WARN(this->get_logger(), "%s", print_str);
     return;
   }
 
@@ -1093,7 +1093,7 @@ void FcatSrvs::TlcWriteSrvCb(
             "{'I8', 'I16', 'I32', 'I64', 'F32', 'U8', 'U16', 'U32', 'U64'}",
             request->data_type.c_str());
     response->message = print_str;
-    EVR_WARNING_LO("%s", print_str);
+    RCLCPP_WARN(this->get_logger(), "%s", print_str);
 
     return;
   }
@@ -1110,7 +1110,7 @@ void FcatSrvs::TlcWriteSrvCb(
 
   async_sdo_write_pub_->publish(msg);
 
-  EVR_ACTIVITY_LO(
+  RCLCPP_INFO(this->get_logger(),
     "Async SDO Write issued {Name:(%s) TLC:(%s) Index:(0x%x)"
     " Subindex:(%u) Data:(%s) DataType:(%s) AppId:(%u)}",
     msg.name.c_str(), request->tlc.c_str(), msg.sdo_index, msg.sdo_subindex,
@@ -1124,7 +1124,7 @@ void FcatSrvs::TlcReadSrvCb(
   const std::shared_ptr<fcat_msgs::srv::TlcReadService::Request> request,
   std::shared_ptr<fcat_msgs::srv::TlcReadService::Response> response)
 {
-  EVR_ACTIVITY_HI("Handling Two-Letter Command (TLC) Read command");
+  RCLCPP_INFO(this->get_logger(), "Handling Two-Letter Command (TLC) Read command");
   char print_str[512];
   response->message = "";
 
@@ -1135,7 +1135,7 @@ void FcatSrvs::TlcReadSrvCb(
             request->tlc.c_str());
 
     response->message = print_str;
-    EVR_WARNING_LO("%s", print_str);
+    RCLCPP_WARN(this->get_logger(), "%s", print_str);
     return;
   }
 
@@ -1147,7 +1147,7 @@ void FcatSrvs::TlcReadSrvCb(
             request->data_type.c_str());
 
     response->message = print_str;
-    EVR_WARNING_LO("%s", print_str);
+    RCLCPP_WARN(this->get_logger(), "%s", print_str);
     return;
   }
 
@@ -1162,7 +1162,7 @@ void FcatSrvs::TlcReadSrvCb(
 
   async_sdo_read_pub_->publish(msg);
 
-  EVR_ACTIVITY_LO(
+  RCLCPP_INFO(this->get_logger(),
     "Async SDO Read issued {Name:(%s) TLC:(%s) Index:(0x%x)"
     " Subindex:(%u) DataType:(%s) AppId:(%u)}",
     msg.name.c_str(), request->tlc.c_str(), msg.sdo_index, msg.sdo_subindex,

--- a/src/fcat_srvs.cpp
+++ b/src/fcat_srvs.cpp
@@ -188,289 +188,62 @@ void FcatSrvs::InitPublishers()
 
 void FcatSrvs::InitServices()
 {
-  DeclareServiceCommand<fcat_msgs::srv::ActuatorProfPosService>(
-    this, pub_sub_ns_ + "srv/actuator_prof_pos",
-    &FcatSrvs::ActuatorProfPosSrvCb, services_qos_, cb_group_blocking_,
-    CommandDescriptor(
-      "Command a Profiled Position motion profile to the Actuator",
-      {CommandArgumentDescriptor(
-         /*arg name*/ "name",
-         /*description*/ "The Fastcat Device Name"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "target_position",
-         /*description*/ "Goal Position target of the motion profile",
-         /*Units*/ "EU"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "profile_velocity",
-         /*description*/ "The desired cruise rate of the motion profile",
-         /*Units*/ "EU / sec"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "profile_accel",
-         /*description*/ "The desired acceleration of the motion profile",
-         /*Units*/ "EU/sec^2"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "relative",
-         /*description*/ "If true, the target_position will computed "
-                         "relative "
-                         "to actual position")}));
+  services_.push_back(this->create_service<fcat_msgs::srv::ActuatorProfPosService>(
+    pub_sub_ns_ + "srv/actuator_prof_pos",
+    std::bind(&FcatSrvs::ActuatorProfPosSrvCb, this, _1, _2), services_qos_,
+    cb_group_blocking_));
 
-  DeclareServiceCommand<fcat_msgs::srv::ActuatorProfVelService>(
-    this, pub_sub_ns_ + "srv/actuator_prof_vel",
-    &FcatSrvs::ActuatorProfVelSrvCb, services_qos_, cb_group_blocking_,
-    CommandDescriptor(
-      "Command a Profiled Velocity motion profile to the Actuator",
-      {CommandArgumentDescriptor(
-         /*arg name*/ "name",
-         /*description*/ "The Fastcat Device Name"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "target_velocity",
-         /*description*/ "The desired cruise rate of the motion profile",
-         /*Units*/ "EU/sec"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "profile_accel",
-         /*description*/ "The desired acceleration of the motion profile",
-         /*Units*/ "EU/sec^2"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "max_duration",
-         /*description*/
-         "The duration of the command, negative values result "
-         "in indefinite profiles",
-         /*Units*/ "sec")}));
+  services_.push_back(this->create_service<fcat_msgs::srv::ActuatorProfVelService>(
+    pub_sub_ns_ + "srv/actuator_prof_vel",
+    std::bind(&FcatSrvs::ActuatorProfVelSrvCb, this, _1, _2), services_qos_,
+    cb_group_blocking_));
 
-  DeclareServiceCommand<fcat_msgs::srv::ActuatorProfTorqueService>(
-    this, pub_sub_ns_ + "srv/actuator_prof_torque",
-    &FcatSrvs::ActuatorProfTorqueSrvCb, services_qos_, cb_group_blocking_,
-    CommandDescriptor(
-      "Command a Profiled Torque motion profile to the Actuator. Here, "
-      "Torque"
-      "is equivalent to Current (frome the DS-402 specification)",
-      {CommandArgumentDescriptor(
-         /*arg name*/ "name",
-         /*description*/ "The Fastcat Device Name"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "target_torque_amps",
-         /*description*/ "The desired effort in current",
-         /*Units*/ "Amps"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "max_duration",
-         /*description*/
-         "The duration of the command, "
-         "negative values result in indefinite profiles",
-         /*Units*/ "sec")}));
+  services_.push_back(this->create_service<fcat_msgs::srv::ActuatorProfTorqueService>(
+    pub_sub_ns_ + "srv/actuator_prof_torque",
+    std::bind(&FcatSrvs::ActuatorProfTorqueSrvCb, this, _1, _2),
+    services_qos_, cb_group_blocking_));
 
-  DeclareServiceCommand<fcat_msgs::srv::ActuatorCalibrateService>(
-    this, pub_sub_ns_ + "srv/actuator_calibrate",
-    &FcatSrvs::ActuatorCalibrateSrvCb, services_qos_, cb_group_blocking_,
-    CommandDescriptor(
-      "Command hardstop calibration to the Actuator. The actuator will "
-      "move in "
-      "the signed velocity direction with the specified lowered current "
-      "limit "
-      "to detect the hardstop. From there, the position is set to the "
-      "calibration "
-      "limit defined in the configuration file. Finally, the original "
-      "current is "
-      "restored and the actuator is commanded to the command limit defined "
-      "in the "
-      "configuration file.",
-      {CommandArgumentDescriptor(
-         /*arg name*/ "name",
-         /*description*/ "The Fastcat Device Name"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "velocity",
-         /*description*/
-         "The desired approach velocity for all motions during "
-         "hardstop calibration",
-         /*Units*/ "EU/sec"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "accel",
-         /*description*/ "The desired acceleration of the motion profile",
-         /*Units*/ "EU/sec^2"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "max_current",
-         /*description*/
-         "Overrides the Peak current setting but only during "
-         "hardstop contact motion",
-         /*Units*/ "Amps")}));
+  services_.push_back(this->create_service<fcat_msgs::srv::ActuatorCalibrateService>(
+    pub_sub_ns_ + "srv/actuator_calibrate",
+    std::bind(&FcatSrvs::ActuatorCalibrateSrvCb, this, _1, _2), services_qos_,
+    cb_group_blocking_));
 
-  DeclareServiceCommand<fcat_msgs::srv::ActuatorSetGainSchedulingModeService>(
-    this, pub_sub_ns_ + "srv/actuator_set_gain_scheduling_mode",
-    &FcatSrvs::ActuatorSetGainSchedulingModeSrvCb, services_qos_,
-    cb_group_blocking_,
-    CommandDescriptor(
-      "Set the Gain Schedule Mode for the actuator GS[2]. "
-      "0 - No Gain Scheduling. "
-      "[1,63] - Specific controller from table. "
-      "64 - Enable Speed-based scheduling. "
-      "65 - Enable position-based scheduling. "
-      "66 - Best Settling. "
-      "67 - manually scheduled, high-bits. "
-      "68 - manually scheduled, low-bits."
-      "Use this interface only if you know what you are doing, Caveat "
-      "Emptor!",
-      {CommandArgumentDescriptor(
-         /*arg name*/ "name",
-         /*description*/ "The Fastcat Device Name"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "gain_scheduling_mode",
-         /*description*/ "The desired gain schedule mode value")}));
+  services_.push_back(
+    this->create_service<fcat_msgs::srv::ActuatorSetGainSchedulingModeService>(
+      pub_sub_ns_ + "srv/actuator_set_gain_scheduling_mode",
+      std::bind(&FcatSrvs::ActuatorSetGainSchedulingModeSrvCb, this, _1, _2),
+      services_qos_, cb_group_blocking_));
 
-  DeclareServiceCommand<fcat_msgs::srv::ActuatorSetUnitModeService>(
-    this, pub_sub_ns_ + "srv/actuator_set_unit_mode",
-    &FcatSrvs::ActuatorSetUnitModeSrvCb, services_qos_, cb_group_blocking_,
-    CommandDescriptor("Sets the Unit Mode UM[1]. "
-                      "1 - Torque Control. "
-                      "2 - Speed Control. "
-                      "3 - Stepper Control. "
-                      "5 - Position Control (default). "
-                      "6 - Stepper Open or Closed Loop.",
-                      {CommandArgumentDescriptor(
-                         /*arg name*/ "name",
-                         /*description*/ "The Fastcat Device Name"),
-                       CommandArgumentDescriptor(
-                         /*arg name*/ "gain_scheduling_mode",
-                         /*description*/ "The desired Unit Mode UM[1]. ")}));
+  services_.push_back(
+    this->create_service<fcat_msgs::srv::ActuatorSetUnitModeService>(
+      pub_sub_ns_ + "srv/actuator_set_unit_mode",
+      std::bind(&FcatSrvs::ActuatorSetUnitModeSrvCb, this, _1, _2),
+      services_qos_, cb_group_blocking_));
 
-  DeclareServiceCommand<fcat_msgs::srv::PidActivateService>(
-    this, pub_sub_ns_ + "srv/pid_activate", &FcatSrvs::PidActivateSrvCb,
-    services_qos_, cb_group_blocking_,
-    CommandDescriptor(
-      "Start the PID Controller with specified parameters.  "
-      "Returns failure if it does not converge in the specified duration. "
-      "Returns success and self-disables if the controller converges.",
-      {CommandArgumentDescriptor(
-         /*arg name*/ "name",
-         /*description*/ "The Fastcat Device Name"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "setpoint",
-         /*description*/ "The controller setpoint",
-         /*Units*/ "EU"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "deadband",
-         /*description*/
-         "The controller deadband tolerance around the setpoint",
-         /*Units*/ "EU"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "persistence_duration",
-         /*description*/
-         "The amount of time the signal must remain with the "
-         "deadband to end control",
-         /*Units*/ "sec"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "max_duration",
-         /*description*/
-         "The maximum duration of the command. Beware: "
-         "negative values can result in indefinite runtime",
-         /*Units*/ "sec")}));
+  services_.push_back(this->create_service<fcat_msgs::srv::PidActivateService>(
+    pub_sub_ns_ + "srv/pid_activate",
+    std::bind(&FcatSrvs::PidActivateSrvCb, this, _1, _2), services_qos_,
+    cb_group_blocking_));
 
-  DeclareServiceCommand<fcat_msgs::srv::AsyncSdoWriteService>(
-    this, pub_sub_ns_ + "srv/async_sdo_write",
-    &FcatSrvs::AsyncSdoWriteSrvCb, services_qos_, cb_group_blocking_,
-    CommandDescriptor(
-      "Issues an Asynchronous SDO parameter Write and waits for the "
-      "result of the operation to indicate success or failure.",
-      {CommandArgumentDescriptor(
-         /*arg name*/ "name",
-         /*description*/ "The Fastcat Device Name"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "sdo_index",
-         /*description*/ "The SDO register index in hexidecimal (0x3034) "
-                         "or "
-                         "decimal (12340) form"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "sdo_subindex",
-         /*description*/ "The SDO register subindex (e.g. the 1 in "
-                         "0x3034:1)"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "data",
-         /*description*/ "Data payload to write to the SDO"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "data_type",
-         /*description*/ "The type of the data payload, must be one of: "
-                         "{I8, I16, I32, I64, F32, U8, U16, U32, "
-                         "U64}")}));
+  services_.push_back(this->create_service<fcat_msgs::srv::AsyncSdoWriteService>(
+    pub_sub_ns_ + "srv/async_sdo_write",
+    std::bind(&FcatSrvs::AsyncSdoWriteSrvCb, this, _1, _2), services_qos_,
+    cb_group_blocking_));
 
-  DeclareServiceCommand<fcat_msgs::srv::AsyncSdoReadService>(
-    this, pub_sub_ns_ + "srv/async_sdo_read", &FcatSrvs::AsyncSdoReadSrvCb,
-    services_qos_, cb_group_blocking_,
-    CommandDescriptor(
-      "Issues an Asynchronous SDO parameter Read and waits for the "
-      "result of the operation to indicate success or failure.",
-      {CommandArgumentDescriptor(
-         /*arg name*/ "name",
-         /*description*/ "The Fastcat Device Name"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "sdo_index",
-         /*description*/ "The SDO register index in hexidecimal (0x3034) "
-                         "or "
-                         "decimal (12340) form"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "sdo_subindex",
-         /*description*/ "The SDO register subindex (the 1 in 0x3034:1)"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "data_type",
-         /*description*/ "The type of the data payload, must be one of: "
-                         "{I8, I16, I32, I64, F32, U8, U16, U32, "
-                         "U64}")}));
+  services_.push_back(this->create_service<fcat_msgs::srv::AsyncSdoReadService>(
+    pub_sub_ns_ + "srv/async_sdo_read",
+    std::bind(&FcatSrvs::AsyncSdoReadSrvCb, this, _1, _2), services_qos_,
+    cb_group_blocking_));
 
-  DeclareServiceCommand<fcat_msgs::srv::TlcWriteService>(
-    this, pub_sub_ns_ + "srv/tlc_write", &FcatSrvs::TlcWriteSrvCb,
-    services_qos_, cb_group_blocking_,
-    CommandDescriptor(
-      "Issues a ELMO Two-Letter Command (TLC) which in turn issues an "
-      "Asynchronous SDO "
-      "parameter Write and waits for the result to indicate success or "
-      "failure. Consult "
-      "The MAN-G-CR document for full listing of drive data objects.",
-      {CommandArgumentDescriptor(
-         /*arg name*/ "name",
-         /*description*/ "The Fastcat Device Name"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "tlc",
-         /*description*/ "The Two-Letter Command (TLC) found in the ELMO "
-                         "MAN-G-CR Command Reference Document. These two "
-                         "chars "
-                         "are converted to an SDO index. (e.g. PL, CL)"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "subindex",
-         /*description*/ "The TLC/SDO register subindex (the 1 in "
-                         "PL[1])"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "data",
-         /*description*/ "Data payload to write to the drive"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "data_type",
-         /*description*/ "The type of the data payload, must be one of: "
-                         "{I8, I16, I32, I64, F32, U8, U16, U32, "
-                         "U64}")}));
+  services_.push_back(this->create_service<fcat_msgs::srv::TlcWriteService>(
+    pub_sub_ns_ + "srv/tlc_write",
+    std::bind(&FcatSrvs::TlcWriteSrvCb, this, _1, _2), services_qos_,
+    cb_group_blocking_));
 
-  DeclareServiceCommand<fcat_msgs::srv::TlcReadService>(
-    this, pub_sub_ns_ + "srv/tlc_read", &FcatSrvs::TlcReadSrvCb,
-    services_qos_, cb_group_blocking_,
-    CommandDescriptor(
-      "Issues a ELMO Two-Letter Command (TLC) which in turn issues an "
-      "Asynchronous SDO "
-      "parameter Read and waits for the result to indicate success or "
-      "failure. Consult "
-      "The MAN-G-CR document for full listing of drive data objects.",
-      {CommandArgumentDescriptor(
-         /*arg name*/ "name",
-         /*description*/ "The Fastcat Device Name"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "tlc",
-         /*description*/ "The Two-Letter Command (TLC) found in the ELMO "
-                         "MAN-G-CR Command Reference Document. These two "
-                         "chars "
-                         "are converted to an SDO index. (e.g. PL, CL)"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "subindex",
-         /*description*/ "The TLC/SDO register subindex (the 1 in "
-                         "PL[1])"),
-       CommandArgumentDescriptor(
-         /*arg name*/ "data_type",
-         /*description*/ "The type of the data payload, must be one of: "
-                         "{I8, I16, I32, I64, F32, U8, U16, U32, "
-                         "U64}")}));
+  services_.push_back(this->create_service<fcat_msgs::srv::TlcReadService>(
+    pub_sub_ns_ + "srv/tlc_read",
+    std::bind(&FcatSrvs::TlcReadSrvCb, this, _1, _2), services_qos_,
+    cb_group_blocking_));
 }
 
 //

--- a/src/fcat_srvs.cpp
+++ b/src/fcat_srvs.cpp
@@ -114,16 +114,7 @@ FcatSrvs::FcatSrvs(const rclcpp::NodeOptions& options)
   InitSubscribers();
   InitPublishers();
   InitServices();
-
-  // Call this only after setting all initialization array params
-  PreventArrayParamSet();
-  InitializeTimerRate();
-
-  // No need to call StartTimer(). Relying on executor.spin(),
-  //   callbackgroups, and rclcpp::Rate instead
-  rate_ = std::make_unique<rclcpp::Rate>(this->GetTimerRate());
-
-  SetActive();
+  rate_ = std::make_unique<rclcpp::Rate>(loop_rate_hz_);
 }
 
 void FcatSrvs::InitSubscribers()

--- a/src/fcat_srvs.cpp
+++ b/src/fcat_srvs.cpp
@@ -1,5 +1,8 @@
 #include "fcat/fcat_services.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "rcl_interfaces/msg/floating_point_range.hpp"
+#include "rcl_interfaces/msg/integer_range.hpp"
+#include "rcl_interfaces/msg/parameter_descriptor.hpp"
 #include "fastcat/jsd/actuator.h"
 #include "fcat/fcat_utils.hpp"
 #include "jsd/jsd_print.h"
@@ -26,44 +29,88 @@ FcatSrvs::FcatSrvs(const rclcpp::NodeOptions& options)
     this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 
   // Init Parameters
-  pub_sub_ns_ =
-    DeclareInitParameterString("pub_sub_namespace", "/fcat/",
-                               "The namespace of the outgoing publisher and "
-                               "incoming subscription topics");
+  {
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.description =
+      "The namespace of the outgoing publisher and incoming subscription "
+      "topics";
+    descriptor.read_only = true;
+    pub_sub_ns_ = this->declare_parameter<std::string>(
+      "pub_sub_namespace", "/fcat/", descriptor);
+  }
 
-  sdo_app_id_ = static_cast<uint16_t>(
-    DeclareInitParameterInt("starting_sdo_app_id", 1000,
-                            "Starting value of the SDO tracking app_id. The "
-                            "value is incremented each request",
-                            0, 65535));
+  {
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.description =
+      "Starting value of the SDO tracking app_id. The value is incremented "
+      "each request";
+    descriptor.read_only = true;
+    rcl_interfaces::msg::IntegerRange range;
+    range.from_value = 0;
+    range.to_value = 65535;
+    range.step = 1;
+    descriptor.integer_range.push_back(range);
+    sdo_app_id_ = static_cast<uint16_t>(this->declare_parameter<int64_t>(
+      "starting_sdo_app_id", 1000, descriptor));
+  }
 
-  max_sdo_queue_size_ = static_cast<size_t>(DeclareInitParameterInt(
-    "max_sdo_queue_size", 32,
-    "Max size of the SDO Response queue. This queue is not checked unless an"
-    " SDO blocking service is active. This prevents the queue from allocating"
-    " too much memory when left running for a long time",
-    1, 10000));
+  {
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.description =
+      "Max size of the SDO Response queue. This queue is not checked unless "
+      "an SDO blocking service is active. This prevents the queue from "
+      "allocating too much memory when left running for a long time";
+    descriptor.read_only = true;
+    rcl_interfaces::msg::IntegerRange range;
+    range.from_value = 1;
+    range.to_value = 10000;
+    range.step = 1;
+    descriptor.integer_range.push_back(range);
+    max_sdo_queue_size_ = static_cast<size_t>(this->declare_parameter<int64_t>(
+      "max_sdo_queue_size", 32, descriptor));
+  }
 
   // Rutime Parameters
-  DeclareRuntimeParameterInt(
-    "idle_persist_rti", 5,
-    "Number of RTI loops to wait to see if device state changes from idle to "
-    "moving."
-    "If this number of RTIs passes, then the command returns success, "
-    "assumed device "
-    "did not need to change in order or achieve the command.",
-    1, 1000);
+  {
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.description =
+      "Number of RTI loops to wait to see if device state changes from idle "
+      "to moving.If this number of RTIs passes, then the command returns "
+      "success, assumed device did not need to change in order or achieve "
+      "the command.";
+    rcl_interfaces::msg::IntegerRange range;
+    range.from_value = 1;
+    range.to_value = 1000;
+    range.step = 1;
+    descriptor.integer_range.push_back(range);
+    this->declare_parameter<int64_t>("idle_persist_rti", 5, descriptor);
+  }
 
-  DeclareRuntimeParameterDouble("tolerance", 1.0e-8,
-                                "Tolerance used to check if argument is near "
-                                "zero e.g. fabs(arg) < tolerance",
-                                0, 10);
+  {
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.description =
+      "Tolerance used to check if argument is near zero e.g. fabs(arg) < "
+      "tolerance";
+    rcl_interfaces::msg::FloatingPointRange range;
+    range.from_value = 0.0;
+    range.to_value = 10.0;
+    range.step = 0.0;
+    descriptor.floating_point_range.push_back(range);
+    this->declare_parameter<double>("tolerance", 1.0e-8, descriptor);
+  }
 
-  DeclareRuntimeParameterDouble(
-    "sdo_wait_duration_sec", 2.0,
-    "Maximum time to wait for an Async SDO response. If this timer expires"
-    " the service will terminate with a failure",
-    0, 60);
+  {
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.description =
+      "Maximum time to wait for an Async SDO response. If this timer expires"
+      " the service will terminate with a failure";
+    rcl_interfaces::msg::FloatingPointRange range;
+    range.from_value = 0.0;
+    range.to_value = 60.0;
+    range.step = 0.0;
+    descriptor.floating_point_range.push_back(range);
+    this->declare_parameter<double>("sdo_wait_duration_sec", 2.0, descriptor);
+  }
 
   InitSubscribers();
   InitPublishers();

--- a/src/fcat_srvs.cpp
+++ b/src/fcat_srvs.cpp
@@ -1,4 +1,4 @@
-#include "fcat/fcat_services.hpp"
+#include "fcat/fcat_srvs.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rcl_interfaces/msg/floating_point_range.hpp"
 #include "rcl_interfaces/msg/integer_range.hpp"
@@ -7,8 +7,6 @@
 #include "fcat/fcat_utils.hpp"
 #include "jsd/jsd_print.h"
 
-#include "casah_node/utils.hpp"
-
 #include <chrono>
 #include <cstdio>
 using namespace std::chrono_literals;
@@ -16,7 +14,7 @@ using std::placeholders::_1;
 using std::placeholders::_2;
 
 FcatSrvs::FcatSrvs(const rclcpp::NodeOptions& options)
-    : casah_node::BaseInterface("fcat_services", "fcat", options),
+    : rclcpp::Node("fcat_services", "fcat", options),
       services_qos_(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_services_default), rmw_qos_profile_services_default),
       module_state_last_recv_time_(0),
       act_states_last_recv_time_(0),
@@ -121,7 +119,7 @@ FcatSrvs::FcatSrvs(const rclcpp::NodeOptions& options)
   PreventArrayParamSet();
   InitializeTimerRate();
 
-  // No need to call CasahNode::StartTimer(). Relying on executor.spin(),
+  // No need to call StartTimer(). Relying on executor.spin(),
   //   callbackgroups, and rclcpp::Rate instead
   rate_ = std::make_unique<rclcpp::Rate>(this->GetTimerRate());
 

--- a/src/fcat_srvs.cpp
+++ b/src/fcat_srvs.cpp
@@ -1,10 +1,12 @@
-#include "fcat/fcat_srvs.hpp"
+// Copyright 2021 California Institute of Technology
+
+#include "fcat_srvs.hpp"
 
 #include <chrono>
 #include <cstdio>
 
 #include "fastcat/jsd/actuator.h"
-#include "fcat/fcat_utils.hpp"
+#include "fcat_utils.hpp"
 #include "jsd/jsd_print.h"
 #include "rcl_interfaces/msg/floating_point_range.hpp"
 #include "rcl_interfaces/msg/integer_range.hpp"
@@ -430,21 +432,21 @@ bool FcatSrvs::WaitForSdoResponse(std::string& message, uint16_t app_id) {
       bool success = async_sdo_response_msg_.success;
 
       if (!success) {
-        sprintf(print_str,
-                "SDO Response Failed {Name:(%s) Index:(0x%x)"
-                " Subindex:(%u) Data:(%s) DataType:(%s) AppId:(%u)}",
-                async_sdo_response_msg_.device_name.c_str(), async_sdo_response_msg_.sdo_index,
-                async_sdo_response_msg_.sdo_subindex, async_sdo_response_msg_.data.c_str(),
-                async_sdo_response_msg_.data_type.c_str(), async_sdo_response_msg_.app_id);
+        snprintf(print_str, sizeof(print_str),
+                 "SDO Response Failed {Name:(%s) Index:(0x%x)"
+                 " Subindex:(%u) Data:(%s) DataType:(%s) AppId:(%u)}",
+                 async_sdo_response_msg_.device_name.c_str(), async_sdo_response_msg_.sdo_index,
+                 async_sdo_response_msg_.sdo_subindex, async_sdo_response_msg_.data.c_str(),
+                 async_sdo_response_msg_.data_type.c_str(), async_sdo_response_msg_.app_id);
         message = print_str;
         RCLCPP_WARN(this->get_logger(), "%s", print_str);
       } else {
-        sprintf(print_str,
-                "SDO Response Success {Name:(%s) Index:(0x%x)"
-                " Subindex:(%u) Data:(%s) DataType:(%s) AppId:(%u)}",
-                async_sdo_response_msg_.device_name.c_str(), async_sdo_response_msg_.sdo_index,
-                async_sdo_response_msg_.sdo_subindex, async_sdo_response_msg_.data.c_str(),
-                async_sdo_response_msg_.data_type.c_str(), async_sdo_response_msg_.app_id);
+        snprintf(print_str, sizeof(print_str),
+                 "SDO Response Success {Name:(%s) Index:(0x%x)"
+                 " Subindex:(%u) Data:(%s) DataType:(%s) AppId:(%u)}",
+                 async_sdo_response_msg_.device_name.c_str(), async_sdo_response_msg_.sdo_index,
+                 async_sdo_response_msg_.sdo_subindex, async_sdo_response_msg_.data.c_str(),
+                 async_sdo_response_msg_.data_type.c_str(), async_sdo_response_msg_.app_id);
         message = print_str;
         RCLCPP_INFO(this->get_logger(), "%s", print_str);
       }
@@ -455,10 +457,10 @@ bool FcatSrvs::WaitForSdoResponse(std::string& message, uint16_t app_id) {
   }
 
   // if here, runout timer has expired
-  sprintf(print_str,
-          "SDO Runout timer expired for app_id:(%u). "
-          "Parameter 'sdo_wait_duration_sec' is set to (%lf)",
-          app_id, sdo_wait_duration_sec);
+  snprintf(print_str, sizeof(print_str),
+           "SDO Runout timer expired for app_id:(%u). "
+           "Parameter 'sdo_wait_duration_sec' is set to (%lf)",
+           app_id, sdo_wait_duration_sec);
   message = print_str;
   RCLCPP_WARN(this->get_logger(), "%s", print_str);
   return false;
@@ -709,8 +711,8 @@ void FcatSrvs::AsyncSdoWriteSrvCb(
   // 1) Parse input args
   uint16_t parsed_sdo_index = 0;
   if (!HexOrDecStrToNum(request->sdo_index, parsed_sdo_index)) {
-    sprintf(print_str, "Invalid SDO index string:(%s) conversion to U16",
-            request->sdo_index.c_str());
+    snprintf(print_str, sizeof(print_str), "Invalid SDO index string:(%s) conversion to U16",
+             request->sdo_index.c_str());
 
     response->message = print_str;
     RCLCPP_WARN(this->get_logger(), "%s", print_str);
@@ -719,10 +721,10 @@ void FcatSrvs::AsyncSdoWriteSrvCb(
   }
 
   if (JSD_SDO_DATA_UNSPECIFIED == jsd_sdo_data_type_from_string(request->data_type)) {
-    sprintf(print_str,
-            "Invalid SDO Write data_type:(%s) Must be one of "
-            "{'I8', 'I16', 'I32', 'I64', 'F32', 'U8', 'U16', 'U32', 'U64'}",
-            request->data_type.c_str());
+    snprintf(print_str, sizeof(print_str),
+             "Invalid SDO Write data_type:(%s) Must be one of "
+             "{'I8', 'I16', 'I32', 'I64', 'F32', 'U8', 'U16', 'U32', 'U64'}",
+             request->data_type.c_str());
     response->message = print_str;
     RCLCPP_WARN(this->get_logger(), "%s", print_str);
     return;
@@ -760,8 +762,8 @@ void FcatSrvs::AsyncSdoReadSrvCb(
   // 1) Parse input args
   uint16_t parsed_sdo_index = 0;
   if (!HexOrDecStrToNum(request->sdo_index, parsed_sdo_index)) {
-    sprintf(print_str, "Invalid SDO index string:(%s) conversion to U16",
-            request->sdo_index.c_str());
+    snprintf(print_str, sizeof(print_str), "Invalid SDO index string:(%s) conversion to U16",
+             request->sdo_index.c_str());
 
     response->message = print_str;
     RCLCPP_WARN(this->get_logger(), "%s", print_str);
@@ -769,10 +771,10 @@ void FcatSrvs::AsyncSdoReadSrvCb(
   }
 
   if (JSD_SDO_DATA_UNSPECIFIED == jsd_sdo_data_type_from_string(request->data_type)) {
-    sprintf(print_str,
-            "Invalid SDO Read data_type:(%s) Must be one of "
-            "{'I8', 'I16', 'I32', 'I64', 'F32', 'U8', 'U16', 'U32', 'U64'}",
-            request->data_type.c_str());
+    snprintf(print_str, sizeof(print_str),
+             "Invalid SDO Read data_type:(%s) Must be one of "
+             "{'I8', 'I16', 'I32', 'I64', 'F32', 'U8', 'U16', 'U32', 'U64'}",
+             request->data_type.c_str());
 
     response->message = print_str;
     RCLCPP_WARN(this->get_logger(), "%s", print_str);
@@ -809,7 +811,8 @@ void FcatSrvs::TlcWriteSrvCb(
   // 1) Parse input args
   uint16_t parsed_sdo_index = 0;
   if (!TlcStrToNum(request->tlc, parsed_sdo_index)) {
-    sprintf(print_str, "Invalid TLC string:(%s) conversion to SDO", request->tlc.c_str());
+    snprintf(print_str, sizeof(print_str), "Invalid TLC string:(%s) conversion to SDO",
+             request->tlc.c_str());
 
     response->message = print_str;
     RCLCPP_WARN(this->get_logger(), "%s", print_str);
@@ -817,10 +820,10 @@ void FcatSrvs::TlcWriteSrvCb(
   }
 
   if (JSD_SDO_DATA_UNSPECIFIED == jsd_sdo_data_type_from_string(request->data_type)) {
-    sprintf(print_str,
-            "Invalid SDO Write data_type:(%s) Must be one of "
-            "{'I8', 'I16', 'I32', 'I64', 'F32', 'U8', 'U16', 'U32', 'U64'}",
-            request->data_type.c_str());
+    snprintf(print_str, sizeof(print_str),
+             "Invalid SDO Write data_type:(%s) Must be one of "
+             "{'I8', 'I16', 'I32', 'I64', 'F32', 'U8', 'U16', 'U32', 'U64'}",
+             request->data_type.c_str());
     response->message = print_str;
     RCLCPP_WARN(this->get_logger(), "%s", print_str);
 
@@ -858,7 +861,8 @@ void FcatSrvs::TlcReadSrvCb(const std::shared_ptr<fcat_msgs::srv::TlcReadService
   // 1) Parse input args
   uint16_t parsed_sdo_index = 0;
   if (!TlcStrToNum(request->tlc, parsed_sdo_index)) {
-    sprintf(print_str, "Invalid TLC string:(%s) conversion to SDO", request->tlc.c_str());
+    snprintf(print_str, sizeof(print_str), "Invalid TLC string:(%s) conversion to SDO",
+             request->tlc.c_str());
 
     response->message = print_str;
     RCLCPP_WARN(this->get_logger(), "%s", print_str);
@@ -866,10 +870,10 @@ void FcatSrvs::TlcReadSrvCb(const std::shared_ptr<fcat_msgs::srv::TlcReadService
   }
 
   if (JSD_SDO_DATA_UNSPECIFIED == jsd_sdo_data_type_from_string(request->data_type)) {
-    sprintf(print_str,
-            "Invalid SDO Read data_type:(%s) Must be one of "
-            "{'I8', 'I16', 'I32', 'I64', 'F32', 'U8', 'U16', 'U32', 'U64'}",
-            request->data_type.c_str());
+    snprintf(print_str, sizeof(print_str),
+             "Invalid SDO Read data_type:(%s) Must be one of "
+             "{'I8', 'I16', 'I32', 'I64', 'F32', 'U8', 'U16', 'U32', 'U64'}",
+             request->data_type.c_str());
 
     response->message = print_str;
     RCLCPP_WARN(this->get_logger(), "%s", print_str);

--- a/src/fcat_srvs.cpp
+++ b/src/fcat_srvs.cpp
@@ -1,82 +1,81 @@
 #include "fcat/fcat_srvs.hpp"
-#include "rclcpp/rclcpp.hpp"
-#include "rcl_interfaces/msg/floating_point_range.hpp"
-#include "rcl_interfaces/msg/integer_range.hpp"
-#include "rcl_interfaces/msg/parameter_descriptor.hpp"
-#include "fastcat/jsd/actuator.h"
-#include "fcat/fcat_utils.hpp"
-#include "jsd/jsd_print.h"
 
 #include <chrono>
 #include <cstdio>
+
+#include "fastcat/jsd/actuator.h"
+#include "fcat/fcat_utils.hpp"
+#include "jsd/jsd_print.h"
+#include "rcl_interfaces/msg/floating_point_range.hpp"
+#include "rcl_interfaces/msg/integer_range.hpp"
+#include "rcl_interfaces/msg/parameter_descriptor.hpp"
+#include "rclcpp/rclcpp.hpp"
 using namespace std::chrono_literals;
 using std::placeholders::_1;
 using std::placeholders::_2;
 
 FcatSrvs::FcatSrvs(const rclcpp::NodeOptions& options)
     : rclcpp::Node("fcat_services", "fcat", options),
-      services_qos_(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_services_default), rmw_qos_profile_services_default),
+      services_qos_(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_services_default),
+                    rmw_qos_profile_services_default),
       module_state_last_recv_time_(0),
       act_states_last_recv_time_(0),
       pid_states_last_recv_time_(0),
-      srv_state_(FCAT_SRV_STATE_IDLE_CHECKING)
-{
-  cb_group_blocking_ =
-    this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+      srv_state_(FCAT_SRV_STATE_IDLE_CHECKING) {
+  cb_group_blocking_ = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 
   cb_group_non_blocking_ =
-    this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+      this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 
   // Init Parameters
   {
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description =
-      "The namespace of the outgoing publisher and incoming subscription "
-      "topics";
+        "The namespace of the outgoing publisher and incoming subscription "
+        "topics";
     descriptor.read_only = true;
-    pub_sub_ns_ = this->declare_parameter<std::string>(
-      "pub_sub_namespace", "/fcat/", descriptor);
+    pub_sub_ns_ = this->declare_parameter<std::string>("pub_sub_namespace", "/fcat/", descriptor);
   }
 
   {
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description =
-      "Starting value of the SDO tracking app_id. The value is incremented "
-      "each request";
+        "Starting value of the SDO tracking app_id. The value is incremented "
+        "each request";
     descriptor.read_only = true;
     rcl_interfaces::msg::IntegerRange range;
     range.from_value = 0;
     range.to_value = 65535;
     range.step = 1;
     descriptor.integer_range.push_back(range);
-    sdo_app_id_ = static_cast<uint16_t>(this->declare_parameter<int64_t>(
-      "starting_sdo_app_id", 1000, descriptor));
+    sdo_app_id_ = static_cast<uint16_t>(
+        this->declare_parameter<int64_t>("starting_sdo_app_id", 1000, descriptor));
   }
 
   {
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description =
-      "Max size of the SDO Response queue. This queue is not checked unless "
-      "an SDO blocking service is active. This prevents the queue from "
-      "allocating too much memory when left running for a long time";
+        "Max size of the SDO Response queue. This queue is not checked unless "
+        "an SDO blocking service is active. This prevents the queue from "
+        "allocating too much memory when left running for a long time";
     descriptor.read_only = true;
     rcl_interfaces::msg::IntegerRange range;
     range.from_value = 1;
     range.to_value = 10000;
     range.step = 1;
     descriptor.integer_range.push_back(range);
-    max_sdo_queue_size_ = static_cast<size_t>(this->declare_parameter<int64_t>(
-      "max_sdo_queue_size", 32, descriptor));
+    max_sdo_queue_size_ =
+        static_cast<size_t>(this->declare_parameter<int64_t>("max_sdo_queue_size", 32, descriptor));
   }
 
   // Rutime Parameters
   {
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description =
-      "Number of RTI loops to wait to see if device state changes from idle "
-      "to moving.If this number of RTIs passes, then the command returns "
-      "success, assumed device did not need to change in order or achieve "
-      "the command.";
+        "Number of RTI loops to wait to see if device state changes from idle "
+        "to moving.If this number of RTIs passes, then the command returns "
+        "success, assumed device did not need to change in order or achieve "
+        "the command.";
     rcl_interfaces::msg::IntegerRange range;
     range.from_value = 1;
     range.to_value = 1000;
@@ -88,8 +87,8 @@ FcatSrvs::FcatSrvs(const rclcpp::NodeOptions& options)
   {
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description =
-      "Tolerance used to check if argument is near zero e.g. fabs(arg) < "
-      "tolerance";
+        "Tolerance used to check if argument is near zero e.g. fabs(arg) < "
+        "tolerance";
     rcl_interfaces::msg::FloatingPointRange range;
     range.from_value = 0.0;
     range.to_value = 10.0;
@@ -101,8 +100,8 @@ FcatSrvs::FcatSrvs(const rclcpp::NodeOptions& options)
   {
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description =
-      "Maximum time to wait for an Async SDO response. If this timer expires"
-      " the service will terminate with a failure";
+        "Maximum time to wait for an Async SDO response. If this timer expires"
+        " the service will terminate with a failure";
     rcl_interfaces::msg::FloatingPointRange range;
     range.from_value = 0.0;
     range.to_value = 60.0;
@@ -117,151 +116,122 @@ FcatSrvs::FcatSrvs(const rclcpp::NodeOptions& options)
   rate_ = std::make_unique<rclcpp::Rate>(loop_rate_hz_);
 }
 
-void FcatSrvs::InitSubscribers()
-{
-  auto sub_opts =
-    rclcpp::SubscriptionOptionsWithAllocator<std::allocator<void>>();
+void FcatSrvs::InitSubscribers() {
+  auto sub_opts = rclcpp::SubscriptionOptionsWithAllocator<std::allocator<void>>();
   sub_opts.callback_group = cb_group_non_blocking_;
 
-  subscriptions_.push_back(
-    this->create_subscription<fcat_msgs::msg::ModuleState>(
+  subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::ModuleState>(
       pub_sub_ns_ + "state/module_state", subscription_qos_,
       std::bind(&FcatSrvs::FcatModuleStateCb, this, _1), sub_opts));
 
-  subscriptions_.push_back(
-    this->create_subscription<fcat_msgs::msg::ActuatorStates>(
+  subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::ActuatorStates>(
       pub_sub_ns_ + "state/actuators", subscription_qos_,
       std::bind(&FcatSrvs::ActuatorStatesCb, this, _1), sub_opts));
 
   subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::PidStates>(
-    pub_sub_ns_ + "state/pids", subscription_qos_,
-    std::bind(&FcatSrvs::PidStatesCb, this, _1), sub_opts));
+      pub_sub_ns_ + "state/pids", subscription_qos_, std::bind(&FcatSrvs::PidStatesCb, this, _1),
+      sub_opts));
 
-  subscriptions_.push_back(
-    this->create_subscription<fcat_msgs::msg::AsyncSdoResponse>(
+  subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::AsyncSdoResponse>(
       pub_sub_ns_ + "state/async_sdo_response", subscription_qos_,
       std::bind(&FcatSrvs::AsyncSdoResponseCb, this, _1), sub_opts));
 }
 
-void FcatSrvs::InitPublishers()
-{
-  act_prof_pos_pub_ =
-    this->create_publisher<fcat_msgs::msg::ActuatorProfPosCmd>(
+void FcatSrvs::InitPublishers() {
+  act_prof_pos_pub_ = this->create_publisher<fcat_msgs::msg::ActuatorProfPosCmd>(
       pub_sub_ns_ + "impl/actuator_prof_pos", publisher_queue_size_);
 
-  act_prof_vel_pub_ =
-    this->create_publisher<fcat_msgs::msg::ActuatorProfVelCmd>(
+  act_prof_vel_pub_ = this->create_publisher<fcat_msgs::msg::ActuatorProfVelCmd>(
       pub_sub_ns_ + "impl/actuator_prof_vel", publisher_queue_size_);
 
-  act_prof_torque_pub_ =
-    this->create_publisher<fcat_msgs::msg::ActuatorProfTorqueCmd>(
+  act_prof_torque_pub_ = this->create_publisher<fcat_msgs::msg::ActuatorProfTorqueCmd>(
       pub_sub_ns_ + "impl/actuator_prof_torque", publisher_queue_size_);
 
-  act_digital_output_pub_ =
-    this->create_publisher<fcat_msgs::msg::ActuatorSetDigitalOutputCmd>(
+  act_digital_output_pub_ = this->create_publisher<fcat_msgs::msg::ActuatorSetDigitalOutputCmd>(
       pub_sub_ns_ + "impl/actuator_set_digital_output", publisher_queue_size_);
 
-  act_calibrate_pub_ =
-    this->create_publisher<fcat_msgs::msg::ActuatorCalibrateCmd>(
+  act_calibrate_pub_ = this->create_publisher<fcat_msgs::msg::ActuatorCalibrateCmd>(
       pub_sub_ns_ + "impl/actuator_calibrate", publisher_queue_size_);
 
   pid_activate_pub_ = this->create_publisher<fcat_msgs::msg::PidActivateCmd>(
-    pub_sub_ns_ + "impl/pid_activate", publisher_queue_size_);
+      pub_sub_ns_ + "impl/pid_activate", publisher_queue_size_);
 
-  async_sdo_write_pub_ =
-    this->create_publisher<fcat_msgs::msg::AsyncSdoWriteCmd>(
+  async_sdo_write_pub_ = this->create_publisher<fcat_msgs::msg::AsyncSdoWriteCmd>(
       pub_sub_ns_ + "impl/async_sdo_write", publisher_queue_size_);
 
   async_sdo_read_pub_ = this->create_publisher<fcat_msgs::msg::AsyncSdoReadCmd>(
-    pub_sub_ns_ + "impl/async_sdo_read", publisher_queue_size_);
+      pub_sub_ns_ + "impl/async_sdo_read", publisher_queue_size_);
 }
 
-void FcatSrvs::InitServices()
-{
+void FcatSrvs::InitServices() {
   services_.push_back(this->create_service<fcat_msgs::srv::ActuatorProfPosService>(
-    pub_sub_ns_ + "srv/actuator_prof_pos",
-    std::bind(&FcatSrvs::ActuatorProfPosSrvCb, this, _1, _2), services_qos_,
-    cb_group_blocking_));
+      pub_sub_ns_ + "srv/actuator_prof_pos",
+      std::bind(&FcatSrvs::ActuatorProfPosSrvCb, this, _1, _2), services_qos_, cb_group_blocking_));
 
   services_.push_back(this->create_service<fcat_msgs::srv::ActuatorProfVelService>(
-    pub_sub_ns_ + "srv/actuator_prof_vel",
-    std::bind(&FcatSrvs::ActuatorProfVelSrvCb, this, _1, _2), services_qos_,
-    cb_group_blocking_));
+      pub_sub_ns_ + "srv/actuator_prof_vel",
+      std::bind(&FcatSrvs::ActuatorProfVelSrvCb, this, _1, _2), services_qos_, cb_group_blocking_));
 
   services_.push_back(this->create_service<fcat_msgs::srv::ActuatorProfTorqueService>(
-    pub_sub_ns_ + "srv/actuator_prof_torque",
-    std::bind(&FcatSrvs::ActuatorProfTorqueSrvCb, this, _1, _2),
-    services_qos_, cb_group_blocking_));
+      pub_sub_ns_ + "srv/actuator_prof_torque",
+      std::bind(&FcatSrvs::ActuatorProfTorqueSrvCb, this, _1, _2), services_qos_,
+      cb_group_blocking_));
 
   services_.push_back(this->create_service<fcat_msgs::srv::ActuatorCalibrateService>(
-    pub_sub_ns_ + "srv/actuator_calibrate",
-    std::bind(&FcatSrvs::ActuatorCalibrateSrvCb, this, _1, _2), services_qos_,
-    cb_group_blocking_));
+      pub_sub_ns_ + "srv/actuator_calibrate",
+      std::bind(&FcatSrvs::ActuatorCalibrateSrvCb, this, _1, _2), services_qos_,
+      cb_group_blocking_));
 
-  services_.push_back(
-    this->create_service<fcat_msgs::srv::ActuatorSetGainSchedulingModeService>(
+  services_.push_back(this->create_service<fcat_msgs::srv::ActuatorSetGainSchedulingModeService>(
       pub_sub_ns_ + "srv/actuator_set_gain_scheduling_mode",
-      std::bind(&FcatSrvs::ActuatorSetGainSchedulingModeSrvCb, this, _1, _2),
-      services_qos_, cb_group_blocking_));
+      std::bind(&FcatSrvs::ActuatorSetGainSchedulingModeSrvCb, this, _1, _2), services_qos_,
+      cb_group_blocking_));
 
-  services_.push_back(
-    this->create_service<fcat_msgs::srv::ActuatorSetUnitModeService>(
+  services_.push_back(this->create_service<fcat_msgs::srv::ActuatorSetUnitModeService>(
       pub_sub_ns_ + "srv/actuator_set_unit_mode",
-      std::bind(&FcatSrvs::ActuatorSetUnitModeSrvCb, this, _1, _2),
-      services_qos_, cb_group_blocking_));
+      std::bind(&FcatSrvs::ActuatorSetUnitModeSrvCb, this, _1, _2), services_qos_,
+      cb_group_blocking_));
 
   services_.push_back(this->create_service<fcat_msgs::srv::PidActivateService>(
-    pub_sub_ns_ + "srv/pid_activate",
-    std::bind(&FcatSrvs::PidActivateSrvCb, this, _1, _2), services_qos_,
-    cb_group_blocking_));
+      pub_sub_ns_ + "srv/pid_activate", std::bind(&FcatSrvs::PidActivateSrvCb, this, _1, _2),
+      services_qos_, cb_group_blocking_));
 
   services_.push_back(this->create_service<fcat_msgs::srv::AsyncSdoWriteService>(
-    pub_sub_ns_ + "srv/async_sdo_write",
-    std::bind(&FcatSrvs::AsyncSdoWriteSrvCb, this, _1, _2), services_qos_,
-    cb_group_blocking_));
+      pub_sub_ns_ + "srv/async_sdo_write", std::bind(&FcatSrvs::AsyncSdoWriteSrvCb, this, _1, _2),
+      services_qos_, cb_group_blocking_));
 
   services_.push_back(this->create_service<fcat_msgs::srv::AsyncSdoReadService>(
-    pub_sub_ns_ + "srv/async_sdo_read",
-    std::bind(&FcatSrvs::AsyncSdoReadSrvCb, this, _1, _2), services_qos_,
-    cb_group_blocking_));
+      pub_sub_ns_ + "srv/async_sdo_read", std::bind(&FcatSrvs::AsyncSdoReadSrvCb, this, _1, _2),
+      services_qos_, cb_group_blocking_));
 
   services_.push_back(this->create_service<fcat_msgs::srv::TlcWriteService>(
-    pub_sub_ns_ + "srv/tlc_write",
-    std::bind(&FcatSrvs::TlcWriteSrvCb, this, _1, _2), services_qos_,
-    cb_group_blocking_));
+      pub_sub_ns_ + "srv/tlc_write", std::bind(&FcatSrvs::TlcWriteSrvCb, this, _1, _2),
+      services_qos_, cb_group_blocking_));
 
   services_.push_back(this->create_service<fcat_msgs::srv::TlcReadService>(
-    pub_sub_ns_ + "srv/tlc_read",
-    std::bind(&FcatSrvs::TlcReadSrvCb, this, _1, _2), services_qos_,
-    cb_group_blocking_));
+      pub_sub_ns_ + "srv/tlc_read", std::bind(&FcatSrvs::TlcReadSrvCb, this, _1, _2), services_qos_,
+      cb_group_blocking_));
 }
 
 //
 // Fcat State Subscription Callbacks
 //
 
-void FcatSrvs::FcatModuleStateCb(
-  const std::shared_ptr<fcat_msgs::msg::ModuleState> msg)
-{
+void FcatSrvs::FcatModuleStateCb(const std::shared_ptr<fcat_msgs::msg::ModuleState> msg) {
   module_state_last_recv_time_ = this->now().seconds();
   fcat_module_state_msg_ = *msg;
 }
 
-void FcatSrvs::ActuatorStatesCb(
-  const std::shared_ptr<fcat_msgs::msg::ActuatorStates> msg)
-{
+void FcatSrvs::ActuatorStatesCb(const std::shared_ptr<fcat_msgs::msg::ActuatorStates> msg) {
   act_states_last_recv_time_ = this->now().seconds();
   actuator_states_msg_ = *msg;
 
   for (size_t i = 0; i < actuator_states_msg_.names.size(); ++i) {
-    act_state_map_[actuator_states_msg_.names[i]] =
-      actuator_states_msg_.states[i];
+    act_state_map_[actuator_states_msg_.names[i]] = actuator_states_msg_.states[i];
   }
 }
 
-void FcatSrvs::PidStatesCb(
-  const std::shared_ptr<fcat_msgs::msg::PidStates> msg)
-{
+void FcatSrvs::PidStatesCb(const std::shared_ptr<fcat_msgs::msg::PidStates> msg) {
   pid_states_last_recv_time_ = this->now().seconds();
   pid_states_msg_ = *msg;
 
@@ -270,9 +240,7 @@ void FcatSrvs::PidStatesCb(
   }
 }
 
-void FcatSrvs::AsyncSdoResponseCb(
-  const std::shared_ptr<fcat_msgs::msg::AsyncSdoResponse> msg)
-{
+void FcatSrvs::AsyncSdoResponseCb(const std::shared_ptr<fcat_msgs::msg::AsyncSdoResponse> msg) {
   // prevent the queue from filling up too much
   if (sdo_response_queue_.size() >= max_sdo_queue_size_) {
     sdo_response_queue_.pop();
@@ -283,11 +251,9 @@ void FcatSrvs::AsyncSdoResponseCb(
 //
 // Helper Functions
 //
-bool FcatSrvs::ActuatorCmdPrechecks(std::string name, std::string& message)
-{
+bool FcatSrvs::ActuatorCmdPrechecks(std::string name, std::string& message) {
   // 1) Check fcat module state liveliness check
-  if ((this->now().seconds() - module_state_last_recv_time_) >
-      liveliness_duration_sec_) {
+  if ((this->now().seconds() - module_state_last_recv_time_) > liveliness_duration_sec_) {
     message = "stale fcat module state topic, fcat is not running";
     RCLCPP_WARN(this->get_logger(), "bad command: %s", message.c_str());
     return false;
@@ -301,11 +267,10 @@ bool FcatSrvs::ActuatorCmdPrechecks(std::string name, std::string& message)
   }
 
   // 3) Check Actuator States liveliness check
-  if ((this->now().seconds() - act_states_last_recv_time_) >
-      liveliness_duration_sec_) {
+  if ((this->now().seconds() - act_states_last_recv_time_) > liveliness_duration_sec_) {
     message =
-      "stale fcat actuator states topic, check fastcat YAML has any "
-      "actuators";
+        "stale fcat actuator states topic, check fastcat YAML has any "
+        "actuators";
     RCLCPP_WARN(this->get_logger(), "bad command: %s", message.c_str());
     return false;
   }
@@ -319,11 +284,9 @@ bool FcatSrvs::ActuatorCmdPrechecks(std::string name, std::string& message)
   return true;
 }
 
-bool FcatSrvs::PidCmdPrechecks(std::string name, std::string& message)
-{
+bool FcatSrvs::PidCmdPrechecks(std::string name, std::string& message) {
   // 1) Check fcat module state liveliness check
-  if ((this->now().seconds() - module_state_last_recv_time_) >
-      liveliness_duration_sec_) {
+  if ((this->now().seconds() - module_state_last_recv_time_) > liveliness_duration_sec_) {
     message = "stale fcat module state topic, fcat is not running";
     RCLCPP_WARN(this->get_logger(), "bad command: %s", message.c_str());
     return false;
@@ -337,10 +300,8 @@ bool FcatSrvs::PidCmdPrechecks(std::string name, std::string& message)
   }
 
   // 3) Check Pid States liveliness check
-  if ((this->now().seconds() - pid_states_last_recv_time_) >
-      liveliness_duration_sec_) {
-    message =
-      "stale fcat pid states topic, check fastcat YAML has any pid devices";
+  if ((this->now().seconds() - pid_states_last_recv_time_) > liveliness_duration_sec_) {
+    message = "stale fcat pid states topic, check fastcat YAML has any pid devices";
     RCLCPP_WARN(this->get_logger(), "bad command: %s", message.c_str());
     return false;
   }
@@ -354,16 +315,14 @@ bool FcatSrvs::PidCmdPrechecks(std::string name, std::string& message)
   return true;
 }
 
-bool FcatSrvs::CheckCommonFaultActive(std::string& error_message)
-{
+bool FcatSrvs::CheckCommonFaultActive(std::string& error_message) {
   if (!rclcpp::ok()) {
     error_message = "fcat_srvs node shutdown";
     RCLCPP_FATAL(this->get_logger(), "Failure: %s", error_message.c_str());
     return true;
   }
 
-  if ((this->now().seconds() - module_state_last_recv_time_) >
-      liveliness_duration_sec_) {
+  if ((this->now().seconds() - module_state_last_recv_time_) > liveliness_duration_sec_) {
     error_message = "stale fcat module state topic, fcat has stopped ";
     RCLCPP_WARN(this->get_logger(), "Failure: %s", error_message.c_str());
     return true;
@@ -378,9 +337,7 @@ bool FcatSrvs::CheckCommonFaultActive(std::string& error_message)
   return false;
 }
 
-bool FcatSrvs::RunActuatorMonitorLoop(std::string& error_message,
-                                          std::string act_name)
-{
+bool FcatSrvs::RunActuatorMonitorLoop(std::string& error_message, std::string act_name) {
   fastcat::ActuatorStateMachineState sms;
   srv_state_ = FCAT_SRV_STATE_IDLE_CHECKING;
 
@@ -400,7 +357,7 @@ bool FcatSrvs::RunActuatorMonitorLoop(std::string& error_message,
     }
 
     sms = static_cast<fastcat::ActuatorStateMachineState>(
-      act_state_map_[act_name].actuator_state_machine_state);
+        act_state_map_[act_name].actuator_state_machine_state);
 
     if (sms == fastcat::ACTUATOR_SMS_FAULTED) {
       error_message = std::string("Actuator unexpectedly faulted");
@@ -415,13 +372,12 @@ bool FcatSrvs::RunActuatorMonitorLoop(std::string& error_message,
         // may not change in response to a queued command sent to the fastcat
         // manager. This check responds "success" if no state machine change is
         // detected
-        if (sms == fastcat::ACTUATOR_SMS_HALTED ||
-            sms == fastcat::ACTUATOR_SMS_HOLDING) {
+        if (sms == fastcat::ACTUATOR_SMS_HALTED || sms == fastcat::ACTUATOR_SMS_HOLDING) {
           if (idle_rti_count >= idle_persist_rti) {
             RCLCPP_INFO(this->get_logger(),
-              "Max number of RTIs (%ld) elapsed with no Actuator SMS change, "
-              "interpreting this result as a success",
-              idle_persist_rti);
+                        "Max number of RTIs (%ld) elapsed with no Actuator SMS change, "
+                        "interpreting this result as a success",
+                        idle_persist_rti);
 
             return true;
           }
@@ -433,8 +389,7 @@ bool FcatSrvs::RunActuatorMonitorLoop(std::string& error_message,
         break;
 
       case FCAT_SRV_STATE_RUNNING:
-        if (sms == fastcat::ACTUATOR_SMS_HALTED ||
-            sms == fastcat::ACTUATOR_SMS_HOLDING) {
+        if (sms == fastcat::ACTUATOR_SMS_HALTED || sms == fastcat::ACTUATOR_SMS_HOLDING) {
           return true;
         }
         break;
@@ -448,11 +403,9 @@ bool FcatSrvs::RunActuatorMonitorLoop(std::string& error_message,
   return true;
 }
 
-bool FcatSrvs::WaitForSdoResponse(std::string& message, uint16_t app_id)
-{
+bool FcatSrvs::WaitForSdoResponse(std::string& message, uint16_t app_id) {
   char print_str[512];
-  double sdo_wait_duration_sec =
-    this->get_parameter("sdo_wait_duration_sec").as_double();
+  double sdo_wait_duration_sec = this->get_parameter("sdo_wait_duration_sec").as_double();
   double start_time = this->now().seconds();
   while (this->now().seconds() < (sdo_wait_duration_sec + start_time)) {
     // Check for FCAT fault
@@ -466,11 +419,10 @@ bool FcatSrvs::WaitForSdoResponse(std::string& message, uint16_t app_id)
 
       // Check the app id, discard and keep waiting if it does not match
       if (app_id != async_sdo_response_msg_.app_id) {
-        fprintf(
-          stderr,
-          "SDO Response received but actual app_id:(%u) does not match "
-          "expected app_id:(%u). Continuing to wait...",
-          async_sdo_response_msg_.app_id, app_id);
+        fprintf(stderr,
+                "SDO Response received but actual app_id:(%u) does not match "
+                "expected app_id:(%u). Continuing to wait...",
+                async_sdo_response_msg_.app_id, app_id);
         fprintf(stderr, "\n");
         continue;
       }
@@ -481,24 +433,18 @@ bool FcatSrvs::WaitForSdoResponse(std::string& message, uint16_t app_id)
         sprintf(print_str,
                 "SDO Response Failed {Name:(%s) Index:(0x%x)"
                 " Subindex:(%u) Data:(%s) DataType:(%s) AppId:(%u)}",
-                async_sdo_response_msg_.device_name.c_str(),
-                async_sdo_response_msg_.sdo_index,
-                async_sdo_response_msg_.sdo_subindex,
-                async_sdo_response_msg_.data.c_str(),
-                async_sdo_response_msg_.data_type.c_str(),
-                async_sdo_response_msg_.app_id);
+                async_sdo_response_msg_.device_name.c_str(), async_sdo_response_msg_.sdo_index,
+                async_sdo_response_msg_.sdo_subindex, async_sdo_response_msg_.data.c_str(),
+                async_sdo_response_msg_.data_type.c_str(), async_sdo_response_msg_.app_id);
         message = print_str;
         RCLCPP_WARN(this->get_logger(), "%s", print_str);
       } else {
         sprintf(print_str,
                 "SDO Response Success {Name:(%s) Index:(0x%x)"
                 " Subindex:(%u) Data:(%s) DataType:(%s) AppId:(%u)}",
-                async_sdo_response_msg_.device_name.c_str(),
-                async_sdo_response_msg_.sdo_index,
-                async_sdo_response_msg_.sdo_subindex,
-                async_sdo_response_msg_.data.c_str(),
-                async_sdo_response_msg_.data_type.c_str(),
-                async_sdo_response_msg_.app_id);
+                async_sdo_response_msg_.device_name.c_str(), async_sdo_response_msg_.sdo_index,
+                async_sdo_response_msg_.sdo_subindex, async_sdo_response_msg_.data.c_str(),
+                async_sdo_response_msg_.data_type.c_str(), async_sdo_response_msg_.app_id);
         message = print_str;
         RCLCPP_INFO(this->get_logger(), "%s", print_str);
       }
@@ -523,10 +469,8 @@ bool FcatSrvs::WaitForSdoResponse(std::string& message, uint16_t app_id)
 //
 
 void FcatSrvs::ActuatorProfPosSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::ActuatorProfPosService::Request>
-    request,
-  std::shared_ptr<fcat_msgs::srv::ActuatorProfPosService::Response> response)
-{
+    const std::shared_ptr<fcat_msgs::srv::ActuatorProfPosService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorProfPosService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling Actuator Prof Pos Command");
   response->success = false;
 
@@ -551,22 +495,18 @@ void FcatSrvs::ActuatorProfPosSrvCb(
   }
 
   RCLCPP_INFO(this->get_logger(), "actuator:%s Profile Position command from: %lf to goal: %lf",
-                  request->name.c_str(),
-                  act_state_map_[request->name].actual_position, goal_pos);
+              request->name.c_str(), act_state_map_[request->name].actual_position, goal_pos);
 
   response->success = RunActuatorMonitorLoop(response->message, request->name);
   if (response->success) {
-    RCLCPP_INFO(this->get_logger(), "Completed ACTUATOR_PROF_POS for: %s",
-                    request->name.c_str());
+    RCLCPP_INFO(this->get_logger(), "Completed ACTUATOR_PROF_POS for: %s", request->name.c_str());
     response->message = "";  // not strictly needed
   }
 }
 
 void FcatSrvs::ActuatorProfVelSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::ActuatorProfVelService::Request>
-    request,
-  std::shared_ptr<fcat_msgs::srv::ActuatorProfVelService::Response> response)
-{
+    const std::shared_ptr<fcat_msgs::srv::ActuatorProfVelService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorProfVelService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling Actuator Prof Vel Command");
   response->success = false;
 
@@ -577,10 +517,10 @@ void FcatSrvs::ActuatorProfVelSrvCb(
   double tol = this->get_parameter("tolerance").as_double();
   if (fabs(request->max_duration) < tol) {
     RCLCPP_WARN(this->get_logger(),
-      "Max Duration (%E) < tolerance (%E) indicating this runs forever. "
-      "In this case, use the topic (non-blocking) interface instead of the "
-      "service (blocking) interface",
-      request->max_duration, tol);
+                "Max Duration (%E) < tolerance (%E) indicating this runs forever. "
+                "In this case, use the topic (non-blocking) interface instead of the "
+                "service (blocking) interface",
+                request->max_duration, tol);
     return;
   }
 
@@ -594,22 +534,19 @@ void FcatSrvs::ActuatorProfVelSrvCb(
 
   act_prof_vel_pub_->publish(cmd_msg);
 
-  RCLCPP_INFO(this->get_logger(), "actuator:%s to goal velocity value: %lf",
-                  request->name.c_str(), request->target_velocity);
+  RCLCPP_INFO(this->get_logger(), "actuator:%s to goal velocity value: %lf", request->name.c_str(),
+              request->target_velocity);
 
   response->success = RunActuatorMonitorLoop(response->message, request->name);
   if (response->success) {
-    RCLCPP_INFO(this->get_logger(), "Completed ACTUATOR_PROF_VEL for: %s",
-                    request->name.c_str());
+    RCLCPP_INFO(this->get_logger(), "Completed ACTUATOR_PROF_VEL for: %s", request->name.c_str());
     response->message = "";
   }
 }
 
 void FcatSrvs::ActuatorProfTorqueSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueService::Request>
-    request,
-  std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueService::Response> response)
-{
+    const std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling Actuator Prof Torque Command");
   response->success = false;
 
@@ -618,7 +555,7 @@ void FcatSrvs::ActuatorProfTorqueSrvCb(
   }
 
   RCLCPP_DEBUG(this->get_logger(),
-    "actuator_prof_torque: issuing topic cmd and watching for completion");
+               "actuator_prof_torque: issuing topic cmd and watching for completion");
 
   // Publish topic to start the service
   auto cmd_msg = fcat_msgs::msg::ActuatorProfTorqueCmd();
@@ -630,21 +567,19 @@ void FcatSrvs::ActuatorProfTorqueSrvCb(
   act_prof_torque_pub_->publish(cmd_msg);
 
   RCLCPP_INFO(this->get_logger(), "fcat_srv actuator:%s to goal current value: %lf",
-                  request->name.c_str(), request->target_torque_amps);
+              request->name.c_str(), request->target_torque_amps);
 
   response->success = RunActuatorMonitorLoop(response->message, request->name);
   if (response->success) {
     RCLCPP_INFO(this->get_logger(), "Completed ACTUATOR_PROF_TORQUE for: %s",
-                    request->name.c_str());
+                request->name.c_str());
     response->message = "";
   }
 }
 
 void FcatSrvs::ActuatorCalibrateSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateService::Request>
-    request,
-  std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateService::Response> response)
-{
+    const std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling Actuator Calibrate Command");
   response->success = false;
 
@@ -664,20 +599,14 @@ void FcatSrvs::ActuatorCalibrateSrvCb(
 
   response->success = RunActuatorMonitorLoop(response->message, request->name);
   if (response->success) {
-    RCLCPP_INFO(this->get_logger(), "Completed ACTUATOR_CALIBRATE for: %s",
-                    request->name.c_str());
+    RCLCPP_INFO(this->get_logger(), "Completed ACTUATOR_CALIBRATE for: %s", request->name.c_str());
     response->message = "";
   }
 }
 
 void FcatSrvs::ActuatorSetGainSchedulingModeSrvCb(
-  const std::shared_ptr<
-    fcat_msgs::srv::ActuatorSetGainSchedulingModeService::Request>
-    request,
-  std::shared_ptr<
-    fcat_msgs::srv::ActuatorSetGainSchedulingModeService::Response>
-    response)
-{
+    const std::shared_ptr<fcat_msgs::srv::ActuatorSetGainSchedulingModeService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorSetGainSchedulingModeService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling Actuator Set Gain Scheduling Mode Command");
   response->success = false;
 
@@ -697,11 +626,8 @@ void FcatSrvs::ActuatorSetGainSchedulingModeSrvCb(
 }
 
 void FcatSrvs::ActuatorSetUnitModeSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::ActuatorSetUnitModeService::Request>
-    request,
-  std::shared_ptr<fcat_msgs::srv::ActuatorSetUnitModeService::Response>
-    response)
-{
+    const std::shared_ptr<fcat_msgs::srv::ActuatorSetUnitModeService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorSetUnitModeService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling Actuator Set Unit Mode Command");
   response->success = false;
 
@@ -721,9 +647,8 @@ void FcatSrvs::ActuatorSetUnitModeSrvCb(
 }
 
 void FcatSrvs::PidActivateSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::PidActivateService::Request> request,
-  std::shared_ptr<fcat_msgs::srv::PidActivateService::Response> response)
-{
+    const std::shared_ptr<fcat_msgs::srv::PidActivateService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::PidActivateService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling Pid Activate Command");
   response->success = false;
 
@@ -775,9 +700,8 @@ void FcatSrvs::PidActivateSrvCb(
 }
 
 void FcatSrvs::AsyncSdoWriteSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::AsyncSdoWriteService::Request> request,
-  std::shared_ptr<fcat_msgs::srv::AsyncSdoWriteService::Response> response)
-{
+    const std::shared_ptr<fcat_msgs::srv::AsyncSdoWriteService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::AsyncSdoWriteService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling SDO Write command");
   char print_str[512];
   response->message = "";
@@ -794,8 +718,7 @@ void FcatSrvs::AsyncSdoWriteSrvCb(
     return;
   }
 
-  if (JSD_SDO_DATA_UNSPECIFIED ==
-      jsd_sdo_data_type_from_string(request->data_type)) {
+  if (JSD_SDO_DATA_UNSPECIFIED == jsd_sdo_data_type_from_string(request->data_type)) {
     sprintf(print_str,
             "Invalid SDO Write data_type:(%s) Must be one of "
             "{'I8', 'I16', 'I32', 'I64', 'F32', 'U8', 'U16', 'U32', 'U64'}",
@@ -818,19 +741,18 @@ void FcatSrvs::AsyncSdoWriteSrvCb(
   async_sdo_write_pub_->publish(msg);
 
   RCLCPP_INFO(this->get_logger(),
-    "Async SDO Write issued {Name:(%s) Index:(0x%x)"
-    " Subindex:(%u) Data:(%s) DataType:(%s) AppId:(%u)}",
-    msg.name.c_str(), msg.sdo_index, msg.sdo_subindex, msg.data.c_str(),
-    msg.data_type.c_str(), msg.app_id);
+              "Async SDO Write issued {Name:(%s) Index:(0x%x)"
+              " Subindex:(%u) Data:(%s) DataType:(%s) AppId:(%u)}",
+              msg.name.c_str(), msg.sdo_index, msg.sdo_subindex, msg.data.c_str(),
+              msg.data_type.c_str(), msg.app_id);
 
   // 3) Wait for the SDO Response from FCAT
   response->success = WaitForSdoResponse(response->message, msg.app_id);
 }
 
 void FcatSrvs::AsyncSdoReadSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::AsyncSdoReadService::Request> request,
-  std::shared_ptr<fcat_msgs::srv::AsyncSdoReadService::Response> response)
-{
+    const std::shared_ptr<fcat_msgs::srv::AsyncSdoReadService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::AsyncSdoReadService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling SDO Read command");
   char print_str[512];
   response->message = "";
@@ -846,8 +768,7 @@ void FcatSrvs::AsyncSdoReadSrvCb(
     return;
   }
 
-  if (JSD_SDO_DATA_UNSPECIFIED ==
-      jsd_sdo_data_type_from_string(request->data_type)) {
+  if (JSD_SDO_DATA_UNSPECIFIED == jsd_sdo_data_type_from_string(request->data_type)) {
     sprintf(print_str,
             "Invalid SDO Read data_type:(%s) Must be one of "
             "{'I8', 'I16', 'I32', 'I64', 'F32', 'U8', 'U16', 'U32', 'U64'}",
@@ -870,19 +791,17 @@ void FcatSrvs::AsyncSdoReadSrvCb(
   async_sdo_read_pub_->publish(msg);
 
   RCLCPP_INFO(this->get_logger(),
-    "Async SDO Read issued {Name:(%s) Index:(0x%x)"
-    " Subindex:(%u) DataType:(%s) AppId:(%u)}",
-    msg.name.c_str(), msg.sdo_index, msg.sdo_subindex, msg.data_type.c_str(),
-    msg.app_id);
+              "Async SDO Read issued {Name:(%s) Index:(0x%x)"
+              " Subindex:(%u) DataType:(%s) AppId:(%u)}",
+              msg.name.c_str(), msg.sdo_index, msg.sdo_subindex, msg.data_type.c_str(), msg.app_id);
 
   // 3) Wait for the SDO Response from FCAT
   response->success = WaitForSdoResponse(response->message, msg.app_id);
 }
 
 void FcatSrvs::TlcWriteSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::TlcWriteService::Request> request,
-  std::shared_ptr<fcat_msgs::srv::TlcWriteService::Response> response)
-{
+    const std::shared_ptr<fcat_msgs::srv::TlcWriteService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::TlcWriteService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling Two-Letter Command (TLC) Write command");
   char print_str[512];
   response->message = "";
@@ -890,16 +809,14 @@ void FcatSrvs::TlcWriteSrvCb(
   // 1) Parse input args
   uint16_t parsed_sdo_index = 0;
   if (!TlcStrToNum(request->tlc, parsed_sdo_index)) {
-    sprintf(print_str, "Invalid TLC string:(%s) conversion to SDO",
-            request->tlc.c_str());
+    sprintf(print_str, "Invalid TLC string:(%s) conversion to SDO", request->tlc.c_str());
 
     response->message = print_str;
     RCLCPP_WARN(this->get_logger(), "%s", print_str);
     return;
   }
 
-  if (JSD_SDO_DATA_UNSPECIFIED ==
-      jsd_sdo_data_type_from_string(request->data_type)) {
+  if (JSD_SDO_DATA_UNSPECIFIED == jsd_sdo_data_type_from_string(request->data_type)) {
     sprintf(print_str,
             "Invalid SDO Write data_type:(%s) Must be one of "
             "{'I8', 'I16', 'I32', 'I64', 'F32', 'U8', 'U16', 'U32', 'U64'}",
@@ -923,19 +840,17 @@ void FcatSrvs::TlcWriteSrvCb(
   async_sdo_write_pub_->publish(msg);
 
   RCLCPP_INFO(this->get_logger(),
-    "Async SDO Write issued {Name:(%s) TLC:(%s) Index:(0x%x)"
-    " Subindex:(%u) Data:(%s) DataType:(%s) AppId:(%u)}",
-    msg.name.c_str(), request->tlc.c_str(), msg.sdo_index, msg.sdo_subindex,
-    msg.data.c_str(), msg.data_type.c_str(), msg.app_id);
+              "Async SDO Write issued {Name:(%s) TLC:(%s) Index:(0x%x)"
+              " Subindex:(%u) Data:(%s) DataType:(%s) AppId:(%u)}",
+              msg.name.c_str(), request->tlc.c_str(), msg.sdo_index, msg.sdo_subindex,
+              msg.data.c_str(), msg.data_type.c_str(), msg.app_id);
 
   // 3) Wait for the SDO Response from FCAT
   response->success = WaitForSdoResponse(response->message, msg.app_id);
 }
 
-void FcatSrvs::TlcReadSrvCb(
-  const std::shared_ptr<fcat_msgs::srv::TlcReadService::Request> request,
-  std::shared_ptr<fcat_msgs::srv::TlcReadService::Response> response)
-{
+void FcatSrvs::TlcReadSrvCb(const std::shared_ptr<fcat_msgs::srv::TlcReadService::Request> request,
+                            std::shared_ptr<fcat_msgs::srv::TlcReadService::Response> response) {
   RCLCPP_INFO(this->get_logger(), "Handling Two-Letter Command (TLC) Read command");
   char print_str[512];
   response->message = "";
@@ -943,16 +858,14 @@ void FcatSrvs::TlcReadSrvCb(
   // 1) Parse input args
   uint16_t parsed_sdo_index = 0;
   if (!TlcStrToNum(request->tlc, parsed_sdo_index)) {
-    sprintf(print_str, "Invalid TLC string:(%s) conversion to SDO",
-            request->tlc.c_str());
+    sprintf(print_str, "Invalid TLC string:(%s) conversion to SDO", request->tlc.c_str());
 
     response->message = print_str;
     RCLCPP_WARN(this->get_logger(), "%s", print_str);
     return;
   }
 
-  if (JSD_SDO_DATA_UNSPECIFIED ==
-      jsd_sdo_data_type_from_string(request->data_type)) {
+  if (JSD_SDO_DATA_UNSPECIFIED == jsd_sdo_data_type_from_string(request->data_type)) {
     sprintf(print_str,
             "Invalid SDO Read data_type:(%s) Must be one of "
             "{'I8', 'I16', 'I32', 'I64', 'F32', 'U8', 'U16', 'U32', 'U64'}",
@@ -975,10 +888,10 @@ void FcatSrvs::TlcReadSrvCb(
   async_sdo_read_pub_->publish(msg);
 
   RCLCPP_INFO(this->get_logger(),
-    "Async SDO Read issued {Name:(%s) TLC:(%s) Index:(0x%x)"
-    " Subindex:(%u) DataType:(%s) AppId:(%u)}",
-    msg.name.c_str(), request->tlc.c_str(), msg.sdo_index, msg.sdo_subindex,
-    msg.data_type.c_str(), msg.app_id);
+              "Async SDO Read issued {Name:(%s) TLC:(%s) Index:(0x%x)"
+              " Subindex:(%u) DataType:(%s) AppId:(%u)}",
+              msg.name.c_str(), request->tlc.c_str(), msg.sdo_index, msg.sdo_subindex,
+              msg.data_type.c_str(), msg.app_id);
 
   // 3) Wait for the SDO Response from FCAT
   response->success = WaitForSdoResponse(response->message, msg.app_id);

--- a/src/fcat_srvs.cpp
+++ b/src/fcat_srvs.cpp
@@ -10,6 +10,7 @@
 #include "casah_node/utils.hpp"
 
 #include <chrono>
+#include <cstdio>
 using namespace std::chrono_literals;
 using std::placeholders::_1;
 using std::placeholders::_2;
@@ -476,10 +477,12 @@ bool FcatSrvs::WaitForSdoResponse(std::string& message, uint16_t app_id)
 
       // Check the app id, discard and keep waiting if it does not match
       if (app_id != async_sdo_response_msg_.app_id) {
-        CFW_DEBUG(
+        fprintf(
+          stderr,
           "SDO Response received but actual app_id:(%u) does not match "
           "expected app_id:(%u). Continuing to wait...",
           async_sdo_response_msg_.app_id, app_id);
+        fprintf(stderr, "\n");
         continue;
       }
 

--- a/src/fcat_srvs.cpp
+++ b/src/fcat_srvs.cpp
@@ -1,554 +1,1173 @@
-#include "fcat/fcat_srvs.hpp"
-#include "jsd/jsd_print.h"
+#include "fcat/fcat_services.hpp"
 #include "fastcat/jsd/actuator.h"
+#include "fcat/fcat_utils.hpp"
+#include "jsd/jsd_print.h"
+
+#include "casah_node/utils.hpp"
 
 #include <chrono>
-
 using namespace std::chrono_literals;
 using std::placeholders::_1;
 using std::placeholders::_2;
 
-//FcatSrvs::~FcatSrvs(){ }
+FcatSrvs::FcatSrvs(const rclcpp::NodeOptions& options)
+    : casah_node::BaseInterface("fcat_services", "fcat", options),
+      casah_node::EvrInterface("fcat_services", "fcat", options),
+      services_qos_(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_services_default), rmw_qos_profile_services_default),
+      module_state_last_recv_time_(0),
+      act_states_last_recv_time_(0),
+      pid_states_last_recv_time_(0),
+      srv_state_(FCAT_SRV_STATE_IDLE_CHECKING)
+{
+  cb_group_blocking_ =
+    this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 
-FcatSrvs::FcatSrvs() : Node("fcat_srvs", "fcat") {
+  cb_group_non_blocking_ =
+    this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 
-  cb_group_blocking_     = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-  cb_group_non_blocking_ = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  // Init Parameters
+  pub_sub_ns_ =
+    DeclareInitParameterString("pub_sub_namespace", "/fcat/",
+                               "The namespace of the outgoing publisher and "
+                               "incoming subscription topics");
 
-  this->declare_parameter<double>("loop_rate_hz", 100);
-  this->get_parameter("loop_rate_hz", loop_rate_hz_);
+  sdo_app_id_ = static_cast<uint16_t>(
+    DeclareInitParameterInt("starting_sdo_app_id", 1000,
+                            "Starting value of the SDO tracking app_id. The "
+                            "value is incremented each request",
+                            0, 65535));
 
-  this->declare_parameter<double>("position_tolerance", 1.0e-2);
-  this->get_parameter("position_tolerance", position_tolerance_);
+  max_sdo_queue_size_ = static_cast<size_t>(DeclareInitParameterInt(
+    "max_sdo_queue_size", 32,
+    "Max size of the SDO Response queue. This queue is not checked unless an"
+    " SDO blocking service is active. This prevents the queue from allocating"
+    " too much memory when left running for a long time",
+    1, 10000));
 
-  this->declare_parameter<double>("velocity_tolerance", 1.0e-2);
-  this->get_parameter("velocity_tolerance", velocity_tolerance_);
+  // Rutime Parameters
+  DeclareRuntimeParameterInt(
+    "idle_persist_rti", 5,
+    "Number of RTI loops to wait to see if device state changes from idle to "
+    "moving."
+    "If this number of RTIs passes, then the command returns success, "
+    "assumed device "
+    "did not need to change in order or achieve the command.",
+    1, 1000);
 
-  this->declare_parameter<double>("current_tolerance", 1.0e-2);
-  this->get_parameter("current_tolerance", current_tolerance_);
+  DeclareRuntimeParameterDouble("tolerance", 1.0e-8,
+                                "Tolerance used to check if argument is near "
+                                "zero e.g. fabs(arg) < tolerance",
+                                0, 10);
 
+  DeclareRuntimeParameterDouble(
+    "sdo_wait_duration_sec", 2.0,
+    "Maximum time to wait for an Async SDO response. If this timer expires"
+    " the service will terminate with a failure",
+    0, 60);
 
   InitSubscribers();
   InitPublishers();
   InitServices();
 
-  module_state_last_recv_time_ = 0;
-  act_states_last_recv_time_ = 0;
-  pid_states_last_recv_time_ = 0;
-  MSG("Spinning...");
+  // Call this only after setting all initialization array params
+  PreventArrayParamSet();
+  InitializeTimerRate();
+
+  // No need to call CasahNode::StartTimer(). Relying on executor.spin(),
+  //   callbackgroups, and rclcpp::Rate instead
+  rate_ = std::make_unique<rclcpp::Rate>(this->GetTimerRate());
+
+  SetActive();
 }
 
 void FcatSrvs::InitSubscribers()
 {
-  auto sub_opts = rclcpp::SubscriptionOptionsWithAllocator<std::allocator<void>>();
+  auto sub_opts =
+    rclcpp::SubscriptionOptionsWithAllocator<std::allocator<void>>();
   sub_opts.callback_group = cb_group_non_blocking_;
 
-  fcat_module_state_sub_ = this->create_subscription<fcat_msgs::msg::ModuleState>(
-      "state/module_state",
-      FCAT_SRVS_QOS_SUBS, 
-      std::bind(&FcatSrvs::FcatModuleStateCb, this, _1),
-      sub_opts);
+  subscriptions_.push_back(
+    this->create_subscription<fcat_msgs::msg::ModuleState>(
+      pub_sub_ns_ + "state/module_state", subscription_qos_,
+      std::bind(&FcatSrvs::FcatModuleStateCb, this, _1), sub_opts));
 
-  act_states_sub_ = this->create_subscription<fcat_msgs::msg::ActuatorStates>(
-      "state/actuators", 
-      FCAT_SRVS_QOS_SUBS, 
-      std::bind(&FcatSrvs::ActuatorStatesCb, this, _1),
-      sub_opts);
+  subscriptions_.push_back(
+    this->create_subscription<fcat_msgs::msg::ActuatorStates>(
+      pub_sub_ns_ + "state/actuators", subscription_qos_,
+      std::bind(&FcatSrvs::ActuatorStatesCb, this, _1), sub_opts));
 
-  pid_states_sub_ = this->create_subscription<fcat_msgs::msg::PidStates>(
-      "state/pids", 
-      FCAT_SRVS_QOS_SUBS, 
-      std::bind(&FcatSrvs::PidStatesCb, this, _1),
-      sub_opts);
+  subscriptions_.push_back(this->create_subscription<fcat_msgs::msg::PidStates>(
+    pub_sub_ns_ + "state/pids", subscription_qos_,
+    std::bind(&FcatSrvs::PidStatesCb, this, _1), sub_opts));
+
+  subscriptions_.push_back(
+    this->create_subscription<fcat_msgs::msg::AsyncSdoResponse>(
+      pub_sub_ns_ + "state/async_sdo_response", subscription_qos_,
+      std::bind(&FcatSrvs::AsyncSdoResponseCb, this, _1), sub_opts));
 }
 
 void FcatSrvs::InitPublishers()
 {
-  act_prof_pos_pub_ = this->create_publisher<fcat_msgs::msg::ActuatorProfPosCmd>(
-      "cmd/actuator_prof_pos", FCAT_SRVS_PUB_QUEUE_SIZE);
+  act_prof_pos_pub_ =
+    this->create_publisher<fcat_msgs::msg::ActuatorProfPosCmd>(
+      pub_sub_ns_ + "impl/actuator_prof_pos", publisher_queue_size_);
 
-  act_prof_vel_pub_ = this->create_publisher<fcat_msgs::msg::ActuatorProfVelCmd>(
-      "cmd/actuator_prof_vel", FCAT_SRVS_PUB_QUEUE_SIZE);
+  act_prof_vel_pub_ =
+    this->create_publisher<fcat_msgs::msg::ActuatorProfVelCmd>(
+      pub_sub_ns_ + "impl/actuator_prof_vel", publisher_queue_size_);
 
-  act_prof_torque_pub_ = this->create_publisher<fcat_msgs::msg::ActuatorProfTorqueCmd>(
-      "cmd/actuator_prof_torque", FCAT_SRVS_PUB_QUEUE_SIZE);
+  act_prof_torque_pub_ =
+    this->create_publisher<fcat_msgs::msg::ActuatorProfTorqueCmd>(
+      pub_sub_ns_ + "impl/actuator_prof_torque", publisher_queue_size_);
 
-  act_calibrate_pub_ = this->create_publisher<fcat_msgs::msg::ActuatorCalibrateCmd>(
-      "cmd/actuator_calibrate", FCAT_SRVS_PUB_QUEUE_SIZE);
+  act_digital_output_pub_ =
+    this->create_publisher<fcat_msgs::msg::ActuatorSetDigitalOutputCmd>(
+      pub_sub_ns_ + "impl/actuator_set_digital_output", publisher_queue_size_);
+
+  act_calibrate_pub_ =
+    this->create_publisher<fcat_msgs::msg::ActuatorCalibrateCmd>(
+      pub_sub_ns_ + "impl/actuator_calibrate", publisher_queue_size_);
 
   pid_activate_pub_ = this->create_publisher<fcat_msgs::msg::PidActivateCmd>(
-      "cmd/pid_activate", FCAT_SRVS_PUB_QUEUE_SIZE);
+    pub_sub_ns_ + "impl/pid_activate", publisher_queue_size_);
+
+  async_sdo_write_pub_ =
+    this->create_publisher<fcat_msgs::msg::AsyncSdoWriteCmd>(
+      pub_sub_ns_ + "impl/async_sdo_write", publisher_queue_size_);
+
+  async_sdo_read_pub_ = this->create_publisher<fcat_msgs::msg::AsyncSdoReadCmd>(
+    pub_sub_ns_ + "impl/async_sdo_read", publisher_queue_size_);
 }
 
 void FcatSrvs::InitServices()
 {
-  act_prof_pos_srv_=
-    this->create_service<fcat_msgs::srv::ActuatorProfPosCmd>(
-        "service/actuator_prof_pos", 
-        std::bind(&FcatSrvs::ActuatorProfPosSrvCb, this, _1, _2),
-        FCAT_SRVS_QOS_SRVS,
-        cb_group_blocking_);
+  DeclareServiceCommand<fcat_msgs::srv::ActuatorProfPosService>(
+    this, pub_sub_ns_ + "srv/actuator_prof_pos",
+    &FcatSrvs::ActuatorProfPosSrvCb, services_qos_, cb_group_blocking_,
+    CommandDescriptor(
+      "Command a Profiled Position motion profile to the Actuator",
+      {CommandArgumentDescriptor(
+         /*arg name*/ "name",
+         /*description*/ "The Fastcat Device Name"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "target_position",
+         /*description*/ "Goal Position target of the motion profile",
+         /*Units*/ "EU"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "profile_velocity",
+         /*description*/ "The desired cruise rate of the motion profile",
+         /*Units*/ "EU / sec"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "profile_accel",
+         /*description*/ "The desired acceleration of the motion profile",
+         /*Units*/ "EU/sec^2"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "relative",
+         /*description*/ "If true, the target_position will computed "
+                         "relative "
+                         "to actual position")}));
 
-  act_prof_vel_srv_=
-    this->create_service<fcat_msgs::srv::ActuatorProfVelCmd>(
-        "service/actuator_prof_vel", 
-        std::bind(&FcatSrvs::ActuatorProfVelSrvCb, this, _1, _2),
-        FCAT_SRVS_QOS_SRVS,
-        cb_group_blocking_);
+  DeclareServiceCommand<fcat_msgs::srv::ActuatorProfVelService>(
+    this, pub_sub_ns_ + "srv/actuator_prof_vel",
+    &FcatSrvs::ActuatorProfVelSrvCb, services_qos_, cb_group_blocking_,
+    CommandDescriptor(
+      "Command a Profiled Velocity motion profile to the Actuator",
+      {CommandArgumentDescriptor(
+         /*arg name*/ "name",
+         /*description*/ "The Fastcat Device Name"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "target_velocity",
+         /*description*/ "The desired cruise rate of the motion profile",
+         /*Units*/ "EU/sec"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "profile_accel",
+         /*description*/ "The desired acceleration of the motion profile",
+         /*Units*/ "EU/sec^2"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "max_duration",
+         /*description*/
+         "The duration of the command, negative values result "
+         "in indefinite profiles",
+         /*Units*/ "sec")}));
 
-  act_prof_torque_srv_=
-    this->create_service<fcat_msgs::srv::ActuatorProfTorqueCmd>(
-        "service/actuator_prof_torque", 
-        std::bind(&FcatSrvs::ActuatorProfTorqueSrvCb, this, _1, _2),
-        FCAT_SRVS_QOS_SRVS,
-        cb_group_blocking_);
+  DeclareServiceCommand<fcat_msgs::srv::ActuatorProfTorqueService>(
+    this, pub_sub_ns_ + "srv/actuator_prof_torque",
+    &FcatSrvs::ActuatorProfTorqueSrvCb, services_qos_, cb_group_blocking_,
+    CommandDescriptor(
+      "Command a Profiled Torque motion profile to the Actuator. Here, "
+      "Torque"
+      "is equivalent to Current (frome the DS-402 specification)",
+      {CommandArgumentDescriptor(
+         /*arg name*/ "name",
+         /*description*/ "The Fastcat Device Name"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "target_torque_amps",
+         /*description*/ "The desired effort in current",
+         /*Units*/ "Amps"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "max_duration",
+         /*description*/
+         "The duration of the command, "
+         "negative values result in indefinite profiles",
+         /*Units*/ "sec")}));
 
-  act_calibrate_srv_=
-    this->create_service<fcat_msgs::srv::ActuatorCalibrateCmd>(
-        "service/actuator_calibrate", 
-        std::bind(&FcatSrvs::ActuatorCalibrateSrvCb, this, _1, _2),
-        FCAT_SRVS_QOS_SRVS,
-        cb_group_blocking_);
+  DeclareServiceCommand<fcat_msgs::srv::ActuatorCalibrateService>(
+    this, pub_sub_ns_ + "srv/actuator_calibrate",
+    &FcatSrvs::ActuatorCalibrateSrvCb, services_qos_, cb_group_blocking_,
+    CommandDescriptor(
+      "Command hardstop calibration to the Actuator. The actuator will "
+      "move in "
+      "the signed velocity direction with the specified lowered current "
+      "limit "
+      "to detect the hardstop. From there, the position is set to the "
+      "calibration "
+      "limit defined in the configuration file. Finally, the original "
+      "current is "
+      "restored and the actuator is commanded to the command limit defined "
+      "in the "
+      "configuration file.",
+      {CommandArgumentDescriptor(
+         /*arg name*/ "name",
+         /*description*/ "The Fastcat Device Name"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "velocity",
+         /*description*/
+         "The desired approach velocity for all motions during "
+         "hardstop calibration",
+         /*Units*/ "EU/sec"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "accel",
+         /*description*/ "The desired acceleration of the motion profile",
+         /*Units*/ "EU/sec^2"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "max_current",
+         /*description*/
+         "Overrides the Peak current setting but only during "
+         "hardstop contact motion",
+         /*Units*/ "Amps")}));
 
-  pid_activate_srv_=
-    this->create_service<fcat_msgs::srv::PidActivateCmd>(
-        "service/pid_activate", 
-        std::bind(&FcatSrvs::PidActivateSrvCb, this, _1, _2),
-        FCAT_SRVS_QOS_SRVS,
-        cb_group_blocking_);
+  DeclareServiceCommand<fcat_msgs::srv::ActuatorSetGainSchedulingModeService>(
+    this, pub_sub_ns_ + "srv/actuator_set_gain_scheduling_mode",
+    &FcatSrvs::ActuatorSetGainSchedulingModeSrvCb, services_qos_,
+    cb_group_blocking_,
+    CommandDescriptor(
+      "Set the Gain Schedule Mode for the actuator GS[2]. "
+      "0 - No Gain Scheduling. "
+      "[1,63] - Specific controller from table. "
+      "64 - Enable Speed-based scheduling. "
+      "65 - Enable position-based scheduling. "
+      "66 - Best Settling. "
+      "67 - manually scheduled, high-bits. "
+      "68 - manually scheduled, low-bits."
+      "Use this interface only if you know what you are doing, Caveat "
+      "Emptor!",
+      {CommandArgumentDescriptor(
+         /*arg name*/ "name",
+         /*description*/ "The Fastcat Device Name"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "gain_scheduling_mode",
+         /*description*/ "The desired gain schedule mode value")}));
+
+  DeclareServiceCommand<fcat_msgs::srv::ActuatorSetUnitModeService>(
+    this, pub_sub_ns_ + "srv/actuator_set_unit_mode",
+    &FcatSrvs::ActuatorSetUnitModeSrvCb, services_qos_, cb_group_blocking_,
+    CommandDescriptor("Sets the Unit Mode UM[1]. "
+                      "1 - Torque Control. "
+                      "2 - Speed Control. "
+                      "3 - Stepper Control. "
+                      "5 - Position Control (default). "
+                      "6 - Stepper Open or Closed Loop.",
+                      {CommandArgumentDescriptor(
+                         /*arg name*/ "name",
+                         /*description*/ "The Fastcat Device Name"),
+                       CommandArgumentDescriptor(
+                         /*arg name*/ "gain_scheduling_mode",
+                         /*description*/ "The desired Unit Mode UM[1]. ")}));
+
+  DeclareServiceCommand<fcat_msgs::srv::PidActivateService>(
+    this, pub_sub_ns_ + "srv/pid_activate", &FcatSrvs::PidActivateSrvCb,
+    services_qos_, cb_group_blocking_,
+    CommandDescriptor(
+      "Start the PID Controller with specified parameters.  "
+      "Returns failure if it does not converge in the specified duration. "
+      "Returns success and self-disables if the controller converges.",
+      {CommandArgumentDescriptor(
+         /*arg name*/ "name",
+         /*description*/ "The Fastcat Device Name"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "setpoint",
+         /*description*/ "The controller setpoint",
+         /*Units*/ "EU"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "deadband",
+         /*description*/
+         "The controller deadband tolerance around the setpoint",
+         /*Units*/ "EU"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "persistence_duration",
+         /*description*/
+         "The amount of time the signal must remain with the "
+         "deadband to end control",
+         /*Units*/ "sec"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "max_duration",
+         /*description*/
+         "The maximum duration of the command. Beware: "
+         "negative values can result in indefinite runtime",
+         /*Units*/ "sec")}));
+
+  DeclareServiceCommand<fcat_msgs::srv::AsyncSdoWriteService>(
+    this, pub_sub_ns_ + "srv/async_sdo_write",
+    &FcatSrvs::AsyncSdoWriteSrvCb, services_qos_, cb_group_blocking_,
+    CommandDescriptor(
+      "Issues an Asynchronous SDO parameter Write and waits for the "
+      "result of the operation to indicate success or failure.",
+      {CommandArgumentDescriptor(
+         /*arg name*/ "name",
+         /*description*/ "The Fastcat Device Name"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "sdo_index",
+         /*description*/ "The SDO register index in hexidecimal (0x3034) "
+                         "or "
+                         "decimal (12340) form"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "sdo_subindex",
+         /*description*/ "The SDO register subindex (e.g. the 1 in "
+                         "0x3034:1)"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "data",
+         /*description*/ "Data payload to write to the SDO"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "data_type",
+         /*description*/ "The type of the data payload, must be one of: "
+                         "{I8, I16, I32, I64, F32, U8, U16, U32, "
+                         "U64}")}));
+
+  DeclareServiceCommand<fcat_msgs::srv::AsyncSdoReadService>(
+    this, pub_sub_ns_ + "srv/async_sdo_read", &FcatSrvs::AsyncSdoReadSrvCb,
+    services_qos_, cb_group_blocking_,
+    CommandDescriptor(
+      "Issues an Asynchronous SDO parameter Read and waits for the "
+      "result of the operation to indicate success or failure.",
+      {CommandArgumentDescriptor(
+         /*arg name*/ "name",
+         /*description*/ "The Fastcat Device Name"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "sdo_index",
+         /*description*/ "The SDO register index in hexidecimal (0x3034) "
+                         "or "
+                         "decimal (12340) form"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "sdo_subindex",
+         /*description*/ "The SDO register subindex (the 1 in 0x3034:1)"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "data_type",
+         /*description*/ "The type of the data payload, must be one of: "
+                         "{I8, I16, I32, I64, F32, U8, U16, U32, "
+                         "U64}")}));
+
+  DeclareServiceCommand<fcat_msgs::srv::TlcWriteService>(
+    this, pub_sub_ns_ + "srv/tlc_write", &FcatSrvs::TlcWriteSrvCb,
+    services_qos_, cb_group_blocking_,
+    CommandDescriptor(
+      "Issues a ELMO Two-Letter Command (TLC) which in turn issues an "
+      "Asynchronous SDO "
+      "parameter Write and waits for the result to indicate success or "
+      "failure. Consult "
+      "The MAN-G-CR document for full listing of drive data objects.",
+      {CommandArgumentDescriptor(
+         /*arg name*/ "name",
+         /*description*/ "The Fastcat Device Name"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "tlc",
+         /*description*/ "The Two-Letter Command (TLC) found in the ELMO "
+                         "MAN-G-CR Command Reference Document. These two "
+                         "chars "
+                         "are converted to an SDO index. (e.g. PL, CL)"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "subindex",
+         /*description*/ "The TLC/SDO register subindex (the 1 in "
+                         "PL[1])"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "data",
+         /*description*/ "Data payload to write to the drive"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "data_type",
+         /*description*/ "The type of the data payload, must be one of: "
+                         "{I8, I16, I32, I64, F32, U8, U16, U32, "
+                         "U64}")}));
+
+  DeclareServiceCommand<fcat_msgs::srv::TlcReadService>(
+    this, pub_sub_ns_ + "srv/tlc_read", &FcatSrvs::TlcReadSrvCb,
+    services_qos_, cb_group_blocking_,
+    CommandDescriptor(
+      "Issues a ELMO Two-Letter Command (TLC) which in turn issues an "
+      "Asynchronous SDO "
+      "parameter Read and waits for the result to indicate success or "
+      "failure. Consult "
+      "The MAN-G-CR document for full listing of drive data objects.",
+      {CommandArgumentDescriptor(
+         /*arg name*/ "name",
+         /*description*/ "The Fastcat Device Name"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "tlc",
+         /*description*/ "The Two-Letter Command (TLC) found in the ELMO "
+                         "MAN-G-CR Command Reference Document. These two "
+                         "chars "
+                         "are converted to an SDO index. (e.g. PL, CL)"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "subindex",
+         /*description*/ "The TLC/SDO register subindex (the 1 in "
+                         "PL[1])"),
+       CommandArgumentDescriptor(
+         /*arg name*/ "data_type",
+         /*description*/ "The type of the data payload, must be one of: "
+                         "{I8, I16, I32, I64, F32, U8, U16, U32, "
+                         "U64}")}));
 }
 
-bool FcatSrvs::ActuatorCmdPrechecks(std::string name, std::string &message)
-{
-  //1) Check fcat module state liveliness check
-  if((get_time_sec() - module_state_last_recv_time_) > FCAT_SRVS_LIVELINESS_DURATION){ 
-    message = "stale fcat module state topic, fcat is not running";
-    WARNING("bad command: %s", message.c_str());
-    return false;
-  }
-
-  //2) Check fcat module is not faulted
-  if(fcat_module_state_msg_.faulted){
-    message = "fcat is faulted, reset fcat first";
-    WARNING("bad command: %s", message.c_str());
-    return false;
-  }
-
-  //3) Check Actuator States liveliness check
-  if((get_time_sec() - act_states_last_recv_time_) > FCAT_SRVS_LIVELINESS_DURATION){ 
-    message = "stale fcat actuator states topic, check fastcat YAML has any actuators";
-    WARNING("bad command: %s", message.c_str());
-    return false;
-  }
-
-  //4) Check Actuator name is on the bus
-  if(act_state_map_.find(name) == act_state_map_.end()){
-    message = "actuator name not found, check device name";
-    WARNING("bad command: %s", message.c_str());
-    return false;
-  }
-  return true;
-}
-
-bool FcatSrvs::PidCmdPrechecks(std::string name, std::string &message){
-  //1) Check fcat module state liveliness check
-  if((get_time_sec() - module_state_last_recv_time_) > FCAT_SRVS_LIVELINESS_DURATION){ 
-    message = "stale fcat module state topic, fcat is not running";
-    WARNING("bad command: %s", message.c_str());
-    return false;
-  }
-
-  //2) Check fcat module is not faulted
-  if(fcat_module_state_msg_.faulted){
-    message = "fcat is faulted, reset fcat first";
-    WARNING("bad command: %s", message.c_str());
-    return false;
-  }
-
-  //3) Check Pid States liveliness check
-  if((get_time_sec() - pid_states_last_recv_time_) > FCAT_SRVS_LIVELINESS_DURATION){ 
-    message = "stale fcat pid states topic, check fastcat YAML has any pid devices";
-    WARNING("bad command: %s", message.c_str());
-    return false;
-  }
-
-  //4) Check Pid name is on the bus
-  if(pid_state_map_.find(name) == pid_state_map_.end()){
-    message = "pid name not found, check device name";
-    WARNING("bad command: %s", message.c_str());
-    return false;
-  }
-  return true;
-}
+//
+// Fcat State Subscription Callbacks
+//
 
 void FcatSrvs::FcatModuleStateCb(
-    const std::shared_ptr<fcat_msgs::msg::ModuleState> msg)
+  const std::shared_ptr<fcat_msgs::msg::ModuleState> msg)
 {
-  module_state_last_recv_time_ = get_time_sec();
+  module_state_last_recv_time_ = this->now().seconds();
   fcat_module_state_msg_ = *msg;
 }
 
 void FcatSrvs::ActuatorStatesCb(
-    const std::shared_ptr<fcat_msgs::msg::ActuatorStates> msg)
+  const std::shared_ptr<fcat_msgs::msg::ActuatorStates> msg)
 {
-  act_states_last_recv_time_ = get_time_sec();
+  act_states_last_recv_time_ = this->now().seconds();
   actuator_states_msg_ = *msg;
 
-  for(size_t i = 0; i < actuator_states_msg_.names.size(); ++i){
-    act_state_map_[actuator_states_msg_.names[i]] = actuator_states_msg_.states[i];
+  for (size_t i = 0; i < actuator_states_msg_.names.size(); ++i) {
+    act_state_map_[actuator_states_msg_.names[i]] =
+      actuator_states_msg_.states[i];
   }
 }
 
 void FcatSrvs::PidStatesCb(
-    const std::shared_ptr<fcat_msgs::msg::PidStates> msg)
+  const std::shared_ptr<fcat_msgs::msg::PidStates> msg)
 {
-  pid_states_last_recv_time_ = get_time_sec();
+  pid_states_last_recv_time_ = this->now().seconds();
   pid_states_msg_ = *msg;
 
-  for(size_t i = 0; i < pid_states_msg_.names.size(); ++i){
+  for (size_t i = 0; i < pid_states_msg_.names.size(); ++i) {
     pid_state_map_[pid_states_msg_.names[i]] = pid_states_msg_.states[i];
   }
 }
 
-void FcatSrvs::ActuatorProfPosSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::ActuatorProfPosCmd::Request> request,
-    std::shared_ptr<fcat_msgs::srv::ActuatorProfPosCmd::Response>      response)
+void FcatSrvs::AsyncSdoResponseCb(
+  const std::shared_ptr<fcat_msgs::msg::AsyncSdoResponse> msg)
 {
-  MSG("fcat_srv recived new actuator_prof_pos command");
+  // prevent the queue from filling up too much
+  if (sdo_response_queue_.size() >= max_sdo_queue_size_) {
+    sdo_response_queue_.pop();
+  }
+  sdo_response_queue_.push((*msg));
+}
+
+//
+// Helper Functions
+//
+bool FcatSrvs::ActuatorCmdPrechecks(std::string name, std::string& message)
+{
+  // 1) Check fcat module state liveliness check
+  if ((this->now().seconds() - module_state_last_recv_time_) >
+      liveliness_duration_sec_) {
+    message = "stale fcat module state topic, fcat is not running";
+    EVR_WARNING_LO("bad command: %s", message.c_str());
+    return false;
+  }
+
+  // 2) Check fcat module is not faulted
+  if (fcat_module_state_msg_.faulted) {
+    message = "fcat is faulted, reset fcat first";
+    EVR_WARNING_LO("bad command: %s", message.c_str());
+    return false;
+  }
+
+  // 3) Check Actuator States liveliness check
+  if ((this->now().seconds() - act_states_last_recv_time_) >
+      liveliness_duration_sec_) {
+    message =
+      "stale fcat actuator states topic, check fastcat YAML has any "
+      "actuators";
+    EVR_WARNING_LO("bad command: %s", message.c_str());
+    return false;
+  }
+
+  // 4) Check Actuator name is on the bus
+  if (act_state_map_.find(name) == act_state_map_.end()) {
+    message = "actuator name not found, check device name";
+    EVR_WARNING_LO("bad command: %s", message.c_str());
+    return false;
+  }
+  return true;
+}
+
+bool FcatSrvs::PidCmdPrechecks(std::string name, std::string& message)
+{
+  // 1) Check fcat module state liveliness check
+  if ((this->now().seconds() - module_state_last_recv_time_) >
+      liveliness_duration_sec_) {
+    message = "stale fcat module state topic, fcat is not running";
+    EVR_WARNING_LO("bad command: %s", message.c_str());
+    return false;
+  }
+
+  // 2) Check fcat module is not faulted
+  if (fcat_module_state_msg_.faulted) {
+    message = "fcat is faulted, reset fcat first";
+    EVR_WARNING_LO("bad command: %s", message.c_str());
+    return false;
+  }
+
+  // 3) Check Pid States liveliness check
+  if ((this->now().seconds() - pid_states_last_recv_time_) >
+      liveliness_duration_sec_) {
+    message =
+      "stale fcat pid states topic, check fastcat YAML has any pid devices";
+    EVR_WARNING_LO("bad command: %s", message.c_str());
+    return false;
+  }
+
+  // 4) Check Pid name is on the bus
+  if (pid_state_map_.find(name) == pid_state_map_.end()) {
+    message = "pid name not found, check device name";
+    EVR_WARNING_LO("bad command: %s", message.c_str());
+    return false;
+  }
+  return true;
+}
+
+bool FcatSrvs::CheckCommonFaultActive(std::string& error_message)
+{
+  if (!rclcpp::ok()) {
+    error_message = "fcat_srvs node shutdown";
+    EVR_FATAL("Failure: %s", error_message.c_str());
+    return true;
+  }
+
+  if ((this->now().seconds() - module_state_last_recv_time_) >
+      liveliness_duration_sec_) {
+    error_message = "stale fcat module state topic, fcat has stopped ";
+    EVR_WARNING_HI("Failure: %s", error_message.c_str());
+    return true;
+  }
+
+  if (fcat_module_state_msg_.faulted) {
+    error_message = "fcat is encountered a fault";
+    EVR_WARNING_LO("%s", error_message.c_str());
+    return false;
+  }
+
+  return false;
+}
+
+bool FcatSrvs::RunActuatorMonitorLoop(std::string& error_message,
+                                          std::string act_name)
+{
+  fastcat::ActuatorStateMachineState sms;
+  srv_state_ = FCAT_SRV_STATE_IDLE_CHECKING;
+
+  int64_t idle_persist_rti = this->get_parameter("idle_persist_rti").as_int();
+  int64_t idle_rti_count = 0;
+
+  // Continuously check for
+  //  - fcat_srvs shutdown request
+  //  - fcat faults
+  //  - actuator state machine progress
+
+  while (true) {
+    rate_->sleep();
+
+    if (CheckCommonFaultActive(error_message)) {
+      return false;
+    }
+
+    sms = static_cast<fastcat::ActuatorStateMachineState>(
+      act_state_map_[act_name].actuator_state_machine_state);
+
+    if (sms == fastcat::ACTUATOR_SMS_FAULTED) {
+      error_message = std::string("Actuator unexpectedly faulted");
+      EVR_WARNING_LO("Failure: %s", error_message.c_str());
+      return false;
+    }
+
+    switch (srv_state_) {
+      case FCAT_SRV_STATE_IDLE_CHECKING:
+
+        // In the event that the command is trivial, the actuator state machine
+        // may not change in response to a queued command sent to the fastcat
+        // manager. This check responds "success" if no state machine change is
+        // detected
+        if (sms == fastcat::ACTUATOR_SMS_HALTED ||
+            sms == fastcat::ACTUATOR_SMS_HOLDING) {
+          if (idle_rti_count >= idle_persist_rti) {
+            EVR_ACTIVITY_LO(
+              "Max number of RTIs (%ld) elapsed with no Actuator SMS change, "
+              "interpreting this result as a success",
+              idle_persist_rti);
+
+            return true;
+          }
+          idle_rti_count++;
+        } else {
+          // must be in motion by now (faulted would be caught above)
+          srv_state_ = FCAT_SRV_STATE_RUNNING;
+        }
+        break;
+
+      case FCAT_SRV_STATE_RUNNING:
+        if (sms == fastcat::ACTUATOR_SMS_HALTED ||
+            sms == fastcat::ACTUATOR_SMS_HOLDING) {
+          return true;
+        }
+        break;
+
+      default:
+        EVR_WARNING_HI("bad srv state, aborting command");
+        return false;
+    }
+  }
+
+  return true;
+}
+
+bool FcatSrvs::WaitForSdoResponse(std::string& message, uint16_t app_id)
+{
+  char print_str[512];
+  double sdo_wait_duration_sec =
+    this->get_parameter("sdo_wait_duration_sec").as_double();
+  double start_time = this->now().seconds();
+  while (this->now().seconds() < (sdo_wait_duration_sec + start_time)) {
+    // Check for FCAT fault
+    if (CheckCommonFaultActive(message)) {
+      return false;
+    }
+
+    if (!sdo_response_queue_.empty()) {
+      async_sdo_response_msg_ = sdo_response_queue_.front();
+      sdo_response_queue_.pop();
+
+      // Check the app id, discard and keep waiting if it does not match
+      if (app_id != async_sdo_response_msg_.app_id) {
+        CFW_DEBUG(
+          "SDO Response received but actual app_id:(%u) does not match "
+          "expected app_id:(%u). Continuing to wait...",
+          async_sdo_response_msg_.app_id, app_id);
+        continue;
+      }
+
+      bool success = async_sdo_response_msg_.success;
+
+      if (!success) {
+        sprintf(print_str,
+                "SDO Response Failed {Name:(%s) Index:(0x%x)"
+                " Subindex:(%u) Data:(%s) DataType:(%s) AppId:(%u)}",
+                async_sdo_response_msg_.device_name.c_str(),
+                async_sdo_response_msg_.sdo_index,
+                async_sdo_response_msg_.sdo_subindex,
+                async_sdo_response_msg_.data.c_str(),
+                async_sdo_response_msg_.data_type.c_str(),
+                async_sdo_response_msg_.app_id);
+        message = print_str;
+        EVR_WARNING_LO("%s", print_str);
+      } else {
+        sprintf(print_str,
+                "SDO Response Success {Name:(%s) Index:(0x%x)"
+                " Subindex:(%u) Data:(%s) DataType:(%s) AppId:(%u)}",
+                async_sdo_response_msg_.device_name.c_str(),
+                async_sdo_response_msg_.sdo_index,
+                async_sdo_response_msg_.sdo_subindex,
+                async_sdo_response_msg_.data.c_str(),
+                async_sdo_response_msg_.data_type.c_str(),
+                async_sdo_response_msg_.app_id);
+        message = print_str;
+        EVR_ACTIVITY_HI("%s", print_str);
+      }
+      return success;
+    }
+
+    rate_->sleep();
+  }
+
+  // if here, runout timer has expired
+  sprintf(print_str,
+          "SDO Runout timer expired for app_id:(%u). "
+          "Parameter 'sdo_wait_duration_sec' is set to (%lf)",
+          app_id, sdo_wait_duration_sec);
+  message = print_str;
+  EVR_WARNING_LO("%s", print_str);
+  return false;
+}
+
+//
+// Service Callbacks
+//
+
+void FcatSrvs::ActuatorProfPosSrvCb(
+  const std::shared_ptr<fcat_msgs::srv::ActuatorProfPosService::Request>
+    request,
+  std::shared_ptr<fcat_msgs::srv::ActuatorProfPosService::Response> response)
+{
+  EVR_ACTIVITY_LO("Handling Actuator Prof Pos Command");
   response->success = false;
 
-  if(!ActuatorCmdPrechecks(request->name, response->message)){
+  if (!ActuatorCmdPrechecks(request->name, response->message)) {
     return;
   }
 
-  MSG("actuator_prof_pos: issuing topic cmd and watching for completion");
-
-  //Publish topic to start the service
+  // Publish topic to start the service
   auto cmd_msg = fcat_msgs::msg::ActuatorProfPosCmd();
 
-  cmd_msg.name             = request->name;
-  cmd_msg.target_position  = request->target_position;
+  cmd_msg.name = request->name;
+  cmd_msg.target_position = request->target_position;
   cmd_msg.profile_velocity = request->profile_velocity;
-  cmd_msg.profile_accel    = request->profile_accel;
-  cmd_msg.relative         = request->relative;
+  cmd_msg.profile_accel = request->profile_accel;
+  cmd_msg.relative = request->relative;
 
   act_prof_pos_pub_->publish(cmd_msg);
 
-
-  // Continuously check for 
-  //  - fcat_srvs shutdown request
-  //  - fcat faults
-  //  - actuator state machine progress
-
-  fastcat::ActuatorStateMachineState sms;
-
-  double pos;
-  rclcpp::Rate timer(loop_rate_hz_); //Hz
-
-  while(true){
-    if(!rclcpp::ok()){
-      response->message = "fcat_srvs node shutdown";
-      ERROR("Failure: %s", response->message.c_str());
-      return;
-    }
-
-    if((get_time_sec() - module_state_last_recv_time_) > FCAT_SRVS_LIVELINESS_DURATION){ 
-      response->message = "stale fcat module state topic, fcat has stopped ";
-      ERROR("Failure: %s", response->message.c_str());
-      return;
-    }
-
-    sms = static_cast<fastcat::ActuatorStateMachineState>(
-        act_state_map_[request->name].actuator_state_machine_state);
-    pos = act_state_map_[request->name].actual_position;
-
-    if(sms == fastcat::ACTUATOR_SMS_FAULTED){
-      response->message = std::string("Actuator unexpectedly faulted");
-      ERROR("Failure: %s", response->message.c_str());
-      return;
-    }
-
-
-    if(sms != fastcat::ACTUATOR_SMS_PROF_POS &&
-        fabs(pos - request->target_position) < position_tolerance_){
-      break;
-    }
-
-    timer.sleep();
+  double goal_pos = request->target_position;
+  if (request->relative) {
+    goal_pos += act_state_map_[request->name].actual_position;
   }
 
-  MSG("Completed ACTUATOR_PROF_POS for: %s", request->name.c_str());
-  response->message = "";
-  response->success = true;
+  EVR_ACTIVITY_LO("actuator:%s Profile Position command from: %lf to goal: %lf",
+                  request->name.c_str(),
+                  act_state_map_[request->name].actual_position, goal_pos);
+
+  response->success = RunActuatorMonitorLoop(response->message, request->name);
+  if (response->success) {
+    EVR_ACTIVITY_HI("Completed ACTUATOR_PROF_POS for: %s",
+                    request->name.c_str());
+    response->message = "";  // not strictly needed
+  }
 }
 
 void FcatSrvs::ActuatorProfVelSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::ActuatorProfVelCmd::Request> request,
-    std::shared_ptr<fcat_msgs::srv::ActuatorProfVelCmd::Response>      response)
+  const std::shared_ptr<fcat_msgs::srv::ActuatorProfVelService::Request>
+    request,
+  std::shared_ptr<fcat_msgs::srv::ActuatorProfVelService::Response> response)
 {
-  MSG("fcat_srv recived new actuator_prof_vel command");
+  EVR_ACTIVITY_LO("Handling Actuator Prof Vel Command");
   response->success = false;
 
-  if(!ActuatorCmdPrechecks(request->name, response->message)){
+  if (!ActuatorCmdPrechecks(request->name, response->message)) {
     return;
   }
 
-  MSG("actuator_prof_vel: issuing topic cmd and watching for completion");
+  double tol = this->get_parameter("tolerance").as_double();
+  if (fabs(request->max_duration) < tol) {
+    EVR_WARNING_HI(
+      "Max Duration (%E) < tolerance (%E) indicating this runs forever. "
+      "In this case, use the topic (non-blocking) interface instead of the "
+      "service (blocking) interface",
+      request->max_duration, tol);
+    return;
+  }
 
-  //Publish topic to start the service
+  // Publish topic to start the service
   auto cmd_msg = fcat_msgs::msg::ActuatorProfVelCmd();
 
-  cmd_msg.name            = request->name;
+  cmd_msg.name = request->name;
   cmd_msg.target_velocity = request->target_velocity;
-  cmd_msg.profile_accel   = request->profile_accel;
-  cmd_msg.max_duration    = request->max_duration;
+  cmd_msg.profile_accel = request->profile_accel;
+  cmd_msg.max_duration = request->max_duration;
 
   act_prof_vel_pub_->publish(cmd_msg);
 
-  // Continuously check for 
-  //  - fcat_srvs shutdown request
-  //  - fcat faults
-  //  - actuator state machine progress
+  EVR_ACTIVITY_LO("actuator:%s to goal velocity value: %lf",
+                  request->name.c_str(), request->target_velocity);
 
-  fastcat::ActuatorStateMachineState sms;
-  double velocity;
-  rclcpp::Rate timer(loop_rate_hz_); //Hz
-
-  while(true){
-    if(!rclcpp::ok()){
-      response->message = "fcat_srvs node shutdown";
-      ERROR("Failure: %s", response->message.c_str());
-      return;
-    }
-
-    if((get_time_sec() - module_state_last_recv_time_) > FCAT_SRVS_LIVELINESS_DURATION){ 
-      response->message = "stale fcat module state topic, fcat has stopped ";
-      ERROR("Failure: %s", response->message.c_str());
-      return;
-    }
-
-    sms = static_cast<fastcat::ActuatorStateMachineState>(
-        act_state_map_[request->name].actuator_state_machine_state);
-
-    velocity = act_state_map_[request->name].cmd_velocity;
-
-    if(sms == fastcat::ACTUATOR_SMS_FAULTED){
-      response->message = std::string("Actuator unexpectedly faulted");
-      ERROR("Failure: %s", response->message.c_str());
-      return;
-    }
-
-    if(sms == fastcat::ACTUATOR_SMS_PROF_VEL && 
-        fabs(velocity - request->target_velocity) < velocity_tolerance_){
-      MSG("Actuator is in PROF_VEL mode and achieved target velocity");
-      break;
-    }
-
-    timer.sleep();
+  response->success = RunActuatorMonitorLoop(response->message, request->name);
+  if (response->success) {
+    EVR_ACTIVITY_HI("Completed ACTUATOR_PROF_VEL for: %s",
+                    request->name.c_str());
+    response->message = "";
   }
-
-  MSG("Completed ACTUATOR_PROF_VEL for: %s", request->name.c_str());
-  response->message = "";
-  response->success = true;
 }
 
 void FcatSrvs::ActuatorProfTorqueSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueCmd::Request> request,
-    std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueCmd::Response>      response)
+  const std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueService::Request>
+    request,
+  std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueService::Response> response)
 {
-  MSG("fcat_srv recived new actuator_prof_torque command");
+  EVR_ACTIVITY_HI("Handling Actuator Prof Torque Command");
   response->success = false;
 
-  if(!ActuatorCmdPrechecks(request->name, response->message)){
+  if (!ActuatorCmdPrechecks(request->name, response->message)) {
     return;
   }
 
-  MSG("actuator_prof_torque: issuing topic cmd and watching for completion");
+  EVR_DIAGNOSTIC(
+    "actuator_prof_torque: issuing topic cmd and watching for completion");
 
-  //Publish topic to start the service
+  // Publish topic to start the service
   auto cmd_msg = fcat_msgs::msg::ActuatorProfTorqueCmd();
 
-  cmd_msg.name               = request->name;
+  cmd_msg.name = request->name;
   cmd_msg.target_torque_amps = request->target_torque_amps;
-  cmd_msg.max_duration       = request->max_duration;
+  cmd_msg.max_duration = request->max_duration;
 
   act_prof_torque_pub_->publish(cmd_msg);
 
-  // Continuously check for 
-  //  - fcat_srvs shutdown request
-  //  - fcat faults
-  //  - actuator state machine progress
+  EVR_ACTIVITY_LO("fcat_srv actuator:%s to goal current value: %lf",
+                  request->name.c_str(), request->target_torque_amps);
 
-  fastcat::ActuatorStateMachineState sms;
-  double current;
-  rclcpp::Rate timer(loop_rate_hz_); //Hz
-
-  while(true){
-    if(!rclcpp::ok()){
-      response->message = "fcat_srvs node shutdown";
-      ERROR("Failure: %s", response->message.c_str());
-      return;
-    }
-
-    if((get_time_sec() - module_state_last_recv_time_) > FCAT_SRVS_LIVELINESS_DURATION){ 
-      response->message = "stale fcat module state topic, fcat has stopped ";
-      ERROR("Failure: %s", response->message.c_str());
-      return;
-    }
-
-    sms = static_cast<fastcat::ActuatorStateMachineState>(
-        act_state_map_[request->name].actuator_state_machine_state);
-
-    current = act_state_map_[request->name].cmd_current;
-
-    if(sms == fastcat::ACTUATOR_SMS_FAULTED){
-      response->message = std::string("Actuator unexpectedly faulted");
-      ERROR("Failure: %s", response->message.c_str());
-      return;
-    }
-
-    if(sms == fastcat::ACTUATOR_SMS_PROF_TORQUE && 
-        fabs(current - request->target_torque_amps) < current_tolerance_){
-      MSG("Actuator is in PROF_TORQUE mode and achieved target current");
-      break;
-    }
-
-    timer.sleep();
+  response->success = RunActuatorMonitorLoop(response->message, request->name);
+  if (response->success) {
+    EVR_ACTIVITY_HI("Completed ACTUATOR_PROF_TORQUE for: %s",
+                    request->name.c_str());
+    response->message = "";
   }
-
-  MSG("Completed ACTUATOR_PROF_TORQUE for: %s", request->name.c_str());
-  response->message = "";
-  response->success = true;
 }
 
 void FcatSrvs::ActuatorCalibrateSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateCmd::Request> request,
-    std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateCmd::Response>      response)
+  const std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateService::Request>
+    request,
+  std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateService::Response> response)
 {
-  MSG("fcat_srv recived new actuator_calibrate command");
+  EVR_ACTIVITY_HI("Handling Actuator Calibrate Command");
   response->success = false;
 
-  if(!ActuatorCmdPrechecks(request->name, response->message)){
+  if (!ActuatorCmdPrechecks(request->name, response->message)) {
     return;
   }
 
-  MSG("actuator_calibrate: issuing topic cmd and watching for completion");
-
-  //Publish topic to start the service
+  // Publish topic to start the service
   auto cmd_msg = fcat_msgs::msg::ActuatorCalibrateCmd();
 
-  cmd_msg.name        = request->name;
-  cmd_msg.velocity    = request->velocity;
-  cmd_msg.accel       = request->accel;
+  cmd_msg.name = request->name;
+  cmd_msg.velocity = request->velocity;
+  cmd_msg.accel = request->accel;
   cmd_msg.max_current = request->max_current;
 
   act_calibrate_pub_->publish(cmd_msg);
 
-  // Continuously check for 
-  //  - fcat_srvs shutdown request
-  //  - fcat faults
-  //  - actuator state machine progress
-
-  fastcat::ActuatorStateMachineState sms;
-  fastcat::ActuatorStateMachineState last_sms;
-  last_sms = static_cast<fastcat::ActuatorStateMachineState>(
-      act_state_map_[request->name].actuator_state_machine_state);
-
-  rclcpp::Rate timer(loop_rate_hz_); //Hz
-
-  while(true){
-    if(!rclcpp::ok()){
-      response->message = "fcat_srvs node shutdown";
-      ERROR("Failure: %s", response->message.c_str());
-      return;
-    }
-
-    if((get_time_sec() - module_state_last_recv_time_) > FCAT_SRVS_LIVELINESS_DURATION){ 
-      response->message = "stale fcat module state topic, fcat has stopped ";
-      ERROR("Failure: %s", response->message.c_str());
-      return;
-    }
-
-    sms = static_cast<fastcat::ActuatorStateMachineState>(
-        act_state_map_[request->name].actuator_state_machine_state);
-
-    if(sms == fastcat::ACTUATOR_SMS_FAULTED){
-      response->message = std::string("Actuator unexpectedly faulted");
-      ERROR("Failure: %s", response->message.c_str());
-      return;
-    }
-
-    if(sms != fastcat::ACTUATOR_SMS_CAL_MOVE_TO_SOFTSTOP && 
-         last_sms == fastcat::ACTUATOR_SMS_CAL_MOVE_TO_SOFTSTOP){
-      break;
-    }
-
-    last_sms = sms;
-    timer.sleep();
+  response->success = RunActuatorMonitorLoop(response->message, request->name);
+  if (response->success) {
+    EVR_ACTIVITY_HI("Completed ACTUATOR_CALIBRATE for: %s",
+                    request->name.c_str());
+    response->message = "";
   }
+}
 
-  MSG("Completed ACTUATOR_CALIBRATE for: %s", request->name.c_str());
-  response->message = "";
-  response->success = true;
+void FcatSrvs::ActuatorSetGainSchedulingModeSrvCb(
+  const std::shared_ptr<
+    fcat_msgs::srv::ActuatorSetGainSchedulingModeService::Request>
+    request,
+  std::shared_ptr<
+    fcat_msgs::srv::ActuatorSetGainSchedulingModeService::Response>
+    response)
+{
+  EVR_ACTIVITY_HI("Handling Actuator Set Gain Scheduling Mode Command");
+  response->success = false;
+
+  auto tlc_req = std::make_shared<fcat_msgs::srv::TlcWriteService::Request>();
+  auto tlc_res = std::make_shared<fcat_msgs::srv::TlcWriteService::Response>();
+
+  tlc_req->name = request->name;
+  tlc_req->tlc = "GS";
+  tlc_req->subindex = 2;
+  tlc_req->data = std::to_string(request->gain_scheduling_mode);
+  tlc_req->data_type = "I32";
+
+  TlcWriteSrvCb(tlc_req, tlc_res);
+
+  response->message = tlc_res->message;
+  response->success = tlc_res->success;
+}
+
+void FcatSrvs::ActuatorSetUnitModeSrvCb(
+  const std::shared_ptr<fcat_msgs::srv::ActuatorSetUnitModeService::Request>
+    request,
+  std::shared_ptr<fcat_msgs::srv::ActuatorSetUnitModeService::Response>
+    response)
+{
+  EVR_ACTIVITY_HI("Handling Actuator Set Unit Mode Command");
+  response->success = false;
+
+  auto tlc_req = std::make_shared<fcat_msgs::srv::TlcWriteService::Request>();
+  auto tlc_res = std::make_shared<fcat_msgs::srv::TlcWriteService::Response>();
+
+  tlc_req->name = request->name;
+  tlc_req->tlc = "UM";
+  tlc_req->subindex = 1;
+  tlc_req->data = std::to_string(request->mode);
+  tlc_req->data_type = "I32";
+
+  TlcWriteSrvCb(tlc_req, tlc_res);
+
+  response->message = tlc_res->message;
+  response->success = tlc_res->success;
 }
 
 void FcatSrvs::PidActivateSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::PidActivateCmd::Request> request,
-    std::shared_ptr<fcat_msgs::srv::PidActivateCmd::Response>      response)
+  const std::shared_ptr<fcat_msgs::srv::PidActivateService::Request> request,
+  std::shared_ptr<fcat_msgs::srv::PidActivateService::Response> response)
 {
-  MSG("fcat_srv recived new pid_activate command");
+  EVR_ACTIVITY_HI("Handling Pid Activate Command");
   response->success = false;
 
-  if(!PidCmdPrechecks(request->name, response->message)){
+  if (!PidCmdPrechecks(request->name, response->message)) {
     return;
   }
 
-  MSG("pid_activate: issuing topic cmd and watching for completion");
+  EVR_DIAGNOSTIC("pid_activate: issuing topic cmd and watching for completion");
 
-  //Publish topic to start the service
+  // Publish topic to start the service
   auto cmd_msg = fcat_msgs::msg::PidActivateCmd();
 
-  cmd_msg.name                 = request->name;
-  cmd_msg.setpoint             = request->setpoint;
-  cmd_msg.deadband             = request->deadband;
+  cmd_msg.name = request->name;
+  cmd_msg.setpoint = request->setpoint;
+  cmd_msg.deadband = request->deadband;
   cmd_msg.persistence_duration = request->persistence_duration;
-  cmd_msg.max_duration         = request->max_duration;
+  cmd_msg.max_duration = request->max_duration;
 
   pid_activate_pub_->publish(cmd_msg);
 
-  // Continuously check for 
+  // Continuously check for
   //  - fcat_srvs shutdown request
   //  - fcat faults
   //  - pid active flag
   bool pid_is_active;
   bool last_pid_is_active = pid_state_map_[request->name].active;
 
-  rclcpp::Rate timer(loop_rate_hz_); //Hz
-
-  while(true){
-    if(!rclcpp::ok()){
-      response->message = "fcat_srvs node shutdown";
-      ERROR("Failure: %s", response->message.c_str());
-      return;
-    }
-
-    if((get_time_sec() - module_state_last_recv_time_) > FCAT_SRVS_LIVELINESS_DURATION){ 
-      response->message = "stale fcat module state topic, fcat has stopped ";
-      ERROR("Failure: %s", response->message.c_str());
+  while (true) {
+    if (CheckCommonFaultActive(response->message)) {
       return;
     }
 
     pid_is_active = pid_state_map_[request->name].active;
 
-    if(!pid_is_active && last_pid_is_active){
+    // This logic may be a little brittle if the
+    // command uses low or zero persistence. If an issue is ever
+    // reported, solve it here just like for the actuator case.
+    if (!pid_is_active && last_pid_is_active) {
       break;
     }
 
     last_pid_is_active = pid_is_active;
-    timer.sleep();
+    rate_->sleep();
   }
 
-  MSG("Completed ACTUATOR_PROF_TORQUE for: %s", request->name.c_str());
+  EVR_ACTIVITY_HI("Completed PID_ACTIVATE for: %s", request->name.c_str());
   response->message = "";
   response->success = true;
+}
+
+void FcatSrvs::AsyncSdoWriteSrvCb(
+  const std::shared_ptr<fcat_msgs::srv::AsyncSdoWriteService::Request> request,
+  std::shared_ptr<fcat_msgs::srv::AsyncSdoWriteService::Response> response)
+{
+  EVR_ACTIVITY_HI("Handling SDO Write command");
+  char print_str[512];
+  response->message = "";
+
+  // 1) Parse input args
+  uint16_t parsed_sdo_index = 0;
+  if (!HexOrDecStrToNum(request->sdo_index, parsed_sdo_index)) {
+    sprintf(print_str, "Invalid SDO index string:(%s) conversion to U16",
+            request->sdo_index.c_str());
+
+    response->message = print_str;
+    EVR_WARNING_LO("%s", print_str);
+
+    return;
+  }
+
+  if (JSD_SDO_DATA_UNSPECIFIED ==
+      jsd_sdo_data_type_from_string(request->data_type)) {
+    sprintf(print_str,
+            "Invalid SDO Write data_type:(%s) Must be one of "
+            "{'I8', 'I16', 'I32', 'I64', 'F32', 'U8', 'U16', 'U32', 'U64'}",
+            request->data_type.c_str());
+    response->message = print_str;
+    EVR_WARNING_LO("%s", print_str);
+    return;
+  }
+
+  // 2) Dispatch the SDO request to FCAT
+  fcat_msgs::msg::AsyncSdoWriteCmd msg;
+
+  msg.name = request->name;
+  msg.sdo_index = parsed_sdo_index;
+  msg.sdo_subindex = request->sdo_subindex;
+  msg.data = request->data;
+  msg.data_type = request->data_type;
+  msg.app_id = sdo_app_id_++;
+
+  async_sdo_write_pub_->publish(msg);
+
+  EVR_ACTIVITY_LO(
+    "Async SDO Write issued {Name:(%s) Index:(0x%x)"
+    " Subindex:(%u) Data:(%s) DataType:(%s) AppId:(%u)}",
+    msg.name.c_str(), msg.sdo_index, msg.sdo_subindex, msg.data.c_str(),
+    msg.data_type.c_str(), msg.app_id);
+
+  // 3) Wait for the SDO Response from FCAT
+  response->success = WaitForSdoResponse(response->message, msg.app_id);
+}
+
+void FcatSrvs::AsyncSdoReadSrvCb(
+  const std::shared_ptr<fcat_msgs::srv::AsyncSdoReadService::Request> request,
+  std::shared_ptr<fcat_msgs::srv::AsyncSdoReadService::Response> response)
+{
+  EVR_ACTIVITY_HI("Handling SDO Read command");
+  char print_str[512];
+  response->message = "";
+
+  // 1) Parse input args
+  uint16_t parsed_sdo_index = 0;
+  if (!HexOrDecStrToNum(request->sdo_index, parsed_sdo_index)) {
+    sprintf(print_str, "Invalid SDO index string:(%s) conversion to U16",
+            request->sdo_index.c_str());
+
+    response->message = print_str;
+    EVR_WARNING_LO("%s", print_str);
+    return;
+  }
+
+  if (JSD_SDO_DATA_UNSPECIFIED ==
+      jsd_sdo_data_type_from_string(request->data_type)) {
+    sprintf(print_str,
+            "Invalid SDO Read data_type:(%s) Must be one of "
+            "{'I8', 'I16', 'I32', 'I64', 'F32', 'U8', 'U16', 'U32', 'U64'}",
+            request->data_type.c_str());
+
+    response->message = print_str;
+    EVR_WARNING_LO("%s", print_str);
+    return;
+  }
+
+  // 2) Dispatch the SDO request to FCAT
+  fcat_msgs::msg::AsyncSdoReadCmd msg;
+
+  msg.name = request->name;
+  msg.sdo_index = parsed_sdo_index;
+  msg.sdo_subindex = request->sdo_subindex;
+  msg.data_type = request->data_type;
+  msg.app_id = sdo_app_id_++;
+
+  async_sdo_read_pub_->publish(msg);
+
+  EVR_ACTIVITY_LO(
+    "Async SDO Read issued {Name:(%s) Index:(0x%x)"
+    " Subindex:(%u) DataType:(%s) AppId:(%u)}",
+    msg.name.c_str(), msg.sdo_index, msg.sdo_subindex, msg.data_type.c_str(),
+    msg.app_id);
+
+  // 3) Wait for the SDO Response from FCAT
+  response->success = WaitForSdoResponse(response->message, msg.app_id);
+}
+
+void FcatSrvs::TlcWriteSrvCb(
+  const std::shared_ptr<fcat_msgs::srv::TlcWriteService::Request> request,
+  std::shared_ptr<fcat_msgs::srv::TlcWriteService::Response> response)
+{
+  EVR_ACTIVITY_HI("Handling Two-Letter Command (TLC) Write command");
+  char print_str[512];
+  response->message = "";
+
+  // 1) Parse input args
+  uint16_t parsed_sdo_index = 0;
+  if (!TlcStrToNum(request->tlc, parsed_sdo_index)) {
+    sprintf(print_str, "Invalid TLC string:(%s) conversion to SDO",
+            request->tlc.c_str());
+
+    response->message = print_str;
+    EVR_WARNING_LO("%s", print_str);
+    return;
+  }
+
+  if (JSD_SDO_DATA_UNSPECIFIED ==
+      jsd_sdo_data_type_from_string(request->data_type)) {
+    sprintf(print_str,
+            "Invalid SDO Write data_type:(%s) Must be one of "
+            "{'I8', 'I16', 'I32', 'I64', 'F32', 'U8', 'U16', 'U32', 'U64'}",
+            request->data_type.c_str());
+    response->message = print_str;
+    EVR_WARNING_LO("%s", print_str);
+
+    return;
+  }
+
+  // 2) Dispatch the SDO request to FCAT
+  fcat_msgs::msg::AsyncSdoWriteCmd msg;
+
+  msg.name = request->name;
+  msg.sdo_index = parsed_sdo_index;
+  msg.sdo_subindex = request->subindex;
+  msg.data = request->data;
+  msg.data_type = request->data_type;
+  msg.app_id = sdo_app_id_++;
+
+  async_sdo_write_pub_->publish(msg);
+
+  EVR_ACTIVITY_LO(
+    "Async SDO Write issued {Name:(%s) TLC:(%s) Index:(0x%x)"
+    " Subindex:(%u) Data:(%s) DataType:(%s) AppId:(%u)}",
+    msg.name.c_str(), request->tlc.c_str(), msg.sdo_index, msg.sdo_subindex,
+    msg.data.c_str(), msg.data_type.c_str(), msg.app_id);
+
+  // 3) Wait for the SDO Response from FCAT
+  response->success = WaitForSdoResponse(response->message, msg.app_id);
+}
+
+void FcatSrvs::TlcReadSrvCb(
+  const std::shared_ptr<fcat_msgs::srv::TlcReadService::Request> request,
+  std::shared_ptr<fcat_msgs::srv::TlcReadService::Response> response)
+{
+  EVR_ACTIVITY_HI("Handling Two-Letter Command (TLC) Read command");
+  char print_str[512];
+  response->message = "";
+
+  // 1) Parse input args
+  uint16_t parsed_sdo_index = 0;
+  if (!TlcStrToNum(request->tlc, parsed_sdo_index)) {
+    sprintf(print_str, "Invalid TLC string:(%s) conversion to SDO",
+            request->tlc.c_str());
+
+    response->message = print_str;
+    EVR_WARNING_LO("%s", print_str);
+    return;
+  }
+
+  if (JSD_SDO_DATA_UNSPECIFIED ==
+      jsd_sdo_data_type_from_string(request->data_type)) {
+    sprintf(print_str,
+            "Invalid SDO Read data_type:(%s) Must be one of "
+            "{'I8', 'I16', 'I32', 'I64', 'F32', 'U8', 'U16', 'U32', 'U64'}",
+            request->data_type.c_str());
+
+    response->message = print_str;
+    EVR_WARNING_LO("%s", print_str);
+    return;
+  }
+
+  // 2) Dispatch the SDO request to FCAT
+  fcat_msgs::msg::AsyncSdoReadCmd msg;
+
+  msg.name = request->name;
+  msg.sdo_index = parsed_sdo_index;
+  msg.sdo_subindex = request->subindex;
+  msg.data_type = request->data_type;
+  msg.app_id = sdo_app_id_++;
+
+  async_sdo_read_pub_->publish(msg);
+
+  EVR_ACTIVITY_LO(
+    "Async SDO Read issued {Name:(%s) TLC:(%s) Index:(0x%x)"
+    " Subindex:(%u) DataType:(%s) AppId:(%u)}",
+    msg.name.c_str(), request->tlc.c_str(), msg.sdo_index, msg.sdo_subindex,
+    msg.data_type.c_str(), msg.app_id);
+
+  // 3) Wait for the SDO Response from FCAT
+  response->success = WaitForSdoResponse(response->message, msg.app_id);
 }

--- a/src/fcat_srvs.hpp
+++ b/src/fcat_srvs.hpp
@@ -175,6 +175,7 @@ class FcatSrvs : public rclcpp::Node
   std::unique_ptr<rclcpp::Rate> rate_;
   rclcpp::CallbackGroup::SharedPtr cb_group_blocking_;
   rclcpp::CallbackGroup::SharedPtr cb_group_non_blocking_;
+  std::vector<std::any> services_;
   std::vector<std::any> subscriptions_;
 };
 

--- a/src/fcat_srvs.hpp
+++ b/src/fcat_srvs.hpp
@@ -1,119 +1,182 @@
-#ifndef FCAT_SRVS_HPP_
-#define FCAT_SRVS_HPP_
+#ifndef FCAT__FCAT_SERVICES_HPP_
+#define FCAT__FCAT_SERVICES_HPP_
 
-#include "rclcpp/rclcpp.hpp"
 #include <sys/time.h>
+#include <queue>
+#include "casah_node/evr_interface.hpp"
+#include "rclcpp/rclcpp.hpp"
 
 // Service messages
-#include "fcat_msgs/srv/actuator_calibrate_cmd.hpp"
-#include "fcat_msgs/srv/actuator_prof_pos_cmd.hpp"
-#include "fcat_msgs/srv/actuator_prof_torque_cmd.hpp"
-#include "fcat_msgs/srv/actuator_prof_vel_cmd.hpp"
-#include "fcat_msgs/srv/pid_activate_cmd.hpp"
+#include "fcat_msgs/msg/actuator_set_digital_output_cmd.hpp"
+#include "fcat_msgs/srv/actuator_calibrate_service.hpp"
+#include "fcat_msgs/srv/actuator_prof_pos_service.hpp"
+#include "fcat_msgs/srv/actuator_prof_torque_service.hpp"
+#include "fcat_msgs/srv/actuator_prof_vel_service.hpp"
+#include "fcat_msgs/srv/actuator_set_digital_output_service.hpp"
+#include "fcat_msgs/srv/actuator_set_gain_scheduling_mode_service.hpp"
+#include "fcat_msgs/srv/actuator_set_unit_mode_service.hpp"
+#include "fcat_msgs/srv/async_sdo_read_service.hpp"
+#include "fcat_msgs/srv/async_sdo_write_service.hpp"
+#include "fcat_msgs/srv/pid_activate_service.hpp"
+#include "fcat_msgs/srv/tlc_read_service.hpp"
+#include "fcat_msgs/srv/tlc_write_service.hpp"
 
 // Cmd Messages
 #include "fcat_msgs/msg/actuator_calibrate_cmd.hpp"
 #include "fcat_msgs/msg/actuator_prof_pos_cmd.hpp"
 #include "fcat_msgs/msg/actuator_prof_torque_cmd.hpp"
 #include "fcat_msgs/msg/actuator_prof_vel_cmd.hpp"
+#include "fcat_msgs/msg/async_sdo_read_cmd.hpp"
+#include "fcat_msgs/msg/async_sdo_write_cmd.hpp"
 #include "fcat_msgs/msg/pid_activate_cmd.hpp"
 
 // State Messages
-#include "fcat_msgs/msg/module_state.hpp"
 #include "fcat_msgs/msg/actuator_states.hpp"
+#include "fcat_msgs/msg/async_sdo_response.hpp"
+#include "fcat_msgs/msg/module_state.hpp"
 #include "fcat_msgs/msg/pid_states.hpp"
 
-const unsigned int FCAT_SRVS_PUB_QUEUE_SIZE = 5;
-const unsigned int FCAT_SRVS_SUB_QUEUE_SIZE = 5;
-const double FCAT_SRVS_LIVELINESS_DURATION  = 1.0; // sec
-const double FCAT_SRVS_LOOP_RATE            = 100; // Hz
-
-const rclcpp::QoS FCAT_SRVS_QOS_SUBS = rclcpp::QoS(FCAT_SRVS_SUB_QUEUE_SIZE);
-const rmw_qos_profile_t FCAT_SRVS_QOS_SRVS = rmw_qos_profile_services_default;
-
-inline double get_time_sec()
+class FcatServices : public casah_node::EvrInterface
 {
-  struct timeval tv;
-  gettimeofday(&tv, NULL);
-  return (double)tv.tv_sec + (double)tv.tv_usec / 1000000;
-}
+ private:
+  typedef enum {
+    FCAT_SRV_STATE_IDLE_CHECKING,
+    FCAT_SRV_STATE_RUNNING,
+  } FcatSrvState;
 
-class FcatSrvs: public rclcpp::Node{
-  public:
-    //~FcatSrvs();
-    FcatSrvs();
+ public:
+  FcatServices(const rclcpp::NodeOptions& options = rclcpp::NodeOptions());
 
-  private:
+ private:
+  static const unsigned int publisher_queue_size_ = 5;
+  static const unsigned int subscription_queue_size_ = 5;
+  static constexpr double liveliness_duration_sec_ = 1.0;
+  static constexpr double loop_rate_hz_ = 100.0;
+
+  const rclcpp::QoS subscription_qos_ = 
+    rclcpp::QoS(subscription_queue_size_).best_effort();
+  const rclcpp::QoS services_qos_;
+
+  void Process() override{};
 
   void InitSubscribers();
   void InitPublishers();
   void InitServices();
-  bool ActuatorCmdPrechecks(std::string name, std::string &message);
-  bool PidCmdPrechecks(std::string name, std::string &message);
 
-  // Fcat Cmd Publishers
-  rclcpp::Publisher<fcat_msgs::msg::ActuatorProfPosCmd>::SharedPtr act_prof_pos_pub_;
-  rclcpp::Publisher<fcat_msgs::msg::ActuatorProfVelCmd>::SharedPtr act_prof_vel_pub_;
-  rclcpp::Publisher<fcat_msgs::msg::ActuatorProfTorqueCmd>::SharedPtr act_prof_torque_pub_;
-  rclcpp::Publisher<fcat_msgs::msg::ActuatorCalibrateCmd>::SharedPtr act_calibrate_pub_;
-  rclcpp::Publisher<fcat_msgs::msg::PidActivateCmd>::SharedPtr pid_activate_pub_;
+  // Fcat State Subscription Callbacks
+  void FcatModuleStateCb(
+    const std::shared_ptr<fcat_msgs::msg::ModuleState> msg);
+  void ActuatorStatesCb(
+    const std::shared_ptr<fcat_msgs::msg::ActuatorStates> msg);
+  void PidStatesCb(const std::shared_ptr<fcat_msgs::msg::PidStates> msg);
+  void AsyncSdoResponseCb(
+    const std::shared_ptr<fcat_msgs::msg::AsyncSdoResponse> msg);
+
+  // Helper functions
+  bool ActuatorCmdPrechecks(std::string name, std::string& message);
+  bool PidCmdPrechecks(std::string name, std::string& message);
+  bool CheckCommonFaultActive(std::string& error_message);
+  bool RunActuatorMonitorLoop(std::string& error_message, std::string act_name);
+  bool WaitForSdoResponse(std::string& error_message, uint16_t app_id);
 
   // Commander Services and Callbacks
-  rclcpp::Service<fcat_msgs::srv::ActuatorProfPosCmd>::SharedPtr    act_prof_pos_srv_;
-  rclcpp::Service<fcat_msgs::srv::ActuatorProfVelCmd>::SharedPtr    act_prof_vel_srv_;
-  rclcpp::Service<fcat_msgs::srv::ActuatorProfTorqueCmd>::SharedPtr act_prof_torque_srv_;
-  rclcpp::Service<fcat_msgs::srv::ActuatorCalibrateCmd>::SharedPtr  act_calibrate_srv_;
-  rclcpp::Service<fcat_msgs::srv::PidActivateCmd>::SharedPtr        pid_activate_srv_;
-
   void ActuatorProfPosSrvCb(
-      const std::shared_ptr<fcat_msgs::srv::ActuatorProfPosCmd::Request> request,
-      std::shared_ptr<fcat_msgs::srv::ActuatorProfPosCmd::Response>      response);
+    const std::shared_ptr<fcat_msgs::srv::ActuatorProfPosService::Request>
+      request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorProfPosService::Response> response);
 
   void ActuatorProfVelSrvCb(
-      const std::shared_ptr<fcat_msgs::srv::ActuatorProfVelCmd::Request> request,
-      std::shared_ptr<fcat_msgs::srv::ActuatorProfVelCmd::Response>      response);
+    const std::shared_ptr<fcat_msgs::srv::ActuatorProfVelService::Request>
+      request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorProfVelService::Response> response);
 
   void ActuatorProfTorqueSrvCb(
-      const std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueCmd::Request> request,
-      std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueCmd::Response>      response);
+    const std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueService::Request>
+      request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueService::Response>
+      response);
 
   void ActuatorCalibrateSrvCb(
-      const std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateCmd::Request> request,
-      std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateCmd::Response>      response);
+    const std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateService::Request>
+      request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateService::Response>
+      response);
+
+  void ActuatorSetGainSchedulingModeSrvCb(
+    const std::shared_ptr<
+      fcat_msgs::srv::ActuatorSetGainSchedulingModeService::Request>
+      request,
+    std::shared_ptr<
+      fcat_msgs::srv::ActuatorSetGainSchedulingModeService::Response>
+      response);
+
+  void ActuatorSetUnitModeSrvCb(
+    const std::shared_ptr<fcat_msgs::srv::ActuatorSetUnitModeService::Request>
+      request,
+    std::shared_ptr<fcat_msgs::srv::ActuatorSetUnitModeService::Response>
+      response);
 
   void PidActivateSrvCb(
-      const std::shared_ptr<fcat_msgs::srv::PidActivateCmd::Request> request,
-      std::shared_ptr<fcat_msgs::srv::PidActivateCmd::Response>      response);
+    const std::shared_ptr<fcat_msgs::srv::PidActivateService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::PidActivateService::Response> response);
 
+  void AsyncSdoWriteSrvCb(
+    const std::shared_ptr<fcat_msgs::srv::AsyncSdoWriteService::Request>
+      request,
+    std::shared_ptr<fcat_msgs::srv::AsyncSdoWriteService::Response> response);
 
-  // Fcat State Subscribers and Callbacks
-  void FcatModuleStateCb(const std::shared_ptr<fcat_msgs::msg::ModuleState> msg);
-  void ActuatorStatesCb(const std::shared_ptr<fcat_msgs::msg::ActuatorStates> msg);
-  void PidStatesCb(const std::shared_ptr<fcat_msgs::msg::PidStates> msg);
+  void AsyncSdoReadSrvCb(
+    const std::shared_ptr<fcat_msgs::srv::AsyncSdoReadService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::AsyncSdoReadService::Response> response);
 
-  rclcpp::Subscription<fcat_msgs::msg::ModuleState>::SharedPtr    fcat_module_state_sub_;
-  rclcpp::Subscription<fcat_msgs::msg::ActuatorStates>::SharedPtr act_states_sub_;
-  rclcpp::Subscription<fcat_msgs::msg::PidStates>::SharedPtr      pid_states_sub_;
+  void TlcWriteSrvCb(
+    const std::shared_ptr<fcat_msgs::srv::TlcWriteService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::TlcWriteService::Response> response);
 
-  fcat_msgs::msg::ModuleState    fcat_module_state_msg_;
+  void TlcReadSrvCb(
+    const std::shared_ptr<fcat_msgs::srv::TlcReadService::Request> request,
+    std::shared_ptr<fcat_msgs::srv::TlcReadService::Response> response);
+
+ private:
+  // Fcat Cmd Publishers
+  rclcpp::Publisher<fcat_msgs::msg::ActuatorProfPosCmd>::SharedPtr
+    act_prof_pos_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::ActuatorProfVelCmd>::SharedPtr
+    act_prof_vel_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::ActuatorProfTorqueCmd>::SharedPtr
+    act_prof_torque_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::ActuatorCalibrateCmd>::SharedPtr
+    act_calibrate_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::PidActivateCmd>::SharedPtr
+    pid_activate_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::AsyncSdoWriteCmd>::SharedPtr
+    async_sdo_write_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::AsyncSdoReadCmd>::SharedPtr
+    async_sdo_read_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::ActuatorSetDigitalOutputCmd>::SharedPtr
+    act_digital_output_pub_;
+
+  fcat_msgs::msg::ModuleState fcat_module_state_msg_;
   fcat_msgs::msg::ActuatorStates actuator_states_msg_;
-  fcat_msgs::msg::PidStates      pid_states_msg_;
+  fcat_msgs::msg::PidStates pid_states_msg_;
+  fcat_msgs::msg::AsyncSdoResponse async_sdo_response_msg_;
 
+  std::string pub_sub_ns_;
+  uint16_t sdo_app_id_ = 0;
   double module_state_last_recv_time_;
   double act_states_last_recv_time_;
   double pid_states_last_recv_time_;
+  size_t max_sdo_queue_size_;
+  FcatSrvState srv_state_;
 
   std::unordered_map<std::string, fcat_msgs::msg::ActuatorState> act_state_map_;
-  std::unordered_map<std::string, fcat_msgs::msg::PidState>      pid_state_map_;
+  std::unordered_map<std::string, fcat_msgs::msg::PidState> pid_state_map_;
+  std::queue<fcat_msgs::msg::AsyncSdoResponse> sdo_response_queue_;
 
+  std::unique_ptr<rclcpp::Rate> rate_;
   rclcpp::CallbackGroup::SharedPtr cb_group_blocking_;
   rclcpp::CallbackGroup::SharedPtr cb_group_non_blocking_;
-
-  double loop_rate_hz_;
-  double position_tolerance_;
-  double velocity_tolerance_;
-  double current_tolerance_;
-
+  std::vector<std::any> subscriptions_;
 };
 
 #endif

--- a/src/fcat_srvs.hpp
+++ b/src/fcat_srvs.hpp
@@ -1,6 +1,7 @@
 #ifndef FCAT__FCAT_SERVICES_HPP_
 #define FCAT__FCAT_SERVICES_HPP_
 
+#include <any>
 #include <sys/time.h>
 #include <queue>
 #include "rclcpp/rclcpp.hpp"
@@ -55,8 +56,6 @@ class FcatSrvs : public rclcpp::Node
   const rclcpp::QoS subscription_qos_ = 
     rclcpp::QoS(subscription_queue_size_).best_effort();
   const rclcpp::QoS services_qos_;
-
-  void Process() override{};
 
   void InitSubscribers();
   void InitPublishers();

--- a/src/fcat_srvs.hpp
+++ b/src/fcat_srvs.hpp
@@ -1,10 +1,16 @@
-#ifndef FCAT__FCAT_SERVICES_HPP_
-#define FCAT__FCAT_SERVICES_HPP_
+// Copyright 2021 California Institute of Technology
+
+#ifndef FCAT_SRVS_HPP_
+#define FCAT_SRVS_HPP_
 
 #include <sys/time.h>
 
 #include <any>
+#include <memory>
 #include <queue>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -46,6 +52,7 @@ class FcatSrvs : public rclcpp::Node {
   } FcatSrvState;
 
  public:
+  // NOLINTNEXTLINE(runtime/explicit)
   FcatSrvs(const rclcpp::NodeOptions& options = rclcpp::NodeOptions());
 
  private:
@@ -151,4 +158,4 @@ class FcatSrvs : public rclcpp::Node {
   std::vector<std::any> subscriptions_;
 };
 
-#endif
+#endif  // FCAT_SRVS_HPP_

--- a/src/fcat_srvs.hpp
+++ b/src/fcat_srvs.hpp
@@ -1,9 +1,11 @@
 #ifndef FCAT__FCAT_SERVICES_HPP_
 #define FCAT__FCAT_SERVICES_HPP_
 
-#include <any>
 #include <sys/time.h>
+
+#include <any>
 #include <queue>
+
 #include "rclcpp/rclcpp.hpp"
 
 // Service messages
@@ -36,8 +38,7 @@
 #include "fcat_msgs/msg/module_state.hpp"
 #include "fcat_msgs/msg/pid_states.hpp"
 
-class FcatSrvs : public rclcpp::Node
-{
+class FcatSrvs : public rclcpp::Node {
  private:
   typedef enum {
     FCAT_SRV_STATE_IDLE_CHECKING,
@@ -53,8 +54,7 @@ class FcatSrvs : public rclcpp::Node
   static constexpr double liveliness_duration_sec_ = 1.0;
   static constexpr double loop_rate_hz_ = 100.0;
 
-  const rclcpp::QoS subscription_qos_ = 
-    rclcpp::QoS(subscription_queue_size_).best_effort();
+  const rclcpp::QoS subscription_qos_ = rclcpp::QoS(subscription_queue_size_).best_effort();
   const rclcpp::QoS services_qos_;
 
   void InitSubscribers();
@@ -62,13 +62,10 @@ class FcatSrvs : public rclcpp::Node
   void InitServices();
 
   // Fcat State Subscription Callbacks
-  void FcatModuleStateCb(
-    const std::shared_ptr<fcat_msgs::msg::ModuleState> msg);
-  void ActuatorStatesCb(
-    const std::shared_ptr<fcat_msgs::msg::ActuatorStates> msg);
+  void FcatModuleStateCb(const std::shared_ptr<fcat_msgs::msg::ModuleState> msg);
+  void ActuatorStatesCb(const std::shared_ptr<fcat_msgs::msg::ActuatorStates> msg);
   void PidStatesCb(const std::shared_ptr<fcat_msgs::msg::PidStates> msg);
-  void AsyncSdoResponseCb(
-    const std::shared_ptr<fcat_msgs::msg::AsyncSdoResponse> msg);
+  void AsyncSdoResponseCb(const std::shared_ptr<fcat_msgs::msg::AsyncSdoResponse> msg);
 
   // Helper functions
   bool ActuatorCmdPrechecks(std::string name, std::string& message);
@@ -79,80 +76,56 @@ class FcatSrvs : public rclcpp::Node
 
   // Commander Services and Callbacks
   void ActuatorProfPosSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::ActuatorProfPosService::Request>
-      request,
-    std::shared_ptr<fcat_msgs::srv::ActuatorProfPosService::Response> response);
+      const std::shared_ptr<fcat_msgs::srv::ActuatorProfPosService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::ActuatorProfPosService::Response> response);
 
   void ActuatorProfVelSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::ActuatorProfVelService::Request>
-      request,
-    std::shared_ptr<fcat_msgs::srv::ActuatorProfVelService::Response> response);
+      const std::shared_ptr<fcat_msgs::srv::ActuatorProfVelService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::ActuatorProfVelService::Response> response);
 
   void ActuatorProfTorqueSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueService::Request>
-      request,
-    std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueService::Response>
-      response);
+      const std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::ActuatorProfTorqueService::Response> response);
 
   void ActuatorCalibrateSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateService::Request>
-      request,
-    std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateService::Response>
-      response);
+      const std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::ActuatorCalibrateService::Response> response);
 
   void ActuatorSetGainSchedulingModeSrvCb(
-    const std::shared_ptr<
-      fcat_msgs::srv::ActuatorSetGainSchedulingModeService::Request>
-      request,
-    std::shared_ptr<
-      fcat_msgs::srv::ActuatorSetGainSchedulingModeService::Response>
-      response);
+      const std::shared_ptr<fcat_msgs::srv::ActuatorSetGainSchedulingModeService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::ActuatorSetGainSchedulingModeService::Response> response);
 
   void ActuatorSetUnitModeSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::ActuatorSetUnitModeService::Request>
-      request,
-    std::shared_ptr<fcat_msgs::srv::ActuatorSetUnitModeService::Response>
-      response);
+      const std::shared_ptr<fcat_msgs::srv::ActuatorSetUnitModeService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::ActuatorSetUnitModeService::Response> response);
 
-  void PidActivateSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::PidActivateService::Request> request,
-    std::shared_ptr<fcat_msgs::srv::PidActivateService::Response> response);
+  void PidActivateSrvCb(const std::shared_ptr<fcat_msgs::srv::PidActivateService::Request> request,
+                        std::shared_ptr<fcat_msgs::srv::PidActivateService::Response> response);
 
   void AsyncSdoWriteSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::AsyncSdoWriteService::Request>
-      request,
-    std::shared_ptr<fcat_msgs::srv::AsyncSdoWriteService::Response> response);
+      const std::shared_ptr<fcat_msgs::srv::AsyncSdoWriteService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::AsyncSdoWriteService::Response> response);
 
   void AsyncSdoReadSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::AsyncSdoReadService::Request> request,
-    std::shared_ptr<fcat_msgs::srv::AsyncSdoReadService::Response> response);
+      const std::shared_ptr<fcat_msgs::srv::AsyncSdoReadService::Request> request,
+      std::shared_ptr<fcat_msgs::srv::AsyncSdoReadService::Response> response);
 
-  void TlcWriteSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::TlcWriteService::Request> request,
-    std::shared_ptr<fcat_msgs::srv::TlcWriteService::Response> response);
+  void TlcWriteSrvCb(const std::shared_ptr<fcat_msgs::srv::TlcWriteService::Request> request,
+                     std::shared_ptr<fcat_msgs::srv::TlcWriteService::Response> response);
 
-  void TlcReadSrvCb(
-    const std::shared_ptr<fcat_msgs::srv::TlcReadService::Request> request,
-    std::shared_ptr<fcat_msgs::srv::TlcReadService::Response> response);
+  void TlcReadSrvCb(const std::shared_ptr<fcat_msgs::srv::TlcReadService::Request> request,
+                    std::shared_ptr<fcat_msgs::srv::TlcReadService::Response> response);
 
  private:
   // Fcat Cmd Publishers
-  rclcpp::Publisher<fcat_msgs::msg::ActuatorProfPosCmd>::SharedPtr
-    act_prof_pos_pub_;
-  rclcpp::Publisher<fcat_msgs::msg::ActuatorProfVelCmd>::SharedPtr
-    act_prof_vel_pub_;
-  rclcpp::Publisher<fcat_msgs::msg::ActuatorProfTorqueCmd>::SharedPtr
-    act_prof_torque_pub_;
-  rclcpp::Publisher<fcat_msgs::msg::ActuatorCalibrateCmd>::SharedPtr
-    act_calibrate_pub_;
-  rclcpp::Publisher<fcat_msgs::msg::PidActivateCmd>::SharedPtr
-    pid_activate_pub_;
-  rclcpp::Publisher<fcat_msgs::msg::AsyncSdoWriteCmd>::SharedPtr
-    async_sdo_write_pub_;
-  rclcpp::Publisher<fcat_msgs::msg::AsyncSdoReadCmd>::SharedPtr
-    async_sdo_read_pub_;
-  rclcpp::Publisher<fcat_msgs::msg::ActuatorSetDigitalOutputCmd>::SharedPtr
-    act_digital_output_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::ActuatorProfPosCmd>::SharedPtr act_prof_pos_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::ActuatorProfVelCmd>::SharedPtr act_prof_vel_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::ActuatorProfTorqueCmd>::SharedPtr act_prof_torque_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::ActuatorCalibrateCmd>::SharedPtr act_calibrate_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::PidActivateCmd>::SharedPtr pid_activate_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::AsyncSdoWriteCmd>::SharedPtr async_sdo_write_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::AsyncSdoReadCmd>::SharedPtr async_sdo_read_pub_;
+  rclcpp::Publisher<fcat_msgs::msg::ActuatorSetDigitalOutputCmd>::SharedPtr act_digital_output_pub_;
 
   fcat_msgs::msg::ModuleState fcat_module_state_msg_;
   fcat_msgs::msg::ActuatorStates actuator_states_msg_;

--- a/src/fcat_srvs.hpp
+++ b/src/fcat_srvs.hpp
@@ -3,7 +3,6 @@
 
 #include <sys/time.h>
 #include <queue>
-#include "casah_node/evr_interface.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 // Service messages
@@ -36,7 +35,7 @@
 #include "fcat_msgs/msg/module_state.hpp"
 #include "fcat_msgs/msg/pid_states.hpp"
 
-class FcatServices : public casah_node::EvrInterface
+class FcatSrvs : public rclcpp::Node
 {
  private:
   typedef enum {
@@ -45,7 +44,7 @@ class FcatServices : public casah_node::EvrInterface
   } FcatSrvState;
 
  public:
-  FcatServices(const rclcpp::NodeOptions& options = rclcpp::NodeOptions());
+  FcatSrvs(const rclcpp::NodeOptions& options = rclcpp::NodeOptions());
 
  private:
   static const unsigned int publisher_queue_size_ = 5;

--- a/src/fcat_srvs_main.cpp
+++ b/src/fcat_srvs_main.cpp
@@ -13,10 +13,9 @@ int main(int argc, char* argv[])
     2                           // Number of threads
   );
 
-  auto node = std::make_shared<FcatServices>();
+  auto node = std::make_shared<FcatSrvs>();
   executor.add_node(node);
   executor.spin();
   rclcpp::shutdown();
   return 0;
 }
-

--- a/src/fcat_srvs_main.cpp
+++ b/src/fcat_srvs_main.cpp
@@ -1,8 +1,10 @@
+// Copyright 2021 California Institute of Technology
+
 #include <sched.h>
 #include <sys/types.h>
 #include <unistd.h>
 
-#include "fcat/fcat_srvs.hpp"
+#include "fcat_srvs.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 int main(int argc, char* argv[]) {

--- a/src/fcat_srvs_main.cpp
+++ b/src/fcat_srvs_main.cpp
@@ -1,16 +1,15 @@
-#include "fcat/fcat_srvs.hpp"
-#include "rclcpp/rclcpp.hpp"
 #include <sched.h>
 #include <sys/types.h>
 #include <unistd.h>
 
-int main(int argc, char* argv[])
-{
+#include "fcat/fcat_srvs.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+int main(int argc, char* argv[]) {
   rclcpp::init(argc, argv);
 
-  rclcpp::executors::MultiThreadedExecutor executor(
-    rclcpp::ExecutorOptions(),  // Default options
-    2                           // Number of threads
+  rclcpp::executors::MultiThreadedExecutor executor(rclcpp::ExecutorOptions(),  // Default options
+                                                    2                           // Number of threads
   );
 
   auto node = std::make_shared<FcatSrvs>();

--- a/src/fcat_srvs_main.cpp
+++ b/src/fcat_srvs_main.cpp
@@ -4,19 +4,19 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-int main(int argc, char * argv[])
+int main(int argc, char* argv[])
 {
-
   rclcpp::init(argc, argv);
 
   rclcpp::executors::MultiThreadedExecutor executor(
-      rclcpp::ExecutorOptions(), // Default options
-      2 // Number of threads
-      );
+    rclcpp::ExecutorOptions(),  // Default options
+    2                           // Number of threads
+  );
 
-  auto node = std::make_shared<FcatSrvs>();
+  auto node = std::make_shared<FcatServices>();
   executor.add_node(node);
   executor.spin();
   rclcpp::shutdown();
   return 0;
 }
+

--- a/src/fcat_utils.cpp
+++ b/src/fcat_utils.cpp
@@ -565,23 +565,26 @@ bool HexOrDecStrToNum(std::string& str, uint16_t& number)
 bool TlcStrToNum(std::string& str, uint16_t& number)
 {
   if (str.size() != 2) {
-    CFW_WARN("TLC string: (%s) must be 2 chars. size: (%zu)", str.c_str(),
-             str.size());
+    fprintf(stderr, "TLC string: (%s) must be 2 chars. size: (%zu)\n",
+            str.c_str(), str.size());
     return false;
   }
 
   if ((str[0] < 'A') || (str[0] > 'Z') || (str[1] < 'A') || (str[1] > 'Z')) {
-    CFW_WARN("TLC string: (%s) must be upper chars [A-Z]", str.c_str());
+    fprintf(stderr, "TLC string: (%s) must be upper chars [A-Z]\n",
+            str.c_str());
     return false;
   }
 
   number = 0x3000 + (26 * (str[0] - 65)) + (str[1] - 65);
 
   if (number < 0x3000 || number > 0x3FFF) {
-    CFW_WARN(
+    fprintf(
+      stderr,
       "TLC conversion is out of range: %s -> 0x%X not in "
       "range (0x3000,0x3FFF)",
       str.c_str(), number);
+    fprintf(stderr, "\n");
     return false;
   }
 
@@ -653,7 +656,7 @@ jsd_sdo_data_t jsd_sdo_data_from_string(jsd_sdo_data_type_t& type,
       data.as_u64 = static_cast<uint64_t>(atoll(str.c_str()));
       break;
     default:
-      CFW_WARN("SDO data type: %d", static_cast<int>(type));
+      fprintf(stderr, "SDO data type: %d\n", static_cast<int>(type));
   }
   return data;
 }
@@ -670,7 +673,7 @@ std::string jsd_sdo_request_type_to_string(jsd_sdo_req_type_t req_type)
       break;
 
     default:
-      CFW_WARN("Invalid request type: %d", static_cast<int>(req_type));
+      fprintf(stderr, "Invalid request type: %d\n", static_cast<int>(req_type));
   }
   return "INVALID";
 }
@@ -706,7 +709,7 @@ std::string jsd_sdo_data_type_to_string(jsd_sdo_data_type_t data_type)
       return "U64";
       break;
     default:
-      CFW_WARN("Invalid data type: %d", static_cast<int>(data_type));
+      fprintf(stderr, "Invalid data type: %d\n", static_cast<int>(data_type));
   }
   return "UNSPECIFIED";
 }
@@ -743,7 +746,7 @@ std::string jsd_sdo_data_to_string(jsd_sdo_data_type_t data_type,
       return std::to_string(data.as_u64);
       break;
     default:
-      CFW_WARN("Bad data type");
+      fprintf(stderr, "Bad data type\n");
   }
   return "invalid result";
 }

--- a/src/fcat_utils.cpp
+++ b/src/fcat_utils.cpp
@@ -2,6 +2,8 @@
 
 #include "jsd/jsd_print.h"
 
+#include <cstdio>
+
 fcat_msgs::msg::ActuatorState ActuatorStateToMsg(
   std::shared_ptr<const fastcat::DeviceState> state)
 {
@@ -545,14 +547,16 @@ bool HexOrDecStrToNum(std::string& str, uint16_t& number)
   unsigned long int ulnum = strtoul(str.c_str(), &end, 0);
 
   if (*end == '\0') {
-    CFW_TRACE(
+    fprintf(
+      stderr,
       "HexOrDecStrToNum successfully parsed string (%s) to (%lu or 0x%x)",
       str.c_str(), ulnum, ulnum);
+    fprintf(stderr, "\n");
     number = static_cast<uint16_t>(ulnum);
     success = true;
 
   } else {
-    CFW_TRACE("HexOrDecStrToNum could not parse string (%s)", str.c_str());
+    fprintf(stderr, "HexOrDecStrToNum could not parse string (%s)\n", str.c_str());
   }
 
   return success;
@@ -581,7 +585,8 @@ bool TlcStrToNum(std::string& str, uint16_t& number)
     return false;
   }
 
-  CFW_TRACE("Converted TLC string: (%s) to U16: (0x%X)", str.c_str(), number);
+  fprintf(stderr, "Converted TLC string: (%s) to U16: (0x%X)\n",
+          str.c_str(), number);
   return true;
 }
 

--- a/src/fcat_utils.cpp
+++ b/src/fcat_utils.cpp
@@ -1,12 +1,11 @@
 #include "fcat_utils.hpp"
 
-#include "jsd/jsd_print.h"
-
 #include <cstdio>
 
+#include "jsd/jsd_print.h"
+
 fcat_msgs::msg::ActuatorState ActuatorStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state)
-{
+    std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::ActuatorState();
 
   if (state->type == fastcat::GOLD_ACTUATOR_STATE) {
@@ -19,10 +18,8 @@ fcat_msgs::msg::ActuatorState ActuatorStateToMsg(
     msg.cmd_velocity = state->gold_actuator_state.cmd_velocity;
     msg.cmd_current = state->gold_actuator_state.cmd_current;
     msg.cmd_max_current = state->gold_actuator_state.cmd_max_current;
-    msg.egd_state_machine_state =
-      state->gold_actuator_state.elmo_state_machine_state;
-    msg.egd_mode_of_operation =
-      state->gold_actuator_state.elmo_mode_of_operation;
+    msg.egd_state_machine_state = state->gold_actuator_state.elmo_state_machine_state;
+    msg.egd_mode_of_operation = state->gold_actuator_state.elmo_mode_of_operation;
     msg.sto_engaged = state->gold_actuator_state.sto_engaged;
     msg.hall_state = state->gold_actuator_state.hall_state;
     msg.target_reached = state->gold_actuator_state.target_reached;
@@ -35,8 +32,7 @@ fcat_msgs::msg::ActuatorState ActuatorStateToMsg(
     msg.drive_temperature = state->gold_actuator_state.drive_temperature;
     msg.egd_actual_position = state->gold_actuator_state.elmo_actual_position;
     msg.egd_cmd_position = state->gold_actuator_state.elmo_cmd_position;
-    msg.actuator_state_machine_state =
-      state->gold_actuator_state.actuator_state_machine_state;
+    msg.actuator_state_machine_state = state->gold_actuator_state.actuator_state_machine_state;
   } else if (state->type == fastcat::PLATINUM_ACTUATOR_STATE) {
     msg.read_time = state->time;
     msg.actual_position = state->platinum_actuator_state.actual_position;
@@ -47,10 +43,8 @@ fcat_msgs::msg::ActuatorState ActuatorStateToMsg(
     msg.cmd_velocity = state->platinum_actuator_state.cmd_velocity;
     msg.cmd_current = state->platinum_actuator_state.cmd_current;
     msg.cmd_max_current = state->platinum_actuator_state.cmd_max_current;
-    msg.egd_state_machine_state =
-      state->platinum_actuator_state.elmo_state_machine_state;
-    msg.egd_mode_of_operation =
-      state->platinum_actuator_state.elmo_mode_of_operation;
+    msg.egd_state_machine_state = state->platinum_actuator_state.elmo_state_machine_state;
+    msg.egd_mode_of_operation = state->platinum_actuator_state.elmo_mode_of_operation;
     msg.sto_engaged = state->platinum_actuator_state.sto_engaged;
     msg.hall_state = state->platinum_actuator_state.hall_state;
     msg.target_reached = state->platinum_actuator_state.target_reached;
@@ -61,19 +55,15 @@ fcat_msgs::msg::ActuatorState ActuatorStateToMsg(
     msg.emcy_error_code = state->platinum_actuator_state.emcy_error_code;
     msg.bus_voltage = state->platinum_actuator_state.bus_voltage;
     msg.drive_temperature = state->platinum_actuator_state.drive_temperature;
-    msg.egd_actual_position =
-      state->platinum_actuator_state.elmo_actual_position;
+    msg.egd_actual_position = state->platinum_actuator_state.elmo_actual_position;
     msg.egd_cmd_position = state->platinum_actuator_state.elmo_cmd_position;
-    msg.actuator_state_machine_state =
-      state->platinum_actuator_state.actuator_state_machine_state;
+    msg.actuator_state_machine_state = state->platinum_actuator_state.actuator_state_machine_state;
   }
 
   return msg;
 }
 
-fcat_msgs::msg::EgdState EgdStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state)
-{
+fcat_msgs::msg::EgdState EgdStateToMsg(std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::EgdState();
 
   msg.read_time = state->time;
@@ -117,9 +107,7 @@ fcat_msgs::msg::EgdState EgdStateToMsg(
   return msg;
 }
 
-fcat_msgs::msg::El1008State El1008StateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state)
-{
+fcat_msgs::msg::El1008State El1008StateToMsg(std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::El1008State();
 
   msg.read_time = state->time;
@@ -135,9 +123,7 @@ fcat_msgs::msg::El1008State El1008StateToMsg(
   return msg;
 }
 
-fcat_msgs::msg::El2124State El2124StateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state)
-{
+fcat_msgs::msg::El2124State El2124StateToMsg(std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::El2124State();
 
   msg.read_time = state->time;
@@ -149,9 +135,7 @@ fcat_msgs::msg::El2124State El2124StateToMsg(
   return msg;
 }
 
-fcat_msgs::msg::El2809State El2809StateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state)
-{
+fcat_msgs::msg::El2809State El2809StateToMsg(std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::El2809State();
 
   msg.read_time = state->time;
@@ -175,45 +159,39 @@ fcat_msgs::msg::El2809State El2809StateToMsg(
   return msg;
 }
 
-fcat_msgs::msg::El2798State El2798StateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state)
-{
+fcat_msgs::msg::El2798State El2798StateToMsg(std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::El2798State();
 
-  msg.read_time  = state->time;
-  msg.level_ch1  = state->el2798_state.level_ch1;
-  msg.level_ch2  = state->el2798_state.level_ch2;
-  msg.level_ch3  = state->el2798_state.level_ch3;
-  msg.level_ch4  = state->el2798_state.level_ch4;
-  msg.level_ch5  = state->el2798_state.level_ch5;
-  msg.level_ch6  = state->el2798_state.level_ch6;
-  msg.level_ch7  = state->el2798_state.level_ch7;
-  msg.level_ch8  = state->el2798_state.level_ch8;
+  msg.read_time = state->time;
+  msg.level_ch1 = state->el2798_state.level_ch1;
+  msg.level_ch2 = state->el2798_state.level_ch2;
+  msg.level_ch3 = state->el2798_state.level_ch3;
+  msg.level_ch4 = state->el2798_state.level_ch4;
+  msg.level_ch5 = state->el2798_state.level_ch5;
+  msg.level_ch6 = state->el2798_state.level_ch6;
+  msg.level_ch7 = state->el2798_state.level_ch7;
+  msg.level_ch8 = state->el2798_state.level_ch8;
 
   return msg;
 }
 
-fcat_msgs::msg::El2828State El2828StateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state)
-{
+fcat_msgs::msg::El2828State El2828StateToMsg(std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::El2828State();
 
-  msg.read_time  = state->time;
-  msg.level_ch1  = state->el2828_state.level_ch1;
-  msg.level_ch2  = state->el2828_state.level_ch2;
-  msg.level_ch3  = state->el2828_state.level_ch3;
-  msg.level_ch4  = state->el2828_state.level_ch4;
-  msg.level_ch5  = state->el2828_state.level_ch5;
-  msg.level_ch6  = state->el2828_state.level_ch6;
-  msg.level_ch7  = state->el2828_state.level_ch7;
-  msg.level_ch8  = state->el2828_state.level_ch8;
+  msg.read_time = state->time;
+  msg.level_ch1 = state->el2828_state.level_ch1;
+  msg.level_ch2 = state->el2828_state.level_ch2;
+  msg.level_ch3 = state->el2828_state.level_ch3;
+  msg.level_ch4 = state->el2828_state.level_ch4;
+  msg.level_ch5 = state->el2828_state.level_ch5;
+  msg.level_ch6 = state->el2828_state.level_ch6;
+  msg.level_ch7 = state->el2828_state.level_ch7;
+  msg.level_ch8 = state->el2828_state.level_ch8;
 
   return msg;
 }
 
-fcat_msgs::msg::El3104State El3104StateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state)
-{
+fcat_msgs::msg::El3104State El3104StateToMsg(std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::El3104State();
 
   msg.read_time = state->time;
@@ -229,9 +207,7 @@ fcat_msgs::msg::El3104State El3104StateToMsg(
   return msg;
 }
 
-fcat_msgs::msg::El3162State El3162StateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state)
-{
+fcat_msgs::msg::El3162State El3162StateToMsg(std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::El3162State();
 
   msg.read_time = state->time;
@@ -243,9 +219,7 @@ fcat_msgs::msg::El3162State El3162StateToMsg(
   return msg;
 }
 
-fcat_msgs::msg::El3202State El3202StateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state)
-{
+fcat_msgs::msg::El3202State El3202StateToMsg(std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::El3202State();
 
   msg.read_time = state->time;
@@ -257,9 +231,7 @@ fcat_msgs::msg::El3202State El3202StateToMsg(
   return msg;
 }
 
-fcat_msgs::msg::El3208State El3208StateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state)
-{
+fcat_msgs::msg::El3208State El3208StateToMsg(std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::El3208State();
 
   msg.read_time = state->time;
@@ -283,9 +255,7 @@ fcat_msgs::msg::El3208State El3208StateToMsg(
   return msg;
 }
 
-fcat_msgs::msg::El3314State El3314StateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state)
-{
+fcat_msgs::msg::El3314State El3314StateToMsg(std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::El3314State();
 
   msg.read_time = state->time;
@@ -301,9 +271,7 @@ fcat_msgs::msg::El3314State El3314StateToMsg(
   return msg;
 }
 
-fcat_msgs::msg::El3318State El3318StateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state)
-{
+fcat_msgs::msg::El3318State El3318StateToMsg(std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::El3318State();
 
   msg.read_time = state->time;
@@ -327,9 +295,7 @@ fcat_msgs::msg::El3318State El3318StateToMsg(
   return msg;
 }
 
-fcat_msgs::msg::El3602State El3602StateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state)
-{
+fcat_msgs::msg::El3602State El3602StateToMsg(std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::El3602State();
 
   msg.read_time = state->time;
@@ -341,9 +307,7 @@ fcat_msgs::msg::El3602State El3602StateToMsg(
   return msg;
 }
 
-fcat_msgs::msg::El4102State El4102StateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state)
-{
+fcat_msgs::msg::El4102State El4102StateToMsg(std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::El4102State();
 
   msg.read_time = state->time;
@@ -353,27 +317,23 @@ fcat_msgs::msg::El4102State El4102StateToMsg(
   return msg;
 }
 
-fcat_msgs::msg::El5042State El5042StateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state)
-{
+fcat_msgs::msg::El5042State El5042StateToMsg(std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::El5042State();
 
-  msg.read_time    = state->time;
+  msg.read_time = state->time;
   msg.position_ch1 = state->el5042_state.position_ch1;
-  msg.warning_ch1  = state->el5042_state.warning_ch1;
-  msg.error_ch1    = state->el5042_state.error_ch1;
-  msg.ready_ch1    = state->el5042_state.ready_ch1;
+  msg.warning_ch1 = state->el5042_state.warning_ch1;
+  msg.error_ch1 = state->el5042_state.error_ch1;
+  msg.ready_ch1 = state->el5042_state.ready_ch1;
   msg.position_ch2 = state->el5042_state.position_ch2;
-  msg.warning_ch2  = state->el5042_state.warning_ch2;
-  msg.error_ch2    = state->el5042_state.error_ch2;
-  msg.ready_ch2    = state->el5042_state.ready_ch2;
+  msg.warning_ch2 = state->el5042_state.warning_ch2;
+  msg.error_ch2 = state->el5042_state.error_ch2;
+  msg.ready_ch2 = state->el5042_state.ready_ch2;
 
   return msg;
 }
 
-fcat_msgs::msg::Ild1900State Ild1900StateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state)
-{
+fcat_msgs::msg::Ild1900State Ild1900StateToMsg(std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::Ild1900State();
 
   msg.read_time = state->time;
@@ -388,8 +348,7 @@ fcat_msgs::msg::Ild1900State Ild1900StateToMsg(
 }
 
 fcat_msgs::msg::CommanderState CommanderStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state)
-{
+    std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::CommanderState();
 
   msg.read_time = state->time;
@@ -399,8 +358,7 @@ fcat_msgs::msg::CommanderState CommanderStateToMsg(
 }
 
 fcat_msgs::msg::ConditionalState ConditionalStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state)
-{
+    std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::ConditionalState();
 
   msg.read_time = state->time;
@@ -409,9 +367,7 @@ fcat_msgs::msg::ConditionalState ConditionalStateToMsg(
   return msg;
 }
 
-fcat_msgs::msg::FaulterState FaulterStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state)
-{
+fcat_msgs::msg::FaulterState FaulterStateToMsg(std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::FaulterState();
 
   msg.read_time = state->time;
@@ -421,9 +377,7 @@ fcat_msgs::msg::FaulterState FaulterStateToMsg(
   return msg;
 }
 
-fcat_msgs::msg::FilterState FilterStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state)
-{
+fcat_msgs::msg::FilterState FilterStateToMsg(std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::FilterState();
 
   msg.read_time = state->time;
@@ -432,9 +386,7 @@ fcat_msgs::msg::FilterState FilterStateToMsg(
   return msg;
 }
 
-fcat_msgs::msg::FtsState FtsStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state)
-{
+fcat_msgs::msg::FtsState FtsStateToMsg(std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::FtsState();
 
   msg.read_time = state->time;
@@ -455,8 +407,7 @@ fcat_msgs::msg::FtsState FtsStateToMsg(
 }
 
 fcat_msgs::msg::FunctionState FunctionStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state)
-{
+    std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::FunctionState();
 
   msg.read_time = state->time;
@@ -465,9 +416,7 @@ fcat_msgs::msg::FunctionState FunctionStateToMsg(
   return msg;
 }
 
-fcat_msgs::msg::PidState PidStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state)
-{
+fcat_msgs::msg::PidState PidStateToMsg(std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::PidState();
 
   msg.read_time = state->time;
@@ -481,8 +430,7 @@ fcat_msgs::msg::PidState PidStateToMsg(
 }
 
 fcat_msgs::msg::SaturationState SaturationStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state)
-{
+    std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::SaturationState();
 
   msg.read_time = state->time;
@@ -492,8 +440,7 @@ fcat_msgs::msg::SaturationState SaturationStateToMsg(
 }
 
 fcat_msgs::msg::SchmittTriggerState SchmittTriggerStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state)
-{
+    std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::SchmittTriggerState();
 
   msg.read_time = state->time;
@@ -503,8 +450,7 @@ fcat_msgs::msg::SchmittTriggerState SchmittTriggerStateToMsg(
 }
 
 fcat_msgs::msg::SignalGeneratorState SignalGeneratorStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state)
-{
+    std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::SignalGeneratorState();
 
   msg.read_time = state->time;
@@ -514,8 +460,7 @@ fcat_msgs::msg::SignalGeneratorState SignalGeneratorStateToMsg(
 }
 
 fcat_msgs::msg::LinearInterpolationState LinearInterpolationStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state)
-{
+    std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::LinearInterpolationState();
 
   msg.read_time = state->time;
@@ -526,8 +471,7 @@ fcat_msgs::msg::LinearInterpolationState LinearInterpolationStateToMsg(
 }
 
 fcat_msgs::msg::ThreeNodeThermalModelState ThreeNodeThermalModelStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state)
-{
+    std::shared_ptr<const fastcat::DeviceState> state) {
   auto msg = fcat_msgs::msg::ThreeNodeThermalModelState();
 
   msg.read_time = state->time;
@@ -539,18 +483,15 @@ fcat_msgs::msg::ThreeNodeThermalModelState ThreeNodeThermalModelStateToMsg(
   return msg;
 }
 
-bool HexOrDecStrToNum(std::string& str, uint16_t& number)
-{
+bool HexOrDecStrToNum(std::string& str, uint16_t& number) {
   char* end;
   bool success = false;
 
   unsigned long int ulnum = strtoul(str.c_str(), &end, 0);
 
   if (*end == '\0') {
-    fprintf(
-      stderr,
-      "HexOrDecStrToNum successfully parsed string (%s) to (%lu or 0x%lx)",
-      str.c_str(), ulnum, ulnum);
+    fprintf(stderr, "HexOrDecStrToNum successfully parsed string (%s) to (%lu or 0x%lx)",
+            str.c_str(), ulnum, ulnum);
     fprintf(stderr, "\n");
     number = static_cast<uint16_t>(ulnum);
     success = true;
@@ -562,39 +503,33 @@ bool HexOrDecStrToNum(std::string& str, uint16_t& number)
   return success;
 }
 
-bool TlcStrToNum(std::string& str, uint16_t& number)
-{
+bool TlcStrToNum(std::string& str, uint16_t& number) {
   if (str.size() != 2) {
-    fprintf(stderr, "TLC string: (%s) must be 2 chars. size: (%zu)\n",
-            str.c_str(), str.size());
+    fprintf(stderr, "TLC string: (%s) must be 2 chars. size: (%zu)\n", str.c_str(), str.size());
     return false;
   }
 
   if ((str[0] < 'A') || (str[0] > 'Z') || (str[1] < 'A') || (str[1] > 'Z')) {
-    fprintf(stderr, "TLC string: (%s) must be upper chars [A-Z]\n",
-            str.c_str());
+    fprintf(stderr, "TLC string: (%s) must be upper chars [A-Z]\n", str.c_str());
     return false;
   }
 
   number = 0x3000 + (26 * (str[0] - 65)) + (str[1] - 65);
 
   if (number < 0x3000 || number > 0x3FFF) {
-    fprintf(
-      stderr,
-      "TLC conversion is out of range: %s -> 0x%X not in "
-      "range (0x3000,0x3FFF)",
-      str.c_str(), number);
+    fprintf(stderr,
+            "TLC conversion is out of range: %s -> 0x%X not in "
+            "range (0x3000,0x3FFF)",
+            str.c_str(), number);
     fprintf(stderr, "\n");
     return false;
   }
 
-  fprintf(stderr, "Converted TLC string: (%s) to U16: (0x%X)\n",
-          str.c_str(), number);
+  fprintf(stderr, "Converted TLC string: (%s) to U16: (0x%X)\n", str.c_str(), number);
   return true;
 }
 
-jsd_sdo_data_type_t jsd_sdo_data_type_from_string(std::string& str)
-{
+jsd_sdo_data_type_t jsd_sdo_data_type_from_string(std::string& str) {
   jsd_sdo_data_type_t type = {};
 
   if (0 == str.compare("I8")) {
@@ -622,9 +557,7 @@ jsd_sdo_data_type_t jsd_sdo_data_type_from_string(std::string& str)
   return type;
 }
 
-jsd_sdo_data_t jsd_sdo_data_from_string(jsd_sdo_data_type_t& type,
-                                        std::string& str)
-{
+jsd_sdo_data_t jsd_sdo_data_from_string(jsd_sdo_data_type_t& type, std::string& str) {
   jsd_sdo_data_t data = {};
 
   switch (type) {
@@ -661,8 +594,7 @@ jsd_sdo_data_t jsd_sdo_data_from_string(jsd_sdo_data_type_t& type,
   return data;
 }
 
-std::string jsd_sdo_request_type_to_string(jsd_sdo_req_type_t req_type)
-{
+std::string jsd_sdo_request_type_to_string(jsd_sdo_req_type_t req_type) {
   switch (req_type) {
     case JSD_SDO_REQ_TYPE_READ:
       return "READ";
@@ -678,8 +610,7 @@ std::string jsd_sdo_request_type_to_string(jsd_sdo_req_type_t req_type)
   return "INVALID";
 }
 
-std::string jsd_sdo_data_type_to_string(jsd_sdo_data_type_t data_type)
-{
+std::string jsd_sdo_data_type_to_string(jsd_sdo_data_type_t data_type) {
   switch (data_type) {
     case JSD_SDO_DATA_I8:
       return "I8";
@@ -714,9 +645,7 @@ std::string jsd_sdo_data_type_to_string(jsd_sdo_data_type_t data_type)
   return "UNSPECIFIED";
 }
 
-std::string jsd_sdo_data_to_string(jsd_sdo_data_type_t data_type,
-                                   jsd_sdo_data_t data)
-{
+std::string jsd_sdo_data_to_string(jsd_sdo_data_type_t data_type, jsd_sdo_data_t data) {
   switch (data_type) {
     case JSD_SDO_DATA_I8:
       return std::to_string(data.as_i8);

--- a/src/fcat_utils.cpp
+++ b/src/fcat_utils.cpp
@@ -549,7 +549,7 @@ bool HexOrDecStrToNum(std::string& str, uint16_t& number)
   if (*end == '\0') {
     fprintf(
       stderr,
-      "HexOrDecStrToNum successfully parsed string (%s) to (%lu or 0x%x)",
+      "HexOrDecStrToNum successfully parsed string (%s) to (%lu or 0x%lx)",
       str.c_str(), ulnum, ulnum);
     fprintf(stderr, "\n");
     number = static_cast<uint16_t>(ulnum);

--- a/src/fcat_utils.cpp
+++ b/src/fcat_utils.cpp
@@ -1,5 +1,8 @@
+// Copyright 2021 California Institute of Technology
+
 #include "fcat_utils.hpp"
 
+#include <cinttypes>
 #include <cstdio>
 
 #include "jsd/jsd_print.h"
@@ -487,10 +490,11 @@ bool HexOrDecStrToNum(std::string& str, uint16_t& number) {
   char* end;
   bool success = false;
 
-  unsigned long int ulnum = strtoul(str.c_str(), &end, 0);
+  uint64_t ulnum = strtoul(str.c_str(), &end, 0);
 
   if (*end == '\0') {
-    fprintf(stderr, "HexOrDecStrToNum successfully parsed string (%s) to (%lu or 0x%lx)",
+    fprintf(stderr,
+            "HexOrDecStrToNum successfully parsed string (%s) to (%" PRIu64 " or 0x%" PRIx64 ")",
             str.c_str(), ulnum, ulnum);
     fprintf(stderr, "\n");
     number = static_cast<uint16_t>(ulnum);

--- a/src/fcat_utils.cpp
+++ b/src/fcat_utils.cpp
@@ -1,0 +1,744 @@
+#include "fcat_utils.hpp"
+
+#include "jsd/jsd_print.h"
+
+fcat_msgs::msg::ActuatorState ActuatorStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::ActuatorState();
+
+  if (state->type == fastcat::GOLD_ACTUATOR_STATE) {
+    msg.read_time = state->time;
+    msg.actual_position = state->gold_actuator_state.actual_position;
+    msg.actual_velocity = state->gold_actuator_state.actual_velocity;
+    msg.actual_current = state->gold_actuator_state.actual_current;
+    msg.faulted = state->gold_actuator_state.faulted;
+    msg.cmd_position = state->gold_actuator_state.cmd_position;
+    msg.cmd_velocity = state->gold_actuator_state.cmd_velocity;
+    msg.cmd_current = state->gold_actuator_state.cmd_current;
+    msg.cmd_max_current = state->gold_actuator_state.cmd_max_current;
+    msg.egd_state_machine_state =
+      state->gold_actuator_state.elmo_state_machine_state;
+    msg.egd_mode_of_operation =
+      state->gold_actuator_state.elmo_mode_of_operation;
+    msg.sto_engaged = state->gold_actuator_state.sto_engaged;
+    msg.hall_state = state->gold_actuator_state.hall_state;
+    msg.target_reached = state->gold_actuator_state.target_reached;
+    msg.motor_on = state->gold_actuator_state.motor_on;
+    msg.servo_enabled = state->gold_actuator_state.servo_enabled;
+    msg.jsd_fault_code = state->gold_actuator_state.jsd_fault_code;
+    msg.fastcat_fault_code = state->gold_actuator_state.fastcat_fault_code;
+    msg.emcy_error_code = state->gold_actuator_state.emcy_error_code;
+    msg.bus_voltage = state->gold_actuator_state.bus_voltage;
+    msg.drive_temperature = state->gold_actuator_state.drive_temperature;
+    msg.egd_actual_position = state->gold_actuator_state.elmo_actual_position;
+    msg.egd_cmd_position = state->gold_actuator_state.elmo_cmd_position;
+    msg.actuator_state_machine_state =
+      state->gold_actuator_state.actuator_state_machine_state;
+  } else if (state->type == fastcat::PLATINUM_ACTUATOR_STATE) {
+    msg.read_time = state->time;
+    msg.actual_position = state->platinum_actuator_state.actual_position;
+    msg.actual_velocity = state->platinum_actuator_state.actual_velocity;
+    msg.actual_current = state->platinum_actuator_state.actual_current;
+    msg.faulted = state->platinum_actuator_state.faulted;
+    msg.cmd_position = state->platinum_actuator_state.cmd_position;
+    msg.cmd_velocity = state->platinum_actuator_state.cmd_velocity;
+    msg.cmd_current = state->platinum_actuator_state.cmd_current;
+    msg.cmd_max_current = state->platinum_actuator_state.cmd_max_current;
+    msg.egd_state_machine_state =
+      state->platinum_actuator_state.elmo_state_machine_state;
+    msg.egd_mode_of_operation =
+      state->platinum_actuator_state.elmo_mode_of_operation;
+    msg.sto_engaged = state->platinum_actuator_state.sto_engaged;
+    msg.hall_state = state->platinum_actuator_state.hall_state;
+    msg.target_reached = state->platinum_actuator_state.target_reached;
+    msg.motor_on = state->platinum_actuator_state.motor_on;
+    msg.servo_enabled = state->platinum_actuator_state.servo_enabled;
+    msg.jsd_fault_code = state->platinum_actuator_state.jsd_fault_code;
+    msg.fastcat_fault_code = state->platinum_actuator_state.fastcat_fault_code;
+    msg.emcy_error_code = state->platinum_actuator_state.emcy_error_code;
+    msg.bus_voltage = state->platinum_actuator_state.bus_voltage;
+    msg.drive_temperature = state->platinum_actuator_state.drive_temperature;
+    msg.egd_actual_position =
+      state->platinum_actuator_state.elmo_actual_position;
+    msg.egd_cmd_position = state->platinum_actuator_state.elmo_cmd_position;
+    msg.actuator_state_machine_state =
+      state->platinum_actuator_state.actuator_state_machine_state;
+  }
+
+  return msg;
+}
+
+fcat_msgs::msg::EgdState EgdStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::EgdState();
+
+  msg.read_time = state->time;
+  msg.actual_position = state->egd_state.actual_position;
+  msg.actual_velocity = state->egd_state.actual_velocity;
+  msg.actual_current = state->egd_state.actual_current;
+  msg.faulted = state->egd_state.faulted;
+  msg.cmd_position = state->egd_state.cmd_position;
+  msg.cmd_velocity = state->egd_state.cmd_velocity;
+  msg.cmd_current = state->egd_state.cmd_current;
+  msg.cmd_max_current = state->egd_state.cmd_max_current;
+  msg.cmd_ff_position = state->egd_state.cmd_ff_position;
+  msg.cmd_ff_velocity = state->egd_state.cmd_ff_velocity;
+  msg.cmd_ff_current = state->egd_state.cmd_ff_current;
+  msg.actual_state_machine_state = state->egd_state.actual_state_machine_state;
+  msg.actual_mode_of_operation = state->egd_state.actual_mode_of_operation;
+  msg.sto_engaged = state->egd_state.sto_engaged;
+  msg.hall_state = state->egd_state.hall_state;
+  msg.in_motion = state->egd_state.in_motion;
+  msg.warning = state->egd_state.warning;
+  msg.target_reached = state->egd_state.target_reached;
+  msg.motor_on = state->egd_state.motor_on;
+  msg.fault_code = state->egd_state.fault_code;
+  msg.emcy_error_code = state->egd_state.emcy_error_code;
+  msg.bus_voltage = state->egd_state.bus_voltage;
+  msg.analog_input_voltage = state->egd_state.analog_input_voltage;
+  msg.digital_input_ch1 = state->egd_state.digital_input_ch1;
+  msg.digital_input_ch2 = state->egd_state.digital_input_ch2;
+  msg.digital_input_ch3 = state->egd_state.digital_input_ch3;
+  msg.digital_input_ch4 = state->egd_state.digital_input_ch4;
+  msg.digital_input_ch5 = state->egd_state.digital_input_ch5;
+  msg.digital_input_ch6 = state->egd_state.digital_input_ch6;
+  msg.digital_output_cmd_ch1 = state->egd_state.digital_output_cmd_ch1;
+  msg.digital_output_cmd_ch2 = state->egd_state.digital_output_cmd_ch2;
+  msg.digital_output_cmd_ch3 = state->egd_state.digital_output_cmd_ch3;
+  msg.digital_output_cmd_ch4 = state->egd_state.digital_output_cmd_ch4;
+  msg.digital_output_cmd_ch5 = state->egd_state.digital_output_cmd_ch5;
+  msg.digital_output_cmd_ch6 = state->egd_state.digital_output_cmd_ch6;
+  msg.drive_temperature = state->egd_state.drive_temperature;
+
+  return msg;
+}
+
+fcat_msgs::msg::El1008State El1008StateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::El1008State();
+
+  msg.read_time = state->time;
+  msg.level_ch1 = state->el1008_state.level_ch1;
+  msg.level_ch2 = state->el1008_state.level_ch2;
+  msg.level_ch3 = state->el1008_state.level_ch3;
+  msg.level_ch4 = state->el1008_state.level_ch4;
+  msg.level_ch5 = state->el1008_state.level_ch5;
+  msg.level_ch6 = state->el1008_state.level_ch6;
+  msg.level_ch7 = state->el1008_state.level_ch7;
+  msg.level_ch8 = state->el1008_state.level_ch8;
+
+  return msg;
+}
+
+fcat_msgs::msg::El2124State El2124StateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::El2124State();
+
+  msg.read_time = state->time;
+  msg.level_ch1 = state->el2124_state.level_ch1;
+  msg.level_ch2 = state->el2124_state.level_ch2;
+  msg.level_ch3 = state->el2124_state.level_ch3;
+  msg.level_ch4 = state->el2124_state.level_ch4;
+
+  return msg;
+}
+
+fcat_msgs::msg::El2809State El2809StateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::El2809State();
+
+  msg.read_time = state->time;
+  msg.level_ch1 = state->el2809_state.level_ch1;
+  msg.level_ch2 = state->el2809_state.level_ch2;
+  msg.level_ch3 = state->el2809_state.level_ch3;
+  msg.level_ch4 = state->el2809_state.level_ch4;
+  msg.level_ch5 = state->el2809_state.level_ch5;
+  msg.level_ch6 = state->el2809_state.level_ch6;
+  msg.level_ch7 = state->el2809_state.level_ch7;
+  msg.level_ch8 = state->el2809_state.level_ch8;
+  msg.level_ch9 = state->el2809_state.level_ch9;
+  msg.level_ch10 = state->el2809_state.level_ch10;
+  msg.level_ch11 = state->el2809_state.level_ch11;
+  msg.level_ch12 = state->el2809_state.level_ch12;
+  msg.level_ch13 = state->el2809_state.level_ch13;
+  msg.level_ch14 = state->el2809_state.level_ch14;
+  msg.level_ch15 = state->el2809_state.level_ch15;
+  msg.level_ch16 = state->el2809_state.level_ch16;
+
+  return msg;
+}
+
+fcat_msgs::msg::El2798State El2798StateToMsg(
+    std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::El2798State();
+
+  msg.read_time  = state->time;
+  msg.level_ch1  = state->el2798_state.level_ch1;
+  msg.level_ch2  = state->el2798_state.level_ch2;
+  msg.level_ch3  = state->el2798_state.level_ch3;
+  msg.level_ch4  = state->el2798_state.level_ch4;
+  msg.level_ch5  = state->el2798_state.level_ch5;
+  msg.level_ch6  = state->el2798_state.level_ch6;
+  msg.level_ch7  = state->el2798_state.level_ch7;
+  msg.level_ch8  = state->el2798_state.level_ch8;
+
+  return msg;
+}
+
+fcat_msgs::msg::El2828State El2828StateToMsg(
+    std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::El2828State();
+
+  msg.read_time  = state->time;
+  msg.level_ch1  = state->el2828_state.level_ch1;
+  msg.level_ch2  = state->el2828_state.level_ch2;
+  msg.level_ch3  = state->el2828_state.level_ch3;
+  msg.level_ch4  = state->el2828_state.level_ch4;
+  msg.level_ch5  = state->el2828_state.level_ch5;
+  msg.level_ch6  = state->el2828_state.level_ch6;
+  msg.level_ch7  = state->el2828_state.level_ch7;
+  msg.level_ch8  = state->el2828_state.level_ch8;
+
+  return msg;
+}
+
+fcat_msgs::msg::El3104State El3104StateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::El3104State();
+
+  msg.read_time = state->time;
+  msg.voltage_ch1 = state->el3104_state.voltage_ch1;
+  msg.voltage_ch2 = state->el3104_state.voltage_ch2;
+  msg.voltage_ch3 = state->el3104_state.voltage_ch3;
+  msg.voltage_ch4 = state->el3104_state.voltage_ch4;
+  msg.adc_value_ch1 = state->el3104_state.adc_value_ch1;
+  msg.adc_value_ch2 = state->el3104_state.adc_value_ch2;
+  msg.adc_value_ch3 = state->el3104_state.adc_value_ch3;
+  msg.adc_value_ch4 = state->el3104_state.adc_value_ch4;
+
+  return msg;
+}
+
+fcat_msgs::msg::El3162State El3162StateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::El3162State();
+
+  msg.read_time = state->time;
+  msg.voltage_ch1 = state->el3162_state.voltage_ch1;
+  msg.adc_value_ch1 = state->el3162_state.adc_value_ch1;
+  msg.voltage_ch2 = state->el3162_state.voltage_ch2;
+  msg.adc_value_ch2 = state->el3162_state.adc_value_ch2;
+
+  return msg;
+}
+
+fcat_msgs::msg::El3202State El3202StateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::El3202State();
+
+  msg.read_time = state->time;
+  msg.output_ch1 = state->el3202_state.output_eu_ch1;
+  msg.adc_value_ch1 = state->el3202_state.adc_value_ch1;
+  msg.output_ch2 = state->el3202_state.output_eu_ch2;
+  msg.adc_value_ch2 = state->el3202_state.adc_value_ch2;
+
+  return msg;
+}
+
+fcat_msgs::msg::El3208State El3208StateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::El3208State();
+
+  msg.read_time = state->time;
+  msg.output_ch1 = state->el3208_state.output_ch1;
+  msg.adc_value_ch1 = state->el3208_state.adc_value_ch1;
+  msg.output_ch2 = state->el3208_state.output_ch2;
+  msg.adc_value_ch2 = state->el3208_state.adc_value_ch2;
+  msg.output_ch3 = state->el3208_state.output_ch3;
+  msg.adc_value_ch3 = state->el3208_state.adc_value_ch3;
+  msg.output_ch4 = state->el3208_state.output_ch4;
+  msg.adc_value_ch4 = state->el3208_state.adc_value_ch4;
+  msg.output_ch5 = state->el3208_state.output_ch5;
+  msg.adc_value_ch5 = state->el3208_state.adc_value_ch5;
+  msg.output_ch6 = state->el3208_state.output_ch6;
+  msg.adc_value_ch6 = state->el3208_state.adc_value_ch6;
+  msg.output_ch7 = state->el3208_state.output_ch7;
+  msg.adc_value_ch7 = state->el3208_state.adc_value_ch7;
+  msg.output_ch8 = state->el3208_state.output_ch8;
+  msg.adc_value_ch8 = state->el3208_state.adc_value_ch8;
+
+  return msg;
+}
+
+fcat_msgs::msg::El3314State El3314StateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::El3314State();
+
+  msg.read_time = state->time;
+  msg.output_ch1 = state->el3314_state.output_eu_ch1;
+  msg.adc_value_ch1 = state->el3314_state.adc_value_ch1;
+  msg.output_ch2 = state->el3314_state.output_eu_ch2;
+  msg.adc_value_ch2 = state->el3314_state.adc_value_ch2;
+  msg.output_ch3 = state->el3314_state.output_eu_ch3;
+  msg.adc_value_ch3 = state->el3314_state.adc_value_ch3;
+  msg.output_ch4 = state->el3314_state.output_eu_ch4;
+  msg.adc_value_ch4 = state->el3314_state.adc_value_ch4;
+
+  return msg;
+}
+
+fcat_msgs::msg::El3318State El3318StateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::El3318State();
+
+  msg.read_time = state->time;
+  msg.output_ch1 = state->el3318_state.output_eu_ch1;
+  msg.adc_value_ch1 = state->el3318_state.adc_value_ch1;
+  msg.output_ch2 = state->el3318_state.output_eu_ch2;
+  msg.adc_value_ch2 = state->el3318_state.adc_value_ch2;
+  msg.output_ch3 = state->el3318_state.output_eu_ch3;
+  msg.adc_value_ch3 = state->el3318_state.adc_value_ch3;
+  msg.output_ch4 = state->el3318_state.output_eu_ch4;
+  msg.adc_value_ch4 = state->el3318_state.adc_value_ch4;
+  msg.output_ch5 = state->el3318_state.output_eu_ch5;
+  msg.adc_value_ch5 = state->el3318_state.adc_value_ch5;
+  msg.output_ch6 = state->el3318_state.output_eu_ch6;
+  msg.adc_value_ch6 = state->el3318_state.adc_value_ch6;
+  msg.output_ch7 = state->el3318_state.output_eu_ch7;
+  msg.adc_value_ch7 = state->el3318_state.adc_value_ch7;
+  msg.output_ch8 = state->el3318_state.output_eu_ch8;
+  msg.adc_value_ch8 = state->el3318_state.adc_value_ch8;
+
+  return msg;
+}
+
+fcat_msgs::msg::El3602State El3602StateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::El3602State();
+
+  msg.read_time = state->time;
+  msg.voltage_ch1 = state->el3602_state.voltage_ch1;
+  msg.adc_value_ch1 = state->el3602_state.adc_value_ch1;
+  msg.voltage_ch2 = state->el3602_state.voltage_ch2;
+  msg.adc_value_ch2 = state->el3602_state.adc_value_ch2;
+
+  return msg;
+}
+
+fcat_msgs::msg::El4102State El4102StateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::El4102State();
+
+  msg.read_time = state->time;
+  msg.voltage_output_ch1 = state->el4102_state.voltage_output_ch1;
+  msg.voltage_output_ch2 = state->el4102_state.voltage_output_ch2;
+
+  return msg;
+}
+
+fcat_msgs::msg::El5042State El5042StateToMsg(
+    std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::El5042State();
+
+  msg.read_time    = state->time;
+  msg.position_ch1 = state->el5042_state.position_ch1;
+  msg.warning_ch1  = state->el5042_state.warning_ch1;
+  msg.error_ch1    = state->el5042_state.error_ch1;
+  msg.ready_ch1    = state->el5042_state.ready_ch1;
+  msg.position_ch2 = state->el5042_state.position_ch2;
+  msg.warning_ch2  = state->el5042_state.warning_ch2;
+  msg.error_ch2    = state->el5042_state.error_ch2;
+  msg.ready_ch2    = state->el5042_state.ready_ch2;
+
+  return msg;
+}
+
+fcat_msgs::msg::Ild1900State Ild1900StateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::Ild1900State();
+
+  msg.read_time = state->time;
+  msg.distance_m = state->ild1900_state.distance_m;
+  msg.intensity = state->ild1900_state.intensity;
+  msg.distance_raw = state->ild1900_state.distance_raw;
+  msg.sensor_timestamp_us = state->ild1900_state.timestamp_us;
+  msg.counter = state->ild1900_state.counter;
+  msg.error = state->ild1900_state.error;
+
+  return msg;
+}
+
+fcat_msgs::msg::CommanderState CommanderStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::CommanderState();
+
+  msg.read_time = state->time;
+  msg.enable = state->commander_state.enable;
+
+  return msg;
+}
+
+fcat_msgs::msg::ConditionalState ConditionalStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::ConditionalState();
+
+  msg.read_time = state->time;
+  msg.output = state->conditional_state.output;
+
+  return msg;
+}
+
+fcat_msgs::msg::FaulterState FaulterStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::FaulterState();
+
+  msg.read_time = state->time;
+  msg.enable = state->faulter_state.enable;
+  msg.fault_active = state->faulter_state.fault_active;
+
+  return msg;
+}
+
+fcat_msgs::msg::FilterState FilterStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::FilterState();
+
+  msg.read_time = state->time;
+  msg.output = state->filter_state.output;
+
+  return msg;
+}
+
+fcat_msgs::msg::FtsState FtsStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::FtsState();
+
+  msg.read_time = state->time;
+  msg.raw_fx = state->fts_state.raw_fx;
+  msg.raw_fy = state->fts_state.raw_fy;
+  msg.raw_fz = state->fts_state.raw_fz;
+  msg.raw_tx = state->fts_state.raw_tx;
+  msg.raw_ty = state->fts_state.raw_ty;
+  msg.raw_tz = state->fts_state.raw_tz;
+  msg.tared_fx = state->fts_state.tared_fx;
+  msg.tared_fy = state->fts_state.tared_fy;
+  msg.tared_fz = state->fts_state.tared_fz;
+  msg.tared_tx = state->fts_state.tared_tx;
+  msg.tared_ty = state->fts_state.tared_ty;
+  msg.tared_tz = state->fts_state.tared_tz;
+
+  return msg;
+}
+
+fcat_msgs::msg::FunctionState FunctionStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::FunctionState();
+
+  msg.read_time = state->time;
+  msg.output = state->function_state.output;
+
+  return msg;
+}
+
+fcat_msgs::msg::PidState PidStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::PidState();
+
+  msg.read_time = state->time;
+  msg.active = state->pid_state.active;
+  msg.output = state->pid_state.output;
+  msg.kp_term = state->pid_state.kp_term;
+  msg.ki_term = state->pid_state.ki_term;
+  msg.kd_term = state->pid_state.kd_term;
+
+  return msg;
+}
+
+fcat_msgs::msg::SaturationState SaturationStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::SaturationState();
+
+  msg.read_time = state->time;
+  msg.output = state->saturation_state.output;
+
+  return msg;
+}
+
+fcat_msgs::msg::SchmittTriggerState SchmittTriggerStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::SchmittTriggerState();
+
+  msg.read_time = state->time;
+  msg.output = state->schmitt_trigger_state.output;
+
+  return msg;
+}
+
+fcat_msgs::msg::SignalGeneratorState SignalGeneratorStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::SignalGeneratorState();
+
+  msg.read_time = state->time;
+  msg.output = state->signal_generator_state.output;
+
+  return msg;
+}
+
+fcat_msgs::msg::LinearInterpolationState LinearInterpolationStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::LinearInterpolationState();
+
+  msg.read_time = state->time;
+  msg.output = state->linear_interpolation_state.output;
+  msg.is_saturated = state->linear_interpolation_state.is_saturated;
+
+  return msg;
+}
+
+fcat_msgs::msg::ThreeNodeThermalModelState ThreeNodeThermalModelStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state)
+{
+  auto msg = fcat_msgs::msg::ThreeNodeThermalModelState();
+
+  msg.read_time = state->time;
+  msg.node_1_temp = state->three_node_thermal_model_state.node_1_temp;
+  msg.node_2_temp = state->three_node_thermal_model_state.node_2_temp;
+  msg.node_3_temp = state->three_node_thermal_model_state.node_3_temp;
+  msg.node_4_temp = state->three_node_thermal_model_state.node_4_temp;
+
+  return msg;
+}
+
+bool HexOrDecStrToNum(std::string& str, uint16_t& number)
+{
+  char* end;
+  bool success = false;
+
+  unsigned long int ulnum = strtoul(str.c_str(), &end, 0);
+
+  if (*end == '\0') {
+    CFW_TRACE(
+      "HexOrDecStrToNum successfully parsed string (%s) to (%lu or 0x%x)",
+      str.c_str(), ulnum, ulnum);
+    number = static_cast<uint16_t>(ulnum);
+    success = true;
+
+  } else {
+    CFW_TRACE("HexOrDecStrToNum could not parse string (%s)", str.c_str());
+  }
+
+  return success;
+}
+
+bool TlcStrToNum(std::string& str, uint16_t& number)
+{
+  if (str.size() != 2) {
+    CFW_WARN("TLC string: (%s) must be 2 chars. size: (%zu)", str.c_str(),
+             str.size());
+    return false;
+  }
+
+  if ((str[0] < 'A') || (str[0] > 'Z') || (str[1] < 'A') || (str[1] > 'Z')) {
+    CFW_WARN("TLC string: (%s) must be upper chars [A-Z]", str.c_str());
+    return false;
+  }
+
+  number = 0x3000 + (26 * (str[0] - 65)) + (str[1] - 65);
+
+  if (number < 0x3000 || number > 0x3FFF) {
+    CFW_WARN(
+      "TLC conversion is out of range: %s -> 0x%X not in "
+      "range (0x3000,0x3FFF)",
+      str.c_str(), number);
+    return false;
+  }
+
+  CFW_TRACE("Converted TLC string: (%s) to U16: (0x%X)", str.c_str(), number);
+  return true;
+}
+
+jsd_sdo_data_type_t jsd_sdo_data_type_from_string(std::string& str)
+{
+  jsd_sdo_data_type_t type = {};
+
+  if (0 == str.compare("I8")) {
+    type = JSD_SDO_DATA_I8;
+  } else if (0 == str.compare("I16")) {
+    type = JSD_SDO_DATA_I16;
+  } else if (0 == str.compare("I32")) {
+    type = JSD_SDO_DATA_I32;
+  } else if (0 == str.compare("I64")) {
+    type = JSD_SDO_DATA_I64;
+  } else if (0 == str.compare("F32")) {
+    type = JSD_SDO_DATA_FLOAT;
+  } else if (0 == str.compare("U8")) {
+    type = JSD_SDO_DATA_U8;
+  } else if (0 == str.compare("U16")) {
+    type = JSD_SDO_DATA_U16;
+  } else if (0 == str.compare("U32")) {
+    type = JSD_SDO_DATA_U32;
+  } else if (0 == str.compare("U64")) {
+    type = JSD_SDO_DATA_U64;
+  } else {
+    type = JSD_SDO_DATA_UNSPECIFIED;
+  }
+
+  return type;
+}
+
+jsd_sdo_data_t jsd_sdo_data_from_string(jsd_sdo_data_type_t& type,
+                                        std::string& str)
+{
+  jsd_sdo_data_t data = {};
+
+  switch (type) {
+    case JSD_SDO_DATA_I8:
+      data.as_i8 = static_cast<int8_t>(atoi(str.c_str()));
+      break;
+    case JSD_SDO_DATA_I16:
+      data.as_i16 = static_cast<int16_t>(atoi(str.c_str()));
+      break;
+    case JSD_SDO_DATA_I32:
+      data.as_i32 = static_cast<int32_t>(atol(str.c_str()));
+      break;
+    case JSD_SDO_DATA_I64:
+      data.as_i64 = static_cast<int64_t>(atoll(str.c_str()));
+      break;
+    case JSD_SDO_DATA_FLOAT:
+      data.as_float = static_cast<float>(atof(str.c_str()));
+      break;
+    case JSD_SDO_DATA_U8:
+      data.as_u8 = static_cast<uint8_t>(atoi(str.c_str()));
+      break;
+    case JSD_SDO_DATA_U16:
+      data.as_u16 = static_cast<uint16_t>(atol(str.c_str()));
+      break;
+    case JSD_SDO_DATA_U32:
+      data.as_u32 = static_cast<uint32_t>(atoll(str.c_str()));
+      break;
+    case JSD_SDO_DATA_U64:
+      data.as_u64 = static_cast<uint64_t>(atoll(str.c_str()));
+      break;
+    default:
+      CFW_WARN("SDO data type: %d", static_cast<int>(type));
+  }
+  return data;
+}
+
+std::string jsd_sdo_request_type_to_string(jsd_sdo_req_type_t req_type)
+{
+  switch (req_type) {
+    case JSD_SDO_REQ_TYPE_READ:
+      return "READ";
+      break;
+
+    case JSD_SDO_REQ_TYPE_WRITE:
+      return "WRITE";
+      break;
+
+    default:
+      CFW_WARN("Invalid request type: %d", static_cast<int>(req_type));
+  }
+  return "INVALID";
+}
+
+std::string jsd_sdo_data_type_to_string(jsd_sdo_data_type_t data_type)
+{
+  switch (data_type) {
+    case JSD_SDO_DATA_I8:
+      return "I8";
+      break;
+    case JSD_SDO_DATA_I16:
+      return "I16";
+      break;
+    case JSD_SDO_DATA_I32:
+      return "I32";
+      break;
+    case JSD_SDO_DATA_I64:
+      return "I64";
+      break;
+    case JSD_SDO_DATA_FLOAT:
+      return "F32";
+      break;
+    case JSD_SDO_DATA_U8:
+      return "U8";
+      break;
+    case JSD_SDO_DATA_U16:
+      return "U16";
+      break;
+    case JSD_SDO_DATA_U32:
+      return "U32";
+      break;
+    case JSD_SDO_DATA_U64:
+      return "U64";
+      break;
+    default:
+      CFW_WARN("Invalid data type: %d", static_cast<int>(data_type));
+  }
+  return "UNSPECIFIED";
+}
+
+std::string jsd_sdo_data_to_string(jsd_sdo_data_type_t data_type,
+                                   jsd_sdo_data_t data)
+{
+  switch (data_type) {
+    case JSD_SDO_DATA_I8:
+      return std::to_string(data.as_i8);
+      break;
+    case JSD_SDO_DATA_I16:
+      return std::to_string(data.as_i16);
+      break;
+    case JSD_SDO_DATA_I32:
+      return std::to_string(data.as_i32);
+      break;
+    case JSD_SDO_DATA_I64:
+      return std::to_string(data.as_i64);
+      break;
+    case JSD_SDO_DATA_FLOAT:
+      return std::to_string(data.as_float);
+      break;
+    case JSD_SDO_DATA_U8:
+      return std::to_string(data.as_u8);
+      break;
+    case JSD_SDO_DATA_U16:
+      return std::to_string(data.as_u16);
+      break;
+    case JSD_SDO_DATA_U32:
+      return std::to_string(data.as_u32);
+      break;
+    case JSD_SDO_DATA_U64:
+      return std::to_string(data.as_u64);
+      break;
+    default:
+      CFW_WARN("Bad data type");
+  }
+  return "invalid result";
+}

--- a/src/fcat_utils.hpp
+++ b/src/fcat_utils.hpp
@@ -1,0 +1,137 @@
+#ifndef FCAT__FCAT_UTILS_HPP_
+#define FCAT__FCAT_UTILS_HPP_
+
+#include "fcat_msgs/msg/actuator_states.hpp"
+#include "fcat_msgs/msg/egd_states.hpp"
+#include "fcat_msgs/msg/el1008_states.hpp"
+#include "fcat_msgs/msg/el2124_states.hpp"
+#include "fcat_msgs/msg/el2809_states.hpp"
+#include "fcat_msgs/msg/el2798_states.hpp"
+#include "fcat_msgs/msg/el2828_states.hpp"
+#include "fcat_msgs/msg/el3104_states.hpp"
+#include "fcat_msgs/msg/el3162_states.hpp"
+#include "fcat_msgs/msg/el3202_states.hpp"
+#include "fcat_msgs/msg/el3208_states.hpp"
+#include "fcat_msgs/msg/el3314_states.hpp"
+#include "fcat_msgs/msg/el3318_states.hpp"
+#include "fcat_msgs/msg/el3602_states.hpp"
+#include "fcat_msgs/msg/el4102_states.hpp"
+#include "fcat_msgs/msg/el5042_states.hpp"
+#include "fcat_msgs/msg/ild1900_states.hpp"
+
+#include "fcat_msgs/msg/commander_states.hpp"
+#include "fcat_msgs/msg/conditional_states.hpp"
+#include "fcat_msgs/msg/faulter_states.hpp"
+#include "fcat_msgs/msg/filter_states.hpp"
+#include "fcat_msgs/msg/fts_states.hpp"
+#include "fcat_msgs/msg/function_states.hpp"
+#include "fcat_msgs/msg/linear_interpolation_states.hpp"
+#include "fcat_msgs/msg/pid_states.hpp"
+#include "fcat_msgs/msg/saturation_states.hpp"
+#include "fcat_msgs/msg/schmitt_trigger_states.hpp"
+#include "fcat_msgs/msg/signal_generator_states.hpp"
+#include "fcat_msgs/msg/three_node_thermal_model_states.hpp"
+
+#include "fastcat/fastcat.h"
+
+fcat_msgs::msg::ActuatorState ActuatorStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::EgdState EgdStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::El1008State El1008StateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::El2124State El2124StateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::El2809State El2809StateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::El2798State El2798StateToMsg(
+    std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::El2828State El2828StateToMsg(
+    std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::El3104State El3104StateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::El3162State El3162StateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::El3202State El3202StateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::El3208State El3208StateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::El3314State El3314StateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::El3318State El3318StateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::El3602State El3602StateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::El4102State El4102StateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::El5042State El5042StateToMsg(
+    std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::Ild1900State Ild1900StateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::CommanderState CommanderStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::ConditionalState ConditionalStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::FaulterState FaulterStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::FilterState FilterStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::FtsState FtsStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::FunctionState FunctionStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::PidState PidStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::SaturationState SaturationStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::SchmittTriggerState SchmittTriggerStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::SignalGeneratorState SignalGeneratorStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::LinearInterpolationState LinearInterpolationStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state);
+
+fcat_msgs::msg::ThreeNodeThermalModelState ThreeNodeThermalModelStateToMsg(
+  std::shared_ptr<const fastcat::DeviceState> state);
+
+bool HexOrDecStrToNum(std::string& str, uint16_t& number);
+bool TlcStrToNum(std::string& str, uint16_t& number);
+
+jsd_sdo_data_type_t jsd_sdo_data_type_from_string(std::string& str);
+
+jsd_sdo_data_t jsd_sdo_data_from_string(jsd_sdo_data_type_t& type,
+                                        std::string& str);
+
+std::string jsd_sdo_request_type_to_string(jsd_sdo_req_type_t req_type);
+std::string jsd_sdo_data_type_to_string(jsd_sdo_data_type_t data_type);
+std::string jsd_sdo_data_to_string(jsd_sdo_data_type_t data_type,
+                                   jsd_sdo_data_t data);
+
+#endif

--- a/src/fcat_utils.hpp
+++ b/src/fcat_utils.hpp
@@ -1,12 +1,15 @@
 #ifndef FCAT__FCAT_UTILS_HPP_
 #define FCAT__FCAT_UTILS_HPP_
 
+#include "fastcat/fastcat.h"
 #include "fcat_msgs/msg/actuator_states.hpp"
+#include "fcat_msgs/msg/commander_states.hpp"
+#include "fcat_msgs/msg/conditional_states.hpp"
 #include "fcat_msgs/msg/egd_states.hpp"
 #include "fcat_msgs/msg/el1008_states.hpp"
 #include "fcat_msgs/msg/el2124_states.hpp"
-#include "fcat_msgs/msg/el2809_states.hpp"
 #include "fcat_msgs/msg/el2798_states.hpp"
+#include "fcat_msgs/msg/el2809_states.hpp"
 #include "fcat_msgs/msg/el2828_states.hpp"
 #include "fcat_msgs/msg/el3104_states.hpp"
 #include "fcat_msgs/msg/el3162_states.hpp"
@@ -17,14 +20,11 @@
 #include "fcat_msgs/msg/el3602_states.hpp"
 #include "fcat_msgs/msg/el4102_states.hpp"
 #include "fcat_msgs/msg/el5042_states.hpp"
-#include "fcat_msgs/msg/ild1900_states.hpp"
-
-#include "fcat_msgs/msg/commander_states.hpp"
-#include "fcat_msgs/msg/conditional_states.hpp"
 #include "fcat_msgs/msg/faulter_states.hpp"
 #include "fcat_msgs/msg/filter_states.hpp"
 #include "fcat_msgs/msg/fts_states.hpp"
 #include "fcat_msgs/msg/function_states.hpp"
+#include "fcat_msgs/msg/ild1900_states.hpp"
 #include "fcat_msgs/msg/linear_interpolation_states.hpp"
 #include "fcat_msgs/msg/pid_states.hpp"
 #include "fcat_msgs/msg/saturation_states.hpp"
@@ -32,106 +32,80 @@
 #include "fcat_msgs/msg/signal_generator_states.hpp"
 #include "fcat_msgs/msg/three_node_thermal_model_states.hpp"
 
-#include "fastcat/fastcat.h"
+fcat_msgs::msg::ActuatorState ActuatorStateToMsg(std::shared_ptr<const fastcat::DeviceState> state);
 
-fcat_msgs::msg::ActuatorState ActuatorStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state);
+fcat_msgs::msg::EgdState EgdStateToMsg(std::shared_ptr<const fastcat::DeviceState> state);
 
-fcat_msgs::msg::EgdState EgdStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state);
+fcat_msgs::msg::El1008State El1008StateToMsg(std::shared_ptr<const fastcat::DeviceState> state);
 
-fcat_msgs::msg::El1008State El1008StateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state);
+fcat_msgs::msg::El2124State El2124StateToMsg(std::shared_ptr<const fastcat::DeviceState> state);
 
-fcat_msgs::msg::El2124State El2124StateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state);
+fcat_msgs::msg::El2809State El2809StateToMsg(std::shared_ptr<const fastcat::DeviceState> state);
 
-fcat_msgs::msg::El2809State El2809StateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state);
+fcat_msgs::msg::El2798State El2798StateToMsg(std::shared_ptr<const fastcat::DeviceState> state);
 
-fcat_msgs::msg::El2798State El2798StateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state);
+fcat_msgs::msg::El2828State El2828StateToMsg(std::shared_ptr<const fastcat::DeviceState> state);
 
-fcat_msgs::msg::El2828State El2828StateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state);
+fcat_msgs::msg::El3104State El3104StateToMsg(std::shared_ptr<const fastcat::DeviceState> state);
 
-fcat_msgs::msg::El3104State El3104StateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state);
+fcat_msgs::msg::El3162State El3162StateToMsg(std::shared_ptr<const fastcat::DeviceState> state);
 
-fcat_msgs::msg::El3162State El3162StateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state);
+fcat_msgs::msg::El3202State El3202StateToMsg(std::shared_ptr<const fastcat::DeviceState> state);
 
-fcat_msgs::msg::El3202State El3202StateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state);
+fcat_msgs::msg::El3208State El3208StateToMsg(std::shared_ptr<const fastcat::DeviceState> state);
 
-fcat_msgs::msg::El3208State El3208StateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state);
+fcat_msgs::msg::El3314State El3314StateToMsg(std::shared_ptr<const fastcat::DeviceState> state);
 
-fcat_msgs::msg::El3314State El3314StateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state);
+fcat_msgs::msg::El3318State El3318StateToMsg(std::shared_ptr<const fastcat::DeviceState> state);
 
-fcat_msgs::msg::El3318State El3318StateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state);
+fcat_msgs::msg::El3602State El3602StateToMsg(std::shared_ptr<const fastcat::DeviceState> state);
 
-fcat_msgs::msg::El3602State El3602StateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state);
+fcat_msgs::msg::El4102State El4102StateToMsg(std::shared_ptr<const fastcat::DeviceState> state);
 
-fcat_msgs::msg::El4102State El4102StateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state);
+fcat_msgs::msg::El5042State El5042StateToMsg(std::shared_ptr<const fastcat::DeviceState> state);
 
-fcat_msgs::msg::El5042State El5042StateToMsg(
-    std::shared_ptr<const fastcat::DeviceState> state);
-
-fcat_msgs::msg::Ild1900State Ild1900StateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state);
+fcat_msgs::msg::Ild1900State Ild1900StateToMsg(std::shared_ptr<const fastcat::DeviceState> state);
 
 fcat_msgs::msg::CommanderState CommanderStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state);
+    std::shared_ptr<const fastcat::DeviceState> state);
 
 fcat_msgs::msg::ConditionalState ConditionalStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state);
+    std::shared_ptr<const fastcat::DeviceState> state);
 
-fcat_msgs::msg::FaulterState FaulterStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state);
+fcat_msgs::msg::FaulterState FaulterStateToMsg(std::shared_ptr<const fastcat::DeviceState> state);
 
-fcat_msgs::msg::FilterState FilterStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state);
+fcat_msgs::msg::FilterState FilterStateToMsg(std::shared_ptr<const fastcat::DeviceState> state);
 
-fcat_msgs::msg::FtsState FtsStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state);
+fcat_msgs::msg::FtsState FtsStateToMsg(std::shared_ptr<const fastcat::DeviceState> state);
 
-fcat_msgs::msg::FunctionState FunctionStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state);
+fcat_msgs::msg::FunctionState FunctionStateToMsg(std::shared_ptr<const fastcat::DeviceState> state);
 
-fcat_msgs::msg::PidState PidStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state);
+fcat_msgs::msg::PidState PidStateToMsg(std::shared_ptr<const fastcat::DeviceState> state);
 
 fcat_msgs::msg::SaturationState SaturationStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state);
+    std::shared_ptr<const fastcat::DeviceState> state);
 
 fcat_msgs::msg::SchmittTriggerState SchmittTriggerStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state);
+    std::shared_ptr<const fastcat::DeviceState> state);
 
 fcat_msgs::msg::SignalGeneratorState SignalGeneratorStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state);
+    std::shared_ptr<const fastcat::DeviceState> state);
 
 fcat_msgs::msg::LinearInterpolationState LinearInterpolationStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state);
+    std::shared_ptr<const fastcat::DeviceState> state);
 
 fcat_msgs::msg::ThreeNodeThermalModelState ThreeNodeThermalModelStateToMsg(
-  std::shared_ptr<const fastcat::DeviceState> state);
+    std::shared_ptr<const fastcat::DeviceState> state);
 
 bool HexOrDecStrToNum(std::string& str, uint16_t& number);
 bool TlcStrToNum(std::string& str, uint16_t& number);
 
 jsd_sdo_data_type_t jsd_sdo_data_type_from_string(std::string& str);
 
-jsd_sdo_data_t jsd_sdo_data_from_string(jsd_sdo_data_type_t& type,
-                                        std::string& str);
+jsd_sdo_data_t jsd_sdo_data_from_string(jsd_sdo_data_type_t& type, std::string& str);
 
 std::string jsd_sdo_request_type_to_string(jsd_sdo_req_type_t req_type);
 std::string jsd_sdo_data_type_to_string(jsd_sdo_data_type_t data_type);
-std::string jsd_sdo_data_to_string(jsd_sdo_data_type_t data_type,
-                                   jsd_sdo_data_t data);
+std::string jsd_sdo_data_to_string(jsd_sdo_data_type_t data_type, jsd_sdo_data_t data);
 
 #endif

--- a/src/fcat_utils.hpp
+++ b/src/fcat_utils.hpp
@@ -1,5 +1,10 @@
-#ifndef FCAT__FCAT_UTILS_HPP_
-#define FCAT__FCAT_UTILS_HPP_
+// Copyright 2021 California Institute of Technology
+
+#ifndef FCAT_UTILS_HPP_
+#define FCAT_UTILS_HPP_
+
+#include <memory>
+#include <string>
 
 #include "fastcat/fastcat.h"
 #include "fcat_msgs/msg/actuator_states.hpp"
@@ -108,4 +113,4 @@ std::string jsd_sdo_request_type_to_string(jsd_sdo_req_type_t req_type);
 std::string jsd_sdo_data_type_to_string(jsd_sdo_data_type_t data_type);
 std::string jsd_sdo_data_to_string(jsd_sdo_data_type_t data_type, jsd_sdo_data_t data);
 
-#endif
+#endif  // FCAT_UTILS_HPP_


### PR DESCRIPTION
Update fcat with internal changes. Last commit was 5 years ago, so this PR is easier to understand as removing internal code from current version, than an update of public fcat. 

Tested on Astroubud Testbed. It needs [ fcat_msgs@update-msgs](https://github.com/nasa-jpl/fcat_msgs/tree/update-msgs) 

bump:minor

@JosephBowkett @kwehage @preston-rogers @dwai-wai 