### PR TITLE
Split fastcat init

### DIFF
--- a/.github/workflows/ros2_build_and_tag.yml
+++ b/.github/workflows/ros2_build_and_tag.yml
@@ -46,7 +46,7 @@ env:
     apt-get install -y python3-ipython
     dpkg -i fcat/.github/python3-cogapp_3.3.0-3_all.deb
     cp fcat/.github/cog /usr/local/bin/
-    git clone --depth 1 --branch update-msgs https://github.com/nasa-jpl/fcat_msgs.git
+    git clone --depth 1 --branch v0.10.0 https://github.com/nasa-jpl/fcat_msgs.git
 
 jobs:
   # ============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 include(FetchContent)
 FetchContent_Declare(fastcat
   GIT_REPOSITORY https://github.com/nasa-jpl/fastcat.git
-  GIT_TAG v0.13.13
+  GIT_TAG split-init
 )
 FetchContent_MakeAvailable(fastcat)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 include(FetchContent)
 FetchContent_Declare(fastcat
   GIT_REPOSITORY https://github.com/nasa-jpl/fastcat.git
-  GIT_TAG split-init
+  GIT_TAG v0.13.15
 )
 FetchContent_MakeAvailable(fastcat)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An optional ROS2 node called `fcat_srvs` is provided in this package. The purpos
 
 ## Quickstart
 
-Due to a potential issue in the default RMW implementation, the cyclone vendor is recommended for use as of the Feb 2021 ROS2 Foxy release.
+Due to a potential issue in the default RMW implementation, the cyclone vendor is recommended for use:
 
 ``` bash
 sudo apt install ros-${ROS_DISTRO}-rmw-cyclonedds-cpp

--- a/src/fcat.cpp
+++ b/src/fcat.cpp
@@ -240,7 +240,11 @@ Fcat::Fcat(const rclcpp::NodeOptions& options)
   loop_period_sec_ = 1.0 / fcat_manager_.GetTargetLoopRate();
   last_time_ = this->now().seconds();
   module_state_msg_.faulted = false;
-  
+
+  if (!fcat_manager_.InitHardware()) {
+    throw std::invalid_argument("Fastcat Manager failed to initialize EtherCAT hardware.");
+  }
+
   fcat_state_ = FcatState::INACTIVE;
   StartProcessTimer();
   fcat_state_ = FcatState::ACTIVE;

--- a/src/fcat.cpp
+++ b/src/fcat.cpp
@@ -48,7 +48,7 @@ Fcat::Fcat(const rclcpp::NodeOptions& options)
   RCLCPP_INFO(this->get_logger(), "loading Yaml from %s", fastcat_config_path.c_str());
   YAML::Node node = YAML::LoadFile(fastcat_config_path);
 
-  if (!fcat_manager_.ConfigFromYaml(node)) {
+  if (!fcat_manager_.CreateConfigFromYaml(node)) {
     throw std::invalid_argument("Fastcat Manager failed to process bus configuration YAML file.");
   }
 


### PR DESCRIPTION

Use new divided init from fastcat. This is required in slow computers so ros2 config can use fastcat config, so yaml is read early, but ros2 setup would time out ethercat devices. 


Draft: change fastcat `GIT_TAG split-init` to tag once merged. 

bump:minor

@JosephBowkett @kwehage @preston-rogers @dwai-wai